### PR TITLE
SDK dependency

### DIFF
--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     // debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
 
     // Replaced with a local AAR file
-    implementation "com.glia:android-sdk:$gliaSdkVersion"
+    api "com.glia:android-sdk:$gliaSdkVersion"
     // Glia sdk aar
     // implementation(name: "glia-core-sdk-$gliaSdkVersion", ext: 'aar')
 


### PR DESCRIPTION
Change configuration to make Glia Core SDK the end project dependency