### PR TITLE
Fix visitor typing indication doesn't disappear after the message is sent

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
@@ -644,6 +644,9 @@ public class ChatView extends ConstraintLayout implements ChatAdapter.OnFileItem
         if (!Utils.compareStringWithTrim(chatEditText.getText().toString(), chatState.lastTypedText)) {
             chatEditText.removeTextChangedListener(textWatcher);
             chatEditText.setText(chatState.lastTypedText);
+            if (controller != null) {
+                controller.sendMessagePreview(chatState.lastTypedText);
+            }
             chatEditText.addTextChangedListener(textWatcher);
         }
     }


### PR DESCRIPTION
[MUIC-615](https://glia.atlassian.net/browse/MUIC-615)

Fixes issue in https://github.com/salemove/android-sdk-widgets/pull/139/files#diff-9a3bcdbdd5b69de704f92d16dffc971d6bab25e811f3bcdec39bc2e465a53a20R645