### PR TITLE
Fix operator avatar not removed issue

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.java
@@ -123,6 +123,7 @@ public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         } else if (viewType == OPERATOR_IMAGE_VIEW_TYPE) {
             return new OperatorImageAttachmentViewHolder(
                     inflater.inflate(R.layout.chat_attachment_operator_image_layout, parent, false),
+                    uiTheme,
                     getImageFileFromCacheUseCase,
                     getImageFileFromDownloadsUseCase,
                     getImageFileFromNetworkUseCase
@@ -165,9 +166,8 @@ public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 });
             } else {
                 OperatorImageAttachmentViewHolder viewHolder = (OperatorImageAttachmentViewHolder) holder;
-                AttachmentFile file = ((OperatorAttachmentItem) chatItem).attachmentFile;
-                viewHolder.bind(file);
-                viewHolder.itemView.setOnClickListener(v -> onImageItemClickListener.onImageItemClick(file));
+                OperatorAttachmentItem item = (OperatorAttachmentItem) chatItem;
+                viewHolder.bind(item, onImageItemClickListener);
             }
         } else if (chatItem instanceof VisitorAttachmentItem) {
             if (chatItem.getViewType() == VISITOR_FILE_VIEW_TYPE) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/OperatorImageAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/OperatorImageAttachmentViewHolder.java
@@ -4,17 +4,47 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import com.glia.widgets.R;
+import com.glia.widgets.UiTheme;
+import com.glia.widgets.chat.adapter.ChatAdapter;
+import com.glia.widgets.chat.model.history.OperatorAttachmentItem;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromCacheUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromDownloadsUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromNetworkUseCase;
+import com.glia.widgets.view.OperatorStatusView;
 
 public class OperatorImageAttachmentViewHolder extends ImageAttachmentViewHolder {
+    private final OperatorStatusView operatorStatusView;
+
     public OperatorImageAttachmentViewHolder(
             @NonNull View itemView,
+            UiTheme uiTheme,
             GetImageFileFromCacheUseCase getImageFileFromCacheUseCase,
             GetImageFileFromDownloadsUseCase getImageFileFromDownloadsUseCase,
             GetImageFileFromNetworkUseCase getImageFileFromNetworkUseCase
     ) {
         super(itemView, getImageFileFromCacheUseCase, getImageFileFromDownloadsUseCase, getImageFileFromNetworkUseCase);
+        operatorStatusView = itemView.findViewById(R.id.chat_head_view);
+        setupOperatorStatus(uiTheme);
+    }
+
+    private void setupOperatorStatus(UiTheme uiTheme) {
+        operatorStatusView.setTheme(uiTheme);
+        operatorStatusView.isRippleAnimationShowing(false);
+    }
+
+    public void bind(OperatorAttachmentItem item, ChatAdapter.OnImageItemClickListener onImageItemClickListener) {
+        super.bind(item.attachmentFile);
+        itemView.setOnClickListener(v -> onImageItemClickListener.onImageItemClick(item.attachmentFile));
+        updateOperatorStatus(item);
+    }
+
+    private void updateOperatorStatus(OperatorAttachmentItem item) {
+        operatorStatusView.setVisibility(item.showChatHead ? View.VISIBLE : View.GONE);
+        if (item.operatorProfileImgUrl != null) {
+            operatorStatusView.showProfileImage(item.operatorProfileImgUrl);
+        } else {
+            operatorStatusView.showPlaceHolder();
+        }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/VisitorImageAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/VisitorImageAttachmentViewHolder.java
@@ -27,7 +27,7 @@ public class VisitorImageAttachmentViewHolder extends ImageAttachmentViewHolder 
             GetImageFileFromNetworkUseCase getImageFileFromNetworkUseCase
     ) {
         super(itemView, getImageFileFromCacheUseCase, getImageFileFromDownloadsUseCase, getImageFileFromNetworkUseCase);
-        this.deliveredView = itemView.findViewById(R.id.delivered_view);
+        deliveredView = itemView.findViewById(R.id.delivered_view);
         setupDeliveredView(itemView.getContext(), uiTheme);
     }
 

--- a/widgetssdk/src/main/res/layout/chat_attachment_operator_image_layout.xml
+++ b/widgetssdk/src/main/res/layout/chat_attachment_operator_image_layout.xml
@@ -20,6 +20,18 @@
         android:orientation="vertical"
         app:layout_constraintGuide_end="@dimen/glia_chat_operator_message_end" />
 
+    <com.glia.widgets.view.OperatorStatusView
+        android:id="@+id/chat_head_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/glia_small"
+        android:layout_marginEnd="@dimen/glia_small"
+        app:imageSize="@dimen/glia_chat_operator_item_chat_head_size"
+        app:layout_constraintBottom_toBottomOf="@id/incoming_image_attachment"
+        app:layout_constraintEnd_toStartOf="@id/start_guideline"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:ignore="ContentDescription" />
+
     <include
         layout="@layout/chat_attachment_image_item"
         android:layout_width="@dimen/glia_chat_attachment_image_width"
@@ -29,5 +41,4 @@
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-593

**Additional info:**
- Changed the operator message and attachments order as per the hub. Message is shown first and then attachments/images.

