### PR TITLE
MUIC-623: [Android] - Whitelabel customisation

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/Utils.java
+++ b/app/src/main/java/com/glia/exampleapp/Utils.java
@@ -44,7 +44,7 @@ class Utils {
         Integer botActionButtonSelectedBackgroundColor = getColorValueFromPrefs(R.string.pref_bot_action_button_selected_bg_color, sharedPreferences, resources);
         Integer botActionButtonSelectedTextColor = getColorValueFromPrefs(R.string.pref_bot_action_button_selected_txt_color, sharedPreferences, resources);
 
-        Integer whiteLabel = getWhiteLabelValueFromPrefs(sharedPreferences, resources);
+        Boolean whiteLabel = sharedPreferences.getBoolean(resources.getString(R.string.pref_white_label), false);
 
         Boolean gliaAlertDialogButtonUseVerticalAlignment = sharedPreferences.getBoolean(
                 resources.getString(R.string.pref_use_alert_dialog_button_vertical_alignment),
@@ -193,10 +193,5 @@ class Utils {
 
     public static boolean getUseOverlay(SharedPreferences sharedPreferences, Resources resources) {
         return sharedPreferences.getBoolean(resources.getString(R.string.pref_use_overlay), true);
-    }
-
-    public static Integer getWhiteLabelValueFromPrefs(SharedPreferences sharedPreferences, Resources resources) {
-        boolean whiteLabel = sharedPreferences.getBoolean(resources.getString(R.string.pref_white_label), false);
-        return whiteLabel ? 1 : 0;
     }
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -33,6 +33,7 @@
         </item>
 
         <item name="gliaAlertDialogButtonUseVerticalAlignment">true</item>
+        <item name="whiteLabel">false</item>
     </style>
 
     <style name="Application.GliaAndroidSdkWidgetsExample.Button" parent="@style/Widget.MaterialComponents.Button.TextButton.Icon">

--- a/widgetssdk/src/main/java/com/glia/widgets/UiTheme.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/UiTheme.java
@@ -221,7 +221,7 @@ public class UiTheme implements Parcelable {
     private @ColorRes
     final Integer chatStartedCaptionTextColor;
 
-    private final Integer whiteLabel;
+    private final Boolean whiteLabel;
     private final Boolean gliaAlertDialogButtonUseVerticalAlignment;
 
     private final ButtonConfiguration headerEndButtonConfiguration;
@@ -491,7 +491,7 @@ public class UiTheme implements Parcelable {
         Integer chatStartedCaptionTextColor;
 
         private
-        Integer whiteLabel;
+        Boolean whiteLabel;
 
         private
         Boolean gliaAlertDialogButtonUseVerticalAlignment;
@@ -648,7 +648,7 @@ public class UiTheme implements Parcelable {
             this.iconPlaceholder = iconPlaceholder;
         }
 
-        public void setWhiteLabel(Integer whiteLabel) {
+        public void setWhiteLabel(Boolean whiteLabel) {
             this.whiteLabel = whiteLabel;
         }
 
@@ -955,11 +955,8 @@ public class UiTheme implements Parcelable {
         } else {
             chatStartedCaptionTextColor = in.readInt();
         }
-        if (in.readByte() == 0) {
-            whiteLabel = null;
-        } else {
-            whiteLabel = in.readInt();
-        }
+        byte tmpWhiteLabel = in.readByte();
+        whiteLabel = tmpWhiteLabel == 0 ? null : tmpWhiteLabel == 1;
         byte tmpGliaAlertDialogButtonUseVerticalAlignment = in.readByte();
         gliaAlertDialogButtonUseVerticalAlignment = tmpGliaAlertDialogButtonUseVerticalAlignment == 0 ? null : tmpGliaAlertDialogButtonUseVerticalAlignment == 1;
         headerEndButtonConfiguration = in.readParcelable(ButtonConfiguration.class.getClassLoader());
@@ -1211,12 +1208,7 @@ public class UiTheme implements Parcelable {
             dest.writeByte((byte) 1);
             dest.writeInt(chatStartedCaptionTextColor);
         }
-        if (whiteLabel == null) {
-            dest.writeByte((byte) 0);
-        } else {
-            dest.writeByte((byte) 1);
-            dest.writeInt(whiteLabel);
-        }
+        dest.writeByte((byte) (whiteLabel == null ? 0 : whiteLabel ? 1 : 2));
         dest.writeByte((byte) (gliaAlertDialogButtonUseVerticalAlignment == null ? 0 : gliaAlertDialogButtonUseVerticalAlignment ? 1 : 2));
         dest.writeParcelable(headerEndButtonConfiguration, flags);
         dest.writeParcelable(positiveButtonConfiguration, flags);
@@ -1389,7 +1381,7 @@ public class UiTheme implements Parcelable {
         return iconPlaceholder;
     }
 
-    public Integer getWhiteLabel() {
+    public Boolean getWhiteLabel() {
         return whiteLabel;
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -381,11 +381,9 @@ public class Utils {
                 )
         );
         defaultThemeBuilder.setWhiteLabel(
-                getTypedArrayIntegerValue(
+                getTypedArrayBooleanValue(
                         typedArray,
-                        context,
-                        R.styleable.GliaView_whiteLabel,
-                        R.attr.gliaWhiteLabel
+                        R.styleable.GliaView_whiteLabel
                 )
         );
         defaultThemeBuilder.setGliaAlertDialogButtonUseVerticalAlignment(
@@ -546,7 +544,7 @@ public class Utils {
         Integer iconPlaceholder = newTheme.getIconPlaceholder() != null ?
                 newTheme.getIconPlaceholder() : oldTheme.getIconPlaceholder();
 
-        Integer whiteLabel = newTheme.getWhiteLabel() != null ? newTheme.getWhiteLabel() : oldTheme.getWhiteLabel();
+        Boolean whiteLabel = newTheme.getWhiteLabel() != null ? newTheme.getWhiteLabel() : oldTheme.getWhiteLabel();
         Boolean isUseAlertDialogButtonVerticalAlignment =
                 newTheme.getGliaAlertDialogButtonUseVerticalAlignment() != null ?
                         newTheme.getGliaAlertDialogButtonUseVerticalAlignment() :

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.java
@@ -62,7 +62,7 @@ public class Dialogs {
         messageView.setTextColor(baseDarkColor);
         logoView.setImageTintList(ContextCompat.getColorStateList(context, theme.getBaseShadeColor()));
 
-        logoView.setVisibility(theme.getWhiteLabel() == 1 ? View.GONE : View.VISIBLE);
+        logoView.setVisibility(theme.getWhiteLabel() ? View.GONE : View.VISIBLE);
 
         if (theme.getFontRes() != null) {
             Typeface fontFamily = ResourcesCompat.getFont(context, theme.getFontRes());
@@ -206,7 +206,7 @@ public class Dialogs {
             negativeButton.setTypeface(fontFamily);
         }
 
-        logoView.setVisibility(theme.getWhiteLabel() == 1 ? View.GONE : View.VISIBLE);
+        logoView.setVisibility(theme.getWhiteLabel() ? View.GONE : View.VISIBLE);
 
         if (type instanceof DialogOfferType.AudioUpgradeOffer) {
             titleView.setText(
@@ -286,7 +286,7 @@ public class Dialogs {
             negativeButton.setTypeface(fontFamily);
         }
 
-        logoView.setVisibility(theme.getWhiteLabel() == 1 ? View.GONE : View.VISIBLE);
+        logoView.setVisibility(theme.getWhiteLabel() ? View.GONE : View.VISIBLE);
 
         titleView.setText(title);
         messageView.setText(message);

--- a/widgetssdk/src/main/res/values/attrs.xml
+++ b/widgetssdk/src/main/res/values/attrs.xml
@@ -82,7 +82,7 @@
         <attr name="chatStartedHeadingTextColor" format="reference" />
         <attr name="chatStartedCaptionTextColor" format="reference" />
 
-        <attr name="whiteLabel" format="reference" />
+        <attr name="whiteLabel" />
         <attr name="gliaAlertDialogButtonUseVerticalAlignment" />
     </declare-styleable>
 
@@ -166,7 +166,7 @@
     <!-- Bot message action button text color -->
     <attr name="gliaBotActionButtonSelectedTextColor" format="reference" />
 
-    <attr name="gliaWhiteLabel" format="reference" />
+    <attr name="whiteLabel" format="boolean" />
     <attr name="gliaAlertDialogButtonUseVerticalAlignment" format="boolean" />
 
     <!-- Styleable components -->

--- a/widgetssdk/src/main/res/values/themes.xml
+++ b/widgetssdk/src/main/res/values/themes.xml
@@ -59,6 +59,7 @@
         <item name="gliaAlertDialogButtonUseVerticalAlignment">
             ?attr/gliaAlertDialogButtonUseVerticalAlignment
         </item>
+        <item name="whiteLabel">?attr/whiteLabel</item>
 
         <item name="materialThemeOverlay">@style/ThemeOverlay.Glia.Chat</item>
     </style>
@@ -137,6 +138,7 @@
         <item name="buttonBarNeutralButtonStyle">@style/Application.Glia.Chat.Button.Neutral</item>
 
         <item name="gliaAlertDialogButtonUseVerticalAlignment">false</item>
+        <item name="whiteLabel">false</item>
     </style>
 
     <style name="ThemeOverlay.Glia.Chat.AlertDialog" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-623

**Additional info:**
Buildtime attribute fix for whitelabel - to test it don't forget to
DISABLE runtime override
- as agreed on spring:
```
false = enabled 
true = disabled 
```
**Screenshots:**
## False state
<img width="867" alt="Screenshot 2021-12-09 at 16 09 38" src="https://user-images.githubusercontent.com/49229744/145414929-2ef11a28-5a21-4536-a9d9-10625d2d7bbc.png">
<img width="415" alt="Screenshot 2021-12-09 at 16 05 52" src="https://user-images.githubusercontent.com/49229744/145415054-5bddf136-f692-4f2a-a65d-8024e5bf4229.png">
<img width="415" alt="Screenshot 2021-12-09 at 16 08 23" src="https://user-images.githubusercontent.com/49229744/145414967-a5118ca3-74ef-442b-9863-5be36d9508a0.png">

## True state
<img width="867" alt="Screenshot 2021-12-09 at 16 09 48" src="https://user-images.githubusercontent.com/49229744/145415153-6870e8be-a789-43f9-9dc4-679799e1bff8.png">
<img width="415" alt="Screenshot 2021-12-09 at 16 08 43" src="https://user-images.githubusercontent.com/49229744/145415173-3db570c5-2ac8-46c2-9e63-7e84f6bd0a7f.png">
<img width="415" alt="Screenshot 2021-12-09 at 16 08 52" src="https://user-images.githubusercontent.com/49229744/145415194-218f879c-d2ad-4a1b-b293-9c9974d09ea6.png">

