### PR TITLE
Add missing intent extras when navigating from chat head to ChatActivity

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
@@ -263,6 +263,8 @@ public class ChatHeadView extends ConstraintLayout implements ChatHeadContract.V
         newIntent.putExtra(GliaWidgets.QUEUE_ID, sdkConfiguration.getQueueId());
         newIntent.putExtra(GliaWidgets.CONTEXT_URL, sdkConfiguration.getContextUrl());
         newIntent.putExtra(GliaWidgets.UI_THEME, sdkConfiguration.getRunTimeTheme());
+        newIntent.putExtra(GliaWidgets.USE_OVERLAY, sdkConfiguration.getUseOverlay());
+        newIntent.putExtra(GliaWidgets.SCREEN_SHARING_MODE, sdkConfiguration.getScreenSharingMode());
         newIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         return newIntent;
     }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-702

**Additional info:**
UseOverlay and ScreenSharingMode extras were missing when navigating from chat head to chat activity and thus default values were used.
