### PR TITLE
MUIC-362: [Android] Disable "Start chat in integrator app" button

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -40,9 +40,11 @@ public class MainFragment extends Fragment {
             navController.navigate(R.id.settings);
         });
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        /* https://salemove.atlassian.net/browse/MUIC-362
         view.findViewById(R.id.integrator_chat).setOnClickListener(view1 -> {
             navController.navigate(R.id.chat);
         });
+         */
         view.findViewById(R.id.chat_activity_button).setOnClickListener(v -> {
             Intent intent = new Intent(requireContext(), ChatActivity.class);
             setNavigationIntentData(intent, sharedPreferences);

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -43,7 +43,8 @@
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toBottomOf="@id/tool_bar_layout" />
 
-    <Button
+    <!-- https://salemove.atlassian.net/browse/MUIC-362
+    Button
         android:id="@+id/integrator_chat"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -52,7 +53,7 @@
         app:icon="@drawable/ic_baseline_chat_bubble"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/settings_button" />
+        app:layout_constraintTop_toBottomOf="@id/settings_button" /-->
 
     <Button
         android:id="@+id/chat_activity_button"
@@ -63,7 +64,7 @@
         app:icon="@drawable/ic_baseline_chat_bubble"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/integrator_chat" />
+        app:layout_constraintTop_toBottomOf="@id/settings_button" />
 
     <Button
         android:id="@+id/audio_call_button"


### PR DESCRIPTION
Integrators example app navigation to the chat view removed and button hidden

Causing too much confusion as dev is testing there instead of widgets chat activity