### PR TITLE
Fix "visitor is typing" not cleared bug and editText cursor jumping bug

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
@@ -503,6 +503,13 @@ public class ChatView extends ConstraintLayout implements
             public void fileDownloadSuccess(AttachmentFile attachmentFile) {
                 fileDownloadCompleted(attachmentFile);
             }
+
+            @Override
+            public void clearMessageInput() {
+                chatEditText.removeTextChangedListener(textWatcher);
+                chatEditText.getText().clear();
+                chatEditText.addTextChangedListener(textWatcher);
+            }
         };
     }
 
@@ -584,22 +591,12 @@ public class ChatView extends ConstraintLayout implements
     }
 
     private void updateChatEditText(ChatState chatState) {
-        if (!Utils.compareStringWithTrim(chatEditText.getText().toString(), chatState.lastTypedText)) {
-            chatEditText.removeTextChangedListener(textWatcher);
-            chatEditText.setText(chatState.lastTypedText);
-            chatEditText.addTextChangedListener(textWatcher);
-        }
-
         switch (chatState.chatInputMode) {
             case SINGLE_CHOICE_CARD:
                 chatEditText.setHint(R.string.glia_chat_single_choice_card_hint);
                 break;
             case ENABLED_NO_ENGAGEMENT:
-                if (chatState.lastTypedText.isEmpty()) {
-                    chatEditText.setHint(R.string.glia_chat_not_started_hint);
-                } else {
-                    chatEditText.setHint("");
-                }
+                chatEditText.setHint(R.string.glia_chat_not_started_hint);
                 break;
             default:
                 chatEditText.setHint(R.string.glia_chat_enter_message);

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
@@ -26,4 +26,6 @@ public interface ChatViewCallback {
     void fileDownloadError(AttachmentFile attachmentFile, Throwable error);
 
     void fileDownloadSuccess(AttachmentFile attachmentFile);
+
+    void clearMessageInput();
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
@@ -92,6 +92,7 @@ public class ChatController implements
         GliaOnEngagementEndUseCase.Listener {
 
     private final static String TAG = ChatController.class.getSimpleName();
+    private final static String EMPTY_MESSAGE = "";
 
     private ChatViewCallback viewCallback;
     private MediaUpgradeOfferRepositoryCallback mediaUpgradeOfferRepositoryCallback;
@@ -139,10 +140,11 @@ public class ChatController implements
 
         @Override
         public void onMessageValidated() {
+            viewCallback.clearMessageInput();
             emitViewState(
                     chatState
-                            .setLastTypedText("")
-                            .setShowSendButton(isShowSendButtonUseCase.execute(""))
+                            .setLastTypedText(EMPTY_MESSAGE)
+                            .setShowSendButton(isShowSendButtonUseCase.execute(EMPTY_MESSAGE))
             );
         }
 
@@ -254,7 +256,7 @@ public class ChatController implements
                 .setIsVisible(false)
                 .setIntegratorChatStarted(false)
                 .setChatItems(new ArrayList<>())
-                .setLastTypedText("")
+                .setLastTypedText(EMPTY_MESSAGE)
                 .setChatInputMode(ChatInputMode.ENABLED_NO_ENGAGEMENT)
                 .setIsAttachmentButtonNeeded(false)
                 .setIsAttachmentAllowed(true)
@@ -420,16 +422,23 @@ public class ChatController implements
                         .setLastTypedText(message)
                         .setShowSendButton(isShowSendButtonUseCase.execute(message))
         );
-        if (chatState.isOperatorOnline()) {
-            Logger.d(TAG, "Send preview: " + message);
-            sendMessagePreviewUseCase.execute(message);
-        }
+        sendMessagePreview(message);
     }
 
     public void sendMessage(String message) {
         Logger.d(TAG, "Send MESSAGE: " + message);
-        Logger.d(TAG, "SEND MESSAGE sending");
+        clearMessagePreview();
         sendMessageUseCase.execute(message, sendMessageCallback);
+    }
+
+    private void sendMessagePreview(String message) {
+        if (chatState.isOperatorOnline()) {
+            sendMessagePreviewUseCase.execute(message);
+        }
+    }
+
+    private void clearMessagePreview() {
+        sendMessagePreview(EMPTY_MESSAGE);
     }
 
     private void onMessage(ChatMessage message) {
@@ -955,7 +964,7 @@ public class ChatController implements
     }
 
     private void appendOperatorMessageItem(List<ChatItem> currentChatItems, ChatMessage message) {
-        if (!message.getContent().equals("")) {
+        if (!message.getContent().equals(EMPTY_MESSAGE)) {
             MessageAttachment messageAttachment = message.getAttachment();
             currentChatItems.add(
                     new OperatorMessageItem(

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
@@ -438,6 +438,7 @@ public class ChatController implements
     }
 
     private void clearMessagePreview() {
+        // Empty string has to be sent to clear the message preview.
         sendMessagePreview(EMPTY_MESSAGE);
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.java
@@ -516,7 +516,32 @@ public class ChatState {
         }
 
         public ChatState createChatState() {
-            return new ChatState(queueTicketId, historyLoaded, operatorName, operatorProfileImgUrl, companyName, queueId, contextUrl, isVisible, integratorChatStarted, mediaUpgradeStartedTimerItem, chatItems, chatInputMode, lastTypedText, isChatInBottom, messagesNotSeen, engagementRequested, pendingNavigationType, unsentMessages, operatorStatusItem, showSendButton, isOperatorTyping, isAttachmentButtonEnabled, isAttachmentButtonNeeded, isAttachmentAllowed);
+            return new ChatState(
+                    queueTicketId,
+                    historyLoaded,
+                    operatorName,
+                    operatorProfileImgUrl,
+                    companyName,
+                    queueId,
+                    contextUrl,
+                    isVisible,
+                    integratorChatStarted,
+                    mediaUpgradeStartedTimerItem,
+                    chatItems,
+                    chatInputMode,
+                    lastTypedText,
+                    isChatInBottom,
+                    messagesNotSeen,
+                    engagementRequested,
+                    pendingNavigationType,
+                    unsentMessages,
+                    operatorStatusItem,
+                    showSendButton,
+                    isOperatorTyping,
+                    isAttachmentButtonEnabled,
+                    isAttachmentButtonNeeded,
+                    isAttachmentAllowed
+            );
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -30,8 +30,8 @@ import java.io.IOException;
 import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 public class Utils {
     public static float pxFromDp(final Context context, final float dp) {
@@ -690,12 +690,6 @@ public class Utils {
         return Optional.ofNullable(filename)
                 .filter(f -> f.contains("."))
                 .map(f -> f.substring(filename.lastIndexOf(".") + 1).toUpperCase());
-    }
-
-    public static boolean compareStringWithTrim(String a, String b) {
-        if (a == null && b == null) return true;
-        if (a == null || b == null) return false;
-        return a.trim().equals(b.trim());
     }
 
     public static String toString(AttachmentFile attachmentFile) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-665
https://glia.atlassian.net/browse/MUIC-685

**Additional info:**
I changed the two-way data flow in the editText to one way only. Two-way created many issues with the editText, it is not suggested and it was used only for clearing the editText. Clearing happens now via the viewCallback.   