### PR TITLE
MUIC-682 Fix screensharing notification crash

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationFactory.java
@@ -23,7 +23,7 @@ public class NotificationFactory {
                         context,
                         SCREEN_SHARING_PENDING_INTENT_REQUEST_CODE,
                         NotificationActionReceiver.getScreenSharingEndPressedActionIntent(context),
-                        PendingIntent.FLAG_UPDATE_CURRENT
+                        PendingIntent.FLAG_IMMUTABLE
                 );
 
         return new NotificationCompat.Builder(context, NOTIFICATION_SCREEN_SHARING_CHANNEL_ID)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-682

**Additional info:**

Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
