### PR TITLE
Fix incorrect "Audio call" title during connection with operator

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -253,6 +253,13 @@ public class CallController implements
                     MediaUpgradeOfferRepository.Submitter submitter
             ) {
                 Logger.d(TAG, "upgradeOfferChoiceSubmitSuccess");
+                Engagement.MediaType mediaType;
+                if (offer.video != null && offer.video != MediaDirection.NONE) {
+                    mediaType = Engagement.MediaType.VIDEO;
+                } else {
+                    mediaType = Engagement.MediaType.AUDIO;
+                }
+                emitViewState(callState.changeRequestedMediaType(mediaType));
                 dialogController.dismissDialogs();
             }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
@@ -139,6 +139,13 @@ class CallState {
                 .createCallState();
     }
 
+    public CallState changeRequestedMediaType(Engagement.MediaType requestedMediaType) {
+        return new Builder()
+                .copyFrom(this)
+                .setRequestedMediaType(requestedMediaType)
+                .createCallState();
+    }
+
     public CallState engagementStarted(
             String operatorName,
             String operatorProfileImgUrl) {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
@@ -285,18 +285,13 @@ public class CallView extends ConstraintLayout {
                 post(() -> {
                     if (callState.isMediaEngagementStarted()) {
                         appBar.showEndButton();
-                        if (callState.isVideoCall()) {
-                            appBar.setTitle(resources.getString(R.string.glia_call_video_app_bar_title));
-                        } else {
-                            appBar.setTitle(resources.getString(R.string.glia_call_audio_app_bar_title));
-                        }
                     } else {
                         appBar.showXButton();
-                        if (callState.requestedMediaType == Engagement.MediaType.VIDEO) {
-                            appBar.setTitle(resources.getString(R.string.glia_call_video_app_bar_title));
-                        } else {
-                            appBar.setTitle(resources.getString(R.string.glia_call_audio_app_bar_title));
-                        }
+                    }
+                    if (callState.requestedMediaType == Engagement.MediaType.VIDEO) {
+                        appBar.setTitle(resources.getString(R.string.glia_call_video_app_bar_title));
+                    } else {
+                        appBar.setTitle(resources.getString(R.string.glia_call_audio_app_bar_title));
                     }
                     operatorStatusView.isRippleAnimationShowing(
                             callState.isCallNotOngoing() ||

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
@@ -631,7 +631,7 @@ public class ChatController implements
                 Logger.d(TAG, "upgradeOfferChoiceSubmitSuccess");
                 if (submitter == MediaUpgradeOfferRepository.Submitter.CHAT) {
                     String requestedMediaType;
-                    if (offer.video != null) {
+                    if (offer.video != null && offer.video != MediaDirection.NONE) {
                         requestedMediaType = GliaWidgets.MEDIA_TYPE_VIDEO;
                     } else {
                         requestedMediaType = GliaWidgets.MEDIA_TYPE_AUDIO;


### PR DESCRIPTION
Fixed bug where when an operator upgrades to two-way video, a visitor sees an Audio call screen title

Used the requested media type to set the title on the call screen.

[MOB-1037](https://glia.atlassian.net/browse/MOB-1037)
