### PR TITLE
MUIC-625: [Android] - Customisation for Choice Card Content TextView

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/Utils.java
+++ b/app/src/main/java/com/glia/exampleapp/Utils.java
@@ -66,11 +66,15 @@ class Utils {
         builder.setVisitorMessageTextColor(visitorMessageTextColor);
         builder.setOperatorMessageBackgroundColor(operatorMessageBackgroundColor);
         builder.setOperatorMessageTextColor(operatorMessageTextColor);
+
+        builder.setWhiteLabel(whiteLabel);
+
+        // choice card attributes
+        builder.setChoiceCardContentTextConfiguration(null);
         builder.setBotActionButtonBackgroundColor(botActionButtonBackgroundColor);
         builder.setBotActionButtonTextColor(botActionButtonTextColor);
         builder.setBotActionButtonSelectedBackgroundColor(botActionButtonSelectedBackgroundColor);
         builder.setBotActionButtonSelectedTextColor(botActionButtonSelectedTextColor);
-        builder.setWhiteLabel(whiteLabel);
 
         // to set alert buttons to align vertically in runtime
         builder.setGliaAlertDialogButtonUseVerticalAlignment(gliaAlertDialogButtonUseVerticalAlignment);
@@ -123,6 +127,14 @@ class Utils {
                 )
                 .strokeWidth(1)
                 .strokeColor(ColorStateList.valueOf(ContextCompat.getColor(context, R.color.color_black)))
+                .build();
+    }
+
+    private static TextConfiguration getChoiceCardContentTextConfiguration(Context context) {
+        return TextConfiguration.builder()
+                .textSize(16f)      // in sp
+                .fontFamily(R.font.tangerine)
+                .textColor(ContextCompat.getColorStateList(context, R.color.color_dark_cyan))
                 .build();
     }
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -31,6 +31,9 @@
         <item name="buttonBarPositiveButtonStyle">
             @style/Application.GliaAndroidSdkWidgetsExample.Button.Positive
         </item>
+        <item name="choiceCardContentTextStyle">
+            @style/Application.GliaAndroidSdkWidgetsExample.ChoiceCard.ContentText
+        </item>
 
         <item name="gliaAlertDialogButtonUseVerticalAlignment">true</item>
         <item name="whiteLabel">false</item>
@@ -68,6 +71,12 @@
         <!-- item name="android:fontFamily">@font/tangerine</item -->
         <item name="android:textSize">14sp</item>
         <item name="android:textAllCaps">false</item>
+    </style>
+
+    <style name="Application.GliaAndroidSdkWidgetsExample.ChoiceCard.ContentText" parent="TextAppearance.MaterialComponents.Body1">
+        <item name="android:textSize">40sp</item>
+        <item name="android:textColor">@color/color_dark_cyan</item>
+        <!-- item name="fontFamily">@font/tangerine</item -->
     </style>
 
 </resources>

--- a/widgetssdk/src/main/java/com/glia/widgets/UiTheme.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/UiTheme.java
@@ -8,6 +8,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.FontRes;
 
 import com.glia.widgets.view.configuration.ButtonConfiguration;
+import com.glia.widgets.view.configuration.TextConfiguration;
 
 
 public class UiTheme implements Parcelable {
@@ -224,6 +225,8 @@ public class UiTheme implements Parcelable {
     private final Boolean whiteLabel;
     private final Boolean gliaAlertDialogButtonUseVerticalAlignment;
 
+    private final TextConfiguration choiceCardContentTextConfiguration;
+
     private final ButtonConfiguration headerEndButtonConfiguration;
     private final ButtonConfiguration positiveButtonConfiguration;
     private final ButtonConfiguration negativeButtonConfiguration;
@@ -277,6 +280,7 @@ public class UiTheme implements Parcelable {
         this.chatStartingHeadingTextColor = builder.chatStartingHeadingTextColor;
         this.chatStartedCaptionTextColor = builder.chatStartedCaptionTextColor;
         this.chatStartedHeadingTextColor = builder.chatStartedHeadingTextColor;
+        this.choiceCardContentTextConfiguration = builder.choiceCardContentTextConfiguration;
     }
 
     public static class UiThemeBuilder {
@@ -508,6 +512,9 @@ public class UiTheme implements Parcelable {
         private
         ButtonConfiguration neutralButtonConfiguration;
 
+        private
+        TextConfiguration choiceCardContentTextConfiguration;
+
         public void setAppBarTitle(String appBarTitle) {
             this.appBarTitle = appBarTitle;
         }
@@ -700,6 +707,10 @@ public class UiTheme implements Parcelable {
             this.chatStartedCaptionTextColor = color;
         }
 
+        public void setChoiceCardContentTextConfiguration(TextConfiguration textConfiguration) {
+            this.choiceCardContentTextConfiguration = textConfiguration;
+        }
+
         public void setTheme(UiTheme theme) {
             this.appBarTitle = theme.appBarTitle;
             this.brandPrimaryColor = theme.brandPrimaryColor;
@@ -735,6 +746,7 @@ public class UiTheme implements Parcelable {
             this.iconCallSpeakerOff = theme.iconCallSpeakerOff;
             this.iconCallMinimize = theme.iconCallMinimize;
             this.iconPlaceholder = theme.iconPlaceholder;
+            this.whiteLabel = theme.whiteLabel;
             this.headerEndButtonConfiguration = theme.headerEndButtonConfiguration;
             this.positiveButtonConfiguration = theme.positiveButtonConfiguration;
             this.negativeButtonConfiguration = theme.negativeButtonConfiguration;
@@ -746,6 +758,7 @@ public class UiTheme implements Parcelable {
             this.chatStartingHeadingTextColor = theme.chatStartingHeadingTextColor;
             this.chatStartedCaptionTextColor = theme.chatStartedCaptionTextColor;
             this.chatStartedHeadingTextColor = theme.chatStartedHeadingTextColor;
+            this.choiceCardContentTextConfiguration = theme.choiceCardContentTextConfiguration;
         }
 
         public UiTheme build() {
@@ -959,6 +972,7 @@ public class UiTheme implements Parcelable {
         whiteLabel = tmpWhiteLabel == 0 ? null : tmpWhiteLabel == 1;
         byte tmpGliaAlertDialogButtonUseVerticalAlignment = in.readByte();
         gliaAlertDialogButtonUseVerticalAlignment = tmpGliaAlertDialogButtonUseVerticalAlignment == 0 ? null : tmpGliaAlertDialogButtonUseVerticalAlignment == 1;
+        choiceCardContentTextConfiguration = in.readParcelable(TextConfiguration.class.getClassLoader());
         headerEndButtonConfiguration = in.readParcelable(ButtonConfiguration.class.getClassLoader());
         positiveButtonConfiguration = in.readParcelable(ButtonConfiguration.class.getClassLoader());
         negativeButtonConfiguration = in.readParcelable(ButtonConfiguration.class.getClassLoader());
@@ -1210,6 +1224,7 @@ public class UiTheme implements Parcelable {
         }
         dest.writeByte((byte) (whiteLabel == null ? 0 : whiteLabel ? 1 : 2));
         dest.writeByte((byte) (gliaAlertDialogButtonUseVerticalAlignment == null ? 0 : gliaAlertDialogButtonUseVerticalAlignment ? 1 : 2));
+        dest.writeParcelable(choiceCardContentTextConfiguration, flags);
         dest.writeParcelable(headerEndButtonConfiguration, flags);
         dest.writeParcelable(positiveButtonConfiguration, flags);
         dest.writeParcelable(negativeButtonConfiguration, flags);
@@ -1403,6 +1418,10 @@ public class UiTheme implements Parcelable {
 
     public ButtonConfiguration getGliaNeutralButtonConfiguration() {
         return neutralButtonConfiguration;
+    }
+
+    public TextConfiguration getGliaChoiceCardContentTextConfiguration() {
+        return choiceCardContentTextConfiguration;
     }
 
     public Integer getGliaChatStartingHeadingTextColor() {

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -26,6 +26,7 @@ import com.glia.widgets.call.CallActivity;
 import com.glia.widgets.chat.ChatActivity;
 import com.glia.widgets.core.fileupload.model.FileAttachment;
 import com.glia.widgets.view.configuration.ButtonConfiguration;
+import com.glia.widgets.view.configuration.TextConfiguration;
 import com.glia.widgets.view.head.model.ChatHeadInput;
 
 import java.io.File;
@@ -455,9 +456,9 @@ public class Utils {
         imm.hideSoftInputFromWindow(windowToken, 0);
     }
 
-    private static ButtonConfiguration getButtonConfiguration(
-            ButtonConfiguration newConf,
-            ButtonConfiguration oldConf
+    private static <T> T getConfiguration(
+            T newConf,
+            T oldConf
     ) {
         return newConf != null ? newConf : oldConf;
     }
@@ -551,27 +552,33 @@ public class Utils {
                         oldTheme.getGliaAlertDialogButtonUseVerticalAlignment();
 
         ButtonConfiguration endButtonConfiguration =
-                getButtonConfiguration(
+                getConfiguration(
                         newTheme.getGliaEndButtonConfiguration(),
                         oldTheme.getGliaEndButtonConfiguration()
                 );
 
         ButtonConfiguration positiveButtonConfiguration =
-                getButtonConfiguration(
+                getConfiguration(
                         newTheme.getGliaPositiveButtonConfiguration(),
                         oldTheme.getGliaPositiveButtonConfiguration()
                 );
 
         ButtonConfiguration negativeButtonConfiguration =
-                getButtonConfiguration(
+                getConfiguration(
                         newTheme.getGliaNegativeButtonConfiguration(),
                         oldTheme.getGliaNegativeButtonConfiguration()
                 );
 
         ButtonConfiguration neutralButtonConfiguration =
-                getButtonConfiguration(
+                getConfiguration(
                         newTheme.getGliaNeutralButtonConfiguration(),
                         oldTheme.getGliaNeutralButtonConfiguration()
+                );
+
+        TextConfiguration choiceCardContentTextConfiguration =
+                getConfiguration(
+                        newTheme.getGliaChoiceCardContentTextConfiguration(),
+                        oldTheme.getGliaChoiceCardContentTextConfiguration()
                 );
 
         UiTheme.UiThemeBuilder builder = new UiTheme.UiThemeBuilder();
@@ -622,6 +629,7 @@ public class Utils {
         builder.setPositiveButtonConfiguration(positiveButtonConfiguration);
         builder.setNegativeButtonConfiguration(negativeButtonConfiguration);
         builder.setNeutralButtonConfiguration(neutralButtonConfiguration);
+        builder.setChoiceCardContentTextConfiguration(choiceCardContentTextConfiguration);
         return builder.build();
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -50,6 +50,10 @@ public class Utils {
         return toMmSs(Long.valueOf(TimeUnit.MILLISECONDS.toSeconds(milliseconds)).intValue());
     }
 
+    public static float pxToSp(Context context, float pixels) {
+        return pixels / context.getResources().getDisplayMetrics().scaledDensity;
+    }
+
     public static String formatOperatorName(String operatorName) {
         if (operatorName == null) return "";
         int i = operatorName.indexOf(' ');

--- a/widgetssdk/src/main/java/com/glia/widgets/view/SingleChoiceCardView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/SingleChoiceCardView.java
@@ -20,6 +20,7 @@ import com.glia.androidsdk.chat.SingleChoiceOption;
 import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.helper.Utils;
+import com.glia.widgets.view.textview.ChoiceCardContentTextView;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.card.MaterialCardView;
 import com.squareup.picasso.Callback;
@@ -32,7 +33,7 @@ public class SingleChoiceCardView extends FrameLayout {
     private final MaterialCardView materialCardView;
     private final ImageView imageView;
     private final ConstraintLayout layout;
-    private final TextView contentView;
+    private final ChoiceCardContentTextView contentView;
     private OnOptionClickedListener onOptionClickedListener;
     private OnImageLoadedListener onImageLoadedListener;
 
@@ -64,15 +65,8 @@ public class SingleChoiceCardView extends FrameLayout {
             OnImageLoadedListener onImageLoadedListener
     ) {
         this.onImageLoadedListener = onImageLoadedListener;
-
-        int gliaBaseDarkColor = ContextCompat.getColor(
-                this.getContext(), theme.getBaseDarkColor()
-        );
         int gliaBaseLightColor = ContextCompat.getColor(
                 this.getContext(), theme.getBaseLightColor()
-        );
-        int gliaBaseShadeColor = ContextCompat.getColor(
-                this.getContext(), theme.getBaseShadeColor()
         );
         int gliaBrandPrimaryColor = ContextCompat.getColor(
                 this.getContext(), theme.getBrandPrimaryColor()
@@ -97,9 +91,8 @@ public class SingleChoiceCardView extends FrameLayout {
             });
         }
         imageView.setVisibility(imageUrl != null ? VISIBLE : GONE);
-        contentView.setTextColor(gliaBaseDarkColor);
-
         contentView.setText(content);
+        contentView.setTheme(theme);
         ConstraintSet constraintSet = new ConstraintSet();
         int topViewId = R.id.content_view;
         for (int index = 0; index < options.size(); index++) {
@@ -159,12 +152,10 @@ public class SingleChoiceCardView extends FrameLayout {
                             ContextCompat.getColorStateList(this.getContext(), theme.getBotActionButtonSelectedBackgroundColor()) :
                             ContextCompat.getColorStateList(this.getContext(), theme.getBotActionButtonBackgroundColor());
 
-
             ColorStateList actionButtonTextColor =
                     isSelected ?
                             ContextCompat.getColorStateList(this.getContext(), theme.getBotActionButtonSelectedTextColor()) :
                             ContextCompat.getColorStateList(this.getContext(), theme.getBotActionButtonTextColor());
-
 
             button.setBackgroundTintList(actionButtonBackgroundColor);
             button.setTextColor(actionButtonTextColor);
@@ -176,8 +167,6 @@ public class SingleChoiceCardView extends FrameLayout {
                                 theme.getFontRes())
                 );
             }
-
-
             if (selectedIndex != null && selectedIndex != index) {
                 button.setStrokeWidth(
                         Float.valueOf(Utils.pxFromDp(this.getContext(), 1f)).intValue()
@@ -199,13 +188,6 @@ public class SingleChoiceCardView extends FrameLayout {
                 });
             }
             constraintSet.applyTo(layout);
-        }
-        if (theme.getFontRes() != null) {
-            contentView.setTypeface(
-                    ResourcesCompat.getFont(
-                            this.getContext(),
-                            theme.getFontRes())
-            );
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
@@ -212,7 +212,7 @@ public class TextConfiguration implements Parcelable {
             return this;
         }
 
-        public Builder textSize(float textSize) {
+        public Builder textSize(Float textSize) {
             this.textSize = textSize;
             return this;
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
@@ -1,0 +1,84 @@
+package com.glia.widgets.view.textview;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
+
+import com.glia.widgets.R;
+import com.glia.widgets.UiTheme;
+import com.glia.widgets.view.configuration.TextConfiguration;
+import com.google.android.material.textview.MaterialTextView;
+
+public abstract class BaseConfigurableTextView extends MaterialTextView {
+    private TextConfiguration textConfiguration;
+
+    public BaseConfigurableTextView(@NonNull Context context) {
+        this(context, null);
+    }
+
+    public BaseConfigurableTextView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, R.attr.textAppearanceBody1);
+    }
+
+    public BaseConfigurableTextView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, R.style.Application_Glia_Body);
+    }
+
+    public BaseConfigurableTextView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        createBuildTimeConfiguration();
+        updateView();
+    }
+
+    public abstract TextConfiguration getTextConfigurationFromTheme(UiTheme theme);
+
+    private void createBuildTimeConfiguration() {
+        textConfiguration = TextConfiguration
+                .builder()
+                .textColor(getTextColors())
+                .textColorHighlight(getHighlightColor())
+                .textColorHint(getHintTextColors())
+                .textSize(pxToSp(getContext(), getTextSize()))
+                .build();
+    }
+
+    private float pxToSp(Context context, float pixels) {
+        return pixels / context.getResources().getDisplayMetrics().scaledDensity;
+    }
+
+    public void setTheme(UiTheme theme) {
+        if (theme == null) return;
+        TextConfiguration runTimeConfiguration = getTextConfigurationFromTheme(theme);
+        if (runTimeConfiguration == null) return;
+        TextConfiguration.Builder builder = new TextConfiguration.Builder(textConfiguration);
+
+        if (runTimeConfiguration.getTextColor() != null)
+            builder.textColor(runTimeConfiguration.getTextColor());
+        if (runTimeConfiguration.getTextColorHighlight() != null)
+            builder.textColorHighlight(runTimeConfiguration.getTextColorHighlight());
+        if (runTimeConfiguration.getTextColorHint() != null)
+            builder.textColorHint(runTimeConfiguration.getTextColorHint());
+        if (runTimeConfiguration.getTextSize() != null)
+            builder.textSize(runTimeConfiguration.getTextSize());
+        if (runTimeConfiguration.getFontFamily() != null)
+            builder.fontFamily(runTimeConfiguration.getFontFamily());
+
+        textConfiguration = builder.build();
+        updateView();
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private void updateView() {
+        setTextSize(TypedValue.COMPLEX_UNIT_SP, textConfiguration.getTextSize());
+        setTextColor(textConfiguration.getTextColor());
+        setHintTextColor(textConfiguration.getTextColorHint());
+        setLinkTextColor(textConfiguration.getTextColorLink());
+        setHighlightColor(textConfiguration.getTextColorHighlight());
+        if (textConfiguration.getFontFamily() != null && textConfiguration.getFontFamily() != 0)
+            setTypeface(ResourcesCompat.getFont(getContext(), textConfiguration.getFontFamily()));
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.textview;
 
+import static com.glia.widgets.helper.Utils.pxToSp;
+
 import android.content.Context;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -44,10 +46,6 @@ public abstract class BaseConfigurableTextView extends MaterialTextView {
                 .textColorHint(getHintTextColors())
                 .textSize(pxToSp(getContext(), getTextSize()))
                 .build();
-    }
-
-    private float pxToSp(Context context, float pixels) {
-        return pixels / context.getResources().getDisplayMetrics().scaledDensity;
     }
 
     public void setTheme(UiTheme theme) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/textview/ChoiceCardContentTextView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/textview/ChoiceCardContentTextView.java
@@ -1,0 +1,22 @@
+package com.glia.widgets.view.textview;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.glia.widgets.R;
+import com.glia.widgets.UiTheme;
+import com.glia.widgets.view.configuration.TextConfiguration;
+
+public class ChoiceCardContentTextView extends BaseConfigurableTextView {
+    public ChoiceCardContentTextView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs, R.attr.choiceCardContentTextStyle, R.style.Application_Glia_ChoiceCard_ContentText);
+    }
+
+    @Override
+    public TextConfiguration getTextConfigurationFromTheme(UiTheme theme) {
+        return theme.getGliaChoiceCardContentTextConfiguration();
+    }
+}

--- a/widgetssdk/src/main/res/layout/single_choice_card_view.xml
+++ b/widgetssdk/src/main/res/layout/single_choice_card_view.xml
@@ -32,13 +32,12 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
+            <com.glia.widgets.view.textview.ChoiceCardContentTextView
                 android:id="@+id/content_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/glia_medium"
                 android:gravity="center"
-                android:textAppearance="?attr/textAppearanceBody1"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/image"

--- a/widgetssdk/src/main/res/values/attrs.xml
+++ b/widgetssdk/src/main/res/values/attrs.xml
@@ -174,6 +174,7 @@
     <attr name="buttonBarPositiveButtonStyle" format="reference" />
     <attr name="buttonBarNegativeButtonStyle" format="reference" />
     <attr name="buttonBarNeutralButtonStyle" format="reference" />
+    <attr name="choiceCardContentTextStyle" format="reference" />
 
     <declare-styleable name="OutlinedOptionView">
         <attr name="icon" format="reference" />

--- a/widgetssdk/src/main/res/values/styles.xml
+++ b/widgetssdk/src/main/res/values/styles.xml
@@ -92,6 +92,10 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+    <style name="Application.Glia.ChoiceCard.ContentText" parent="Application.Glia.Body">
+        <item name="android:textColor">?attr/gliaBaseDarkColor</item>
+    </style>
+
     <style name="ShapeAppearance.CircularBorder" parent="">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">8dp</item>


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-625

**Additional info:**
For Runtime customisation add this `TextConfiguration` to `UiThemeBuilder`:
```
    private static TextConfiguration getChoiceCardContentTextConfiguration(Context context) {
        return TextConfiguration.builder()
                .textSize(16f)      // in sp
                .fontFamily(R.font.tangerine)
                .textColor(ContextCompat.getColorStateList(context, R.color.color_dark_cyan))
                .build();
    }
```

For Buildtime customisation define or pass a style to `ThemeOverlay.GliaAndroidSDKWidgetsExample.Chat` like this:
```
        <item name="choiceCardContentTextStyle">
            @style/Application.GliaAndroidSdkWidgetsExample.ChoiceCard.ContentText
        </item>
```
style example:
```
    <style name="Application.GliaAndroidSdkWidgetsExample.ChoiceCard.ContentText" parent="TextAppearance.MaterialComponents.Body1">
        <item name="android:textSize">40sp</item>
        <item name="android:textColor">@color/color_dark_cyan</item>
        <!-- item name="fontFamily">@font/tangerine</item -->
    </style>
```

**Screenshots:**
<img width="390" alt="Screenshot 2021-12-10 at 15 41 19" src="https://user-images.githubusercontent.com/49229744/145583070-696447eb-8b5c-4e65-a15b-353e93b9a7dc.png">
<img width="390" alt="Screenshot 2021-12-10 at 15 39 48" src="https://user-images.githubusercontent.com/49229744/145583079-9b7ec0e0-9fff-4a02-a2ad-cba9ec822dab.png">

