### PR TITLE
Avoid using printStackTrace in SDK

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
@@ -932,7 +932,7 @@ public class ChatView extends ConstraintLayout implements ChatAdapter.OnFileItem
         try {
             photoFile = Utils.createTempPhotoFile(getContext());
         } catch (IOException exception) {
-            exception.printStackTrace();
+            Logger.e(TAG, "Create photo file failed: " + exception.getMessage());
         }
 
         if (photoFile != null) {
@@ -1199,7 +1199,6 @@ public class ChatView extends ConstraintLayout implements ChatAdapter.OnFileItem
                     Logger.d(TAG, "File is saved to downloads folder");
                 } catch (IOException e) {
                     Logger.e(TAG, "File saving failed: " + e.getMessage());
-                    e.printStackTrace();
                     onFileSaveFail(attachmentFile);
                 }
             } finally {
@@ -1207,7 +1206,6 @@ public class ChatView extends ConstraintLayout implements ChatAdapter.OnFileItem
                     fileInputStream.close();
                 } catch (IOException e) {
                     Logger.e(TAG, "Closing fileInputStream failed: " + e.getMessage());
-                    e.printStackTrace();
                 }
             }
         }).start());

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/FilePreviewActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/FilePreviewActivity.java
@@ -174,7 +174,7 @@ public class FilePreviewActivity extends AppCompatActivity implements FileHelper
                         fos.flush();
                         fos.close();
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        Logger.e(TAG, "Closing FileOutputStream failed: " + e.getMessage());
                     }
                 }
             }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
@@ -1132,7 +1132,7 @@ public class ChatController implements
 
                     @Override
                     public void onError(Exception ex) {
-                        ex.printStackTrace();
+                        Logger.e(TAG, "Upload file failed: " + ex.getMessage());
                     }
 
                     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/helper/FileHelper.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/helper/FileHelper.java
@@ -65,7 +65,6 @@ public class FileHelper {
         Glia.fetchFile(attachmentFile, (fileInputStream, gliaException) -> {
             if (gliaException != null) {
                 Logger.e(TAG, "Image loaded from the network failed." + gliaException.getMessage());
-                gliaException.printStackTrace();
                 return;
             }
 
@@ -76,7 +75,7 @@ public class FileHelper {
                     bitmapCallback.onBitmapSuccess(bitmap);
                 } catch (Exception e) {
                     bitmapCallback.onBitmapFail();
-                    e.printStackTrace();
+                    Logger.e(TAG, "Image decode failed: " + e.getMessage());
                 }
             }).start();
         });

--- a/widgetssdk/src/main/java/com/glia/widgets/screensharing/ScreenSharingController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/screensharing/ScreenSharingController.java
@@ -69,8 +69,7 @@ public class ScreenSharingController {
             @Override
             public void onScreenSharingRequestError(GliaException exception) {
                 if (viewCallback != null) viewCallback.onScreenSharingRequestError(exception);
-                Logger.e(TAG, "screen sharing request error");
-                exception.printStackTrace();
+                Logger.e(TAG, "screen sharing request error: " + exception.getMessage());
                 hideScreenSharingEnabledNotification();
             }
 


### PR DESCRIPTION
Using printStackTrace in the release application might introduce a potential security risk. It should be removed from SDK.

https://salemove.atlassian.net/browse/MOB-875
https://salemove.atlassian.net/browse/SSD-19423