### PR TITLE
MUIC-647 Fix permission request related crash

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
@@ -1345,11 +1345,15 @@ public class ChatView extends ConstraintLayout implements ChatAdapter.OnFileItem
     }
 
     public void onRequestPermissionsResult(int requestCode, int[] grantResults) {
-        if (requestCode == CAMERA_PERMISSION_REQUEST && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            dispatchImageCapture();
-        }
-        if (requestCode == WRITE_PERMISSION_REQUEST && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            if (downloadFileHolder != null) onFileDownload(downloadFileHolder);
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            switch (requestCode) {
+                case CAMERA_PERMISSION_REQUEST:
+                    dispatchImageCapture();
+                    break;
+                case WRITE_PERMISSION_REQUEST:
+                    if (downloadFileHolder != null) onFileDownload(downloadFileHolder);
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-647

From the docs: https://developer.android.com/reference/androidx/core/app/ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int,java.lang.String[],int[])
>Note: It is possible that the permissions request interaction with the user is interrupted. In this case you will receive empty permissions and results arrays which should be treated as a cancellation.