### PR TITLE
MUIC-574 Chat/Audio/Video - "Attachments" menu becomes unreachable in…

### DIFF
--- a/widgetssdk/src/main/res/layout/chat_attachment_select_item_menu.xml
+++ b/widgetssdk/src/main/res/layout/chat_attachment_select_item_menu.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_margin="8dp"
     app:cardBackgroundColor="@color/glia_attachment_menu_bg"
     app:cardCornerRadius="@dimen/glia_chat_attachment_menu_corner_radius"
     app:layout_constraintBottom_toBottomOf="parent"

--- a/widgetssdk/src/main/res/layout/chat_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_view.xml
@@ -63,15 +63,6 @@
 
     </RelativeLayout>
 
-    <com.glia.widgets.chat.FileUploadMenuView
-        android:id="@+id/add_attachment_menu"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="21dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/divider_view"
-        app:layout_constraintEnd_toEndOf="parent" />
-
     <com.airbnb.lottie.LottieAnimationView
         android:id="@+id/operator_typing_animation_view"
         android:layout_width="wrap_content"
@@ -105,6 +96,15 @@
         app:layout_constraintTop_toBottomOf="@id/divider_view"
         tools:itemCount="6"
         tools:listitem="@layout/chat_attachment_uploaded_item" />
+
+    <com.glia.widgets.chat.FileUploadMenuView
+        android:id="@+id/add_attachment_menu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="13dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/chat_message_layout"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout
         android:id="@+id/chat_message_layout"


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-574

**Additional info:**
Menu is displayed on top of the attachments list.
Also fixed a menu shadow glitch.

**Screenshots:**
<img width="369" alt="Screenshot 2021-12-14 at 17 39 16" src="https://user-images.githubusercontent.com/49229695/146031738-9c630d97-cc2b-473f-b05d-b11be4025935.png">
<img width="810" alt="Screenshot 2021-12-14 at 17 39 42" src="https://user-images.githubusercontent.com/49229695/146031753-57efcc82-e9cb-424a-bf1a-04c75b1a62bd.png">

