### PR TITLE
Visitor Video Popup

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
@@ -785,7 +785,6 @@ public class CallView extends ConstraintLayout {
         setVisibility(INVISIBLE);
         Activity activity = Utils.getActivity(this.getContext());
         hideOperatorVideo();
-        floatingVisitorVideoCoordinatorLayout.setVisibility(GONE);
         floatingVisitorVideoCoordinatorLayout.hide();
         if (defaultStatusbarColor != null && activity != null) {
             activity.getWindow().setStatusBarColor(defaultStatusbarColor);
@@ -1007,8 +1006,6 @@ public class CallView extends ConstraintLayout {
         if (operatorMediaState != null && operatorMediaState.getVideo() != null) {
             Logger.d(TAG, "Starting video operator");
             operatorVideoView = operatorMediaState.getVideo().createVideoView(Utils.getActivity(this.getContext()));
-            operatorVideoView.setZ(10);
-            operatorVideoView.setZOrderMediaOverlay(true);
             operatorVideoContainer.removeAllViews();
             operatorVideoContainer.addView(operatorVideoView);
             operatorVideoContainer.invalidate();

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/ChatHeadService.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/ChatHeadService.java
@@ -70,7 +70,7 @@ public class ChatHeadService extends Service {
         chatHeadView = ChatHeadView.getInstance(this);
         chatHeadView.setController(controller);
         chatHeadView.setOnTouchListener(
-                new ViewHelpers.ChatHeadOnTouchListener(
+                new ViewHelpers.OnTouchListener(
                         () -> new Pair<>(layoutParams.x, layoutParams.y),
                         (x, y) -> {
                             layoutParams.x = Float.valueOf(x).intValue();

--- a/widgetssdk/src/main/java/com/glia/widgets/core/visitor/GliaVisitorMediaRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/visitor/GliaVisitorMediaRepository.java
@@ -4,11 +4,11 @@ import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.comms.Media;
 import com.glia.androidsdk.comms.VisitorMediaState;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class GliaVisitorMediaRepository implements VisitorMediaUpdatesListener {
-    private final List<VisitorMediaUpdatesListener> visitorMediaUpdatesListeners = new ArrayList<>();
+    private final Set<VisitorMediaUpdatesListener> visitorMediaUpdatesListeners = new HashSet<>();
 
     private VisitorMediaState currentMediaState = null;
     private boolean isOnHold = false;

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -16,6 +16,8 @@ import com.glia.widgets.view.head.ChatHeadLayoutContract;
 import com.glia.widgets.view.head.ChatHeadPosition;
 import com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController;
 import com.glia.widgets.view.head.controller.ServiceChatHeadController;
+import com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoContract;
+import com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoController;
 
 public class ControllerFactory {
 
@@ -232,6 +234,13 @@ public class ControllerFactory {
                 messagesNotSeenHandler,
                 useCaseFactory.createSubscribeToQueueingStateChangeUseCase(),
                 useCaseFactory.createUnSubscribeToQueueingStateChangeUseCase(),
+                useCaseFactory.createAddVisitorMediaStateListenerUseCase(),
+                useCaseFactory.createRemoveVisitorMediaStateListenerUseCase()
+        );
+    }
+
+    public FloatingVisitorVideoContract.Controller getFloatingVisitorVideoController() {
+        return new FloatingVisitorVideoController(
                 useCaseFactory.createAddVisitorMediaStateListenerUseCase(),
                 useCaseFactory.createRemoveVisitorMediaStateListenerUseCase()
         );

--- a/widgetssdk/src/main/java/com/glia/widgets/view/ViewHelpers.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/ViewHelpers.java
@@ -7,7 +7,7 @@ import androidx.core.util.Pair;
 
 public class ViewHelpers {
 
-    public static class ChatHeadOnTouchListener implements View.OnTouchListener {
+    public static class OnTouchListener implements View.OnTouchListener {
         private static final int DIFF_THRESHOLD = 20;
         private int initialX;
         private int initialY;
@@ -17,7 +17,7 @@ public class ViewHelpers {
         private final OnMoveListener onMoveListener;
         private final View.OnClickListener onChatHeadClickedListener;
 
-        public ChatHeadOnTouchListener(
+        public OnTouchListener(
                 OnRequestInitialCoordinates onRequestInitialCoordinates,
                 OnMoveListener onMoveListener,
                 View.OnClickListener onChatHeadClickedListener

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoContract.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoContract.java
@@ -1,0 +1,35 @@
+package com.glia.widgets.view.floatingvisitorvideoview;
+
+import android.app.Activity;
+
+import com.glia.androidsdk.comms.VisitorMediaState;
+import com.glia.widgets.base.BaseController;
+import com.glia.widgets.base.BaseView;
+
+public interface FloatingVisitorVideoContract {
+    interface Controller extends BaseController {
+        void onResume();
+
+        void onPause();
+
+        void setView(View view);
+    }
+
+    interface View extends BaseView<Controller> {
+        void setActivity(Activity activity);
+
+        void show(VisitorMediaState state);
+
+        void hide();
+
+        void onResume();
+
+        void onPause();
+
+        void onDestroy();
+
+        void showOnHold();
+
+        void hideOnHold();
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoController.java
@@ -1,0 +1,71 @@
+package com.glia.widgets.view.floatingvisitorvideoview;
+
+import com.glia.androidsdk.comms.Media;
+import com.glia.androidsdk.comms.Video;
+import com.glia.androidsdk.comms.VisitorMediaState;
+import com.glia.widgets.core.visitor.VisitorMediaUpdatesListener;
+import com.glia.widgets.core.visitor.domain.AddVisitorMediaStateListenerUseCase;
+import com.glia.widgets.core.visitor.domain.RemoveVisitorMediaStateListenerUseCase;
+
+public class FloatingVisitorVideoController implements FloatingVisitorVideoContract.Controller, VisitorMediaUpdatesListener {
+    private final AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase;
+    private final RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase;
+
+    private FloatingVisitorVideoContract.View view;
+
+    public FloatingVisitorVideoController(
+            AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase,
+            RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase
+    ) {
+        this.addVisitorMediaStateListenerUseCase = addVisitorMediaStateListenerUseCase;
+        this.removeVisitorMediaStateListenerUseCase = removeVisitorMediaStateListenerUseCase;
+    }
+
+    @Override
+    public void onResume() {
+        addVisitorMediaStateListenerUseCase.execute(this);
+    }
+
+    @Override
+    public void onPause() {
+        removeVisitorMediaStateListenerUseCase.execute(this);
+    }
+
+    @Override
+    public void onDestroy() {
+    }
+
+    @Override
+    public void setView(FloatingVisitorVideoContract.View view) {
+        this.view = view;
+    }
+
+    @Override
+    public void onNewVisitorMediaState(VisitorMediaState visitorMediaState) {
+        if (hasVideoAvailable(visitorMediaState)) {
+            view.show(visitorMediaState);
+        } else {
+            view.hide();
+        }
+    }
+
+    @Override
+    public void onHoldChanged(boolean isOnHold) {
+        if (isOnHold) {
+            view.showOnHold();
+        } else {
+            view.hideOnHold();
+        }
+    }
+
+    private boolean hasVideoAvailable(VisitorMediaState visitorMediaState) {
+        return visitorMediaState != null &&
+                visitorMediaState.getVideo() != null &&
+                isVideoFeedActiveStatus(visitorMediaState.getVideo());
+    }
+
+    private boolean isVideoFeedActiveStatus(Video video) {
+        return video.getStatus() == Media.Status.PLAYING ||
+                video.getStatus() == Media.Status.PAUSED;
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoCoordinatorLayout.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoCoordinatorLayout.java
@@ -52,7 +52,9 @@ public class FloatingVisitorVideoCoordinatorLayout extends FrameLayout implement
     public void show(VisitorMediaState state) {
         post(() -> {
             if (!floatingVisitorVideoContainer.hasVideo()) {
-                floatingVisitorVideoContainer.showVisitorVideo(state.getVideo().createVideoView(activity));
+                floatingVisitorVideoContainer.showVisitorVideo(
+                        state.getVideo().createVideoView(activity)
+                );
             }
             setVisibility(VISIBLE);
         });
@@ -104,7 +106,7 @@ public class FloatingVisitorVideoCoordinatorLayout extends FrameLayout implement
     @SuppressLint("ClickableViewAccessibility")
     private void setVisitorVideoContainerTouchListener() {
         floatingVisitorVideoContainer.setOnTouchListener(
-                new ViewHelpers.ChatHeadOnTouchListener(
+                new ViewHelpers.OnTouchListener(
                         this::getViewLocation,
                         this::onViewDragged,
                         (view) -> { // no-op

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoCoordinatorLayout.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoCoordinatorLayout.java
@@ -83,6 +83,7 @@ public class FloatingVisitorVideoCoordinatorLayout extends FrameLayout implement
     @Override
     public void onDestroy() {
         floatingVisitorVideoContainer.onDestroy();
+        controller.onDestroy();
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoCoordinatorLayout.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoCoordinatorLayout.java
@@ -1,0 +1,144 @@
+package com.glia.widgets.view.floatingvisitorvideoview;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
+import com.glia.androidsdk.comms.VisitorMediaState;
+import com.glia.widgets.R;
+import com.glia.widgets.di.Dependencies;
+import com.glia.widgets.view.ViewHelpers;
+
+public class FloatingVisitorVideoCoordinatorLayout extends FrameLayout implements FloatingVisitorVideoContract.View {
+    private FloatingVisitorVideoContract.Controller controller;
+    private FloatingVisitorVideoView floatingVisitorVideoContainer;
+    private Activity activity;
+
+    public FloatingVisitorVideoCoordinatorLayout(@NonNull Context context) {
+        this(context, null);
+    }
+
+    public FloatingVisitorVideoCoordinatorLayout(@NonNull Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public FloatingVisitorVideoCoordinatorLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public FloatingVisitorVideoCoordinatorLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    @Override
+    public void setController(FloatingVisitorVideoContract.Controller controller) {
+        this.controller = controller;
+    }
+
+    @Override
+    public void setActivity(Activity activity) {
+        this.activity = activity;
+    }
+
+    @Override
+    public void show(VisitorMediaState state) {
+        post(() -> {
+            if (!floatingVisitorVideoContainer.hasVideo()) {
+                floatingVisitorVideoContainer.showVisitorVideo(state.getVideo().createVideoView(activity));
+            }
+            setVisibility(VISIBLE);
+        });
+    }
+
+    @Override
+    public void hide() {
+        post(() -> {
+            floatingVisitorVideoContainer.hideVisitorVideo();
+            setVisibility(GONE);
+        });
+    }
+
+    @Override
+    public void onResume() {
+        floatingVisitorVideoContainer.onResume();
+        controller.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        floatingVisitorVideoContainer.onPause();
+        controller.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
+        floatingVisitorVideoContainer.onDestroy();
+    }
+
+    @Override
+    public void showOnHold() {
+        // TODO- will be implemented in next task
+    }
+
+    @Override
+    public void hideOnHold() {
+        // TODO- will be implemented in next task
+    }
+
+    private void init() {
+        LayoutInflater.from(getContext()).inflate(R.layout.visitor_video_layout_view, this);
+        floatingVisitorVideoContainer = findViewById(R.id.visitor_video_card);
+        setController(Dependencies.getControllerFactory().getFloatingVisitorVideoController());
+        controller.setView(this);
+        setVisitorVideoContainerTouchListener();
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void setVisitorVideoContainerTouchListener() {
+        floatingVisitorVideoContainer.setOnTouchListener(
+                new ViewHelpers.ChatHeadOnTouchListener(
+                        this::getViewLocation,
+                        this::onViewDragged,
+                        (view) -> { // no-op
+                        }
+                )
+        );
+    }
+
+    private Pair<Integer, Integer> getViewLocation() {
+        return new Pair<>(
+                Float.valueOf(floatingVisitorVideoContainer.getX()).intValue(),
+                Float.valueOf(floatingVisitorVideoContainer.getY()).intValue()
+        );
+    }
+
+    private void onViewDragged(float newPositionX, float newPositionY) {
+        if (newPositionX < 0) {
+            newPositionX = 0;
+        }
+        if (newPositionY < 0) {
+            newPositionY = 0;
+        }
+        if (newPositionX > getWidth() - floatingVisitorVideoContainer.getWidth()) {
+            newPositionX = getWidth() - floatingVisitorVideoContainer.getWidth();
+        }
+        if (newPositionY > getHeight() - floatingVisitorVideoContainer.getHeight()) {
+            newPositionY = getHeight() - floatingVisitorVideoContainer.getHeight();
+        }
+        setFloatingViewPosition(newPositionX, newPositionY);
+    }
+
+    private void setFloatingViewPosition(float newPositionX, float newPositionY) {
+        floatingVisitorVideoContainer.setX(newPositionX);
+        floatingVisitorVideoContainer.setY(newPositionY);
+        floatingVisitorVideoContainer.invalidate();
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.java
@@ -47,6 +47,7 @@ public class FloatingVisitorVideoView extends ConstraintLayout {
 
     public void showVisitorVideo(VideoView newVideoView) {
         videoView = newVideoView;
+        videoView.setZOrderMediaOverlay(true);
         videoContainer.addView(videoView);
         videoContainer.invalidate();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.java
@@ -47,8 +47,6 @@ public class FloatingVisitorVideoView extends ConstraintLayout {
 
     public void showVisitorVideo(VideoView newVideoView) {
         videoView = newVideoView;
-        videoView.setZ(20);
-        videoView.setZOrderMediaOverlay(true);
         videoContainer.addView(videoView);
         videoContainer.invalidate();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.java
@@ -1,0 +1,89 @@
+package com.glia.widgets.view.floatingvisitorvideoview;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.constraintlayout.widget.ConstraintLayout;
+
+import com.glia.androidsdk.comms.VideoView;
+import com.glia.widgets.R;
+
+public class FloatingVisitorVideoView extends ConstraintLayout {
+    private VideoView videoView;
+    private FrameLayout videoContainer;
+
+    public FloatingVisitorVideoView(@NonNull Context context) {
+        this(context, null);
+    }
+
+    public FloatingVisitorVideoView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public FloatingVisitorVideoView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public FloatingVisitorVideoView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    public void onResume() {
+        resumeVideoStream();
+    }
+
+    public void onPause() {
+        pauseVideoStream();
+    }
+
+    public void onDestroy() {
+        releaseVideoStream();
+    }
+
+    public void showVisitorVideo(VideoView newVideoView) {
+        videoView = newVideoView;
+        videoView.setZ(20);
+        videoView.setZOrderMediaOverlay(true);
+        videoContainer.addView(videoView);
+        videoContainer.invalidate();
+    }
+
+    public void hideVisitorVideo() {
+        releaseVideoStream();
+        videoContainer.removeAllViews();
+        videoContainer.invalidate();
+    }
+
+    private void init() {
+        LayoutInflater.from(getContext()).inflate(R.layout.visitor_video_floating_view, this);
+        videoContainer = findViewById(R.id.visitor_video_container);
+    }
+
+    private void releaseVideoStream() {
+        if (videoView != null) {
+            videoView.release();
+            videoView = null;
+        }
+    }
+
+    private void pauseVideoStream() {
+        if (videoView != null) {
+            videoView.pauseRendering();
+        }
+    }
+
+    private void resumeVideoStream() {
+        if (videoView != null) {
+            videoView.resumeRendering();
+        }
+    }
+
+    public boolean hasVideo() {
+        return videoView != null;
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadLayout.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadLayout.java
@@ -194,7 +194,7 @@ public class ChatHeadLayout extends FrameLayout implements ChatHeadLayoutContrac
     @SuppressLint("ClickableViewAccessibility")
     private void setupViewActions() {
         chatHeadView.setOnTouchListener(
-                new ViewHelpers.ChatHeadOnTouchListener(
+                new ViewHelpers.OnTouchListener(
                         this::getChatHeadViewPosition,
                         this::onChatHeadDragged,
                         this::onChatHeadClicked

--- a/widgetssdk/src/main/res/layout-land/call_view.xml
+++ b/widgetssdk/src/main/res/layout-land/call_view.xml
@@ -134,20 +134,6 @@
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/visitor_video_container"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="@dimen/glia_large_x_large"
-        android:layout_marginEnd="@dimen/glia_large_x_large"
-        android:contentDescription="@string/glia_call_visitor_video_content_description"
-        android:visibility="gone"
-        app:cardCornerRadius="@dimen/glia_medium"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintHeight_percent="0.45"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.15" />
-
     <com.glia.widgets.view.header.AppBarView
         android:id="@+id/top_app_bar"
         android:layout_width="0dp"
@@ -181,6 +167,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/buttons_top_space" />
+
+    <com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoCoordinatorLayout
+        android:id="@+id/floating_visitor_video"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/glia_call_visitor_video_content_description"
+        app:layout_constraintBottom_toTopOf="@id/buttons_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Space
         android:id="@+id/buttons_top_space"

--- a/widgetssdk/src/main/res/layout/call_view.xml
+++ b/widgetssdk/src/main/res/layout/call_view.xml
@@ -38,19 +38,6 @@
         android:orientation="vertical"
         app:layout_constraintGuide_end="@dimen/glia_large" />
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/visitor_video_container"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_margin="@dimen/glia_large"
-        android:contentDescription="@string/glia_call_visitor_video_content_description"
-        android:visibility="gone"
-        app:cardCornerRadius="@dimen/glia_medium"
-        app:layout_constraintBottom_toTopOf="@id/operator_video_container"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toEndOf="@id/operator_data_barrier"
-        app:layout_constraintTop_toBottomOf="@id/top_app_bar" />
-
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/operator_data_barrier"
         android:layout_width="wrap_content"
@@ -157,11 +144,13 @@
 
     <FrameLayout
         android:id="@+id/operator_video_container"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="@dimen/glia_call_video_height"
         android:contentDescription="@string/glia_call_operator_video_content_description"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/buttons_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/call_timer_view" />
 
     <TextView
@@ -176,6 +165,16 @@
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         tools:text="@string/glia_call_continue_browsing" />
+
+    <com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoCoordinatorLayout
+        android:id="@+id/floating_visitor_video"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/glia_call_visitor_video_content_description"
+        app:layout_constraintBottom_toTopOf="@id/buttons_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_app_bar" />
 
     <View
         android:id="@+id/buttons_layout_bg"

--- a/widgetssdk/src/main/res/layout/visitor_video_floating_view.xml
+++ b/widgetssdk/src/main/res/layout/visitor_video_floating_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="@dimen/glia_visitor_video_width"
+    android:layout_height="@dimen/glia_visitor_video_height"
+    android:layout_margin="@dimen/glia_large"
+    android:contentDescription="@string/glia_call_visitor_video_content_description"
+    app:cardBackgroundColor="@android:color/transparent"
+    app:cardCornerRadius="0dp"
+    app:cardPreventCornerOverlap="true"
+    tools:cardBackgroundColor="@android:color/black">
+
+    <FrameLayout
+        android:id="@+id/visitor_video_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</com.google.android.material.card.MaterialCardView>

--- a/widgetssdk/src/main/res/layout/visitor_video_layout_view.xml
+++ b/widgetssdk/src/main/res/layout/visitor_video_layout_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/visitor_video_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoView
+        android:id="@+id/visitor_video_card"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.85"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.150" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/widgetssdk/src/main/res/values/dimens.xml
+++ b/widgetssdk/src/main/res/values/dimens.xml
@@ -10,6 +10,10 @@
     <dimen name="glia_x_large">32dp</dimen>
     <dimen name="glia_xx_large">64dp</dimen>
 
+    <dimen name="glia_visitor_video_height">182dp</dimen>
+    <dimen name="glia_visitor_video_width">104dp</dimen>
+    <dimen name="glia_visitor_video_corner_radius">@dimen/glia_medium</dimen>
+
     <dimen name="glia_ripple_animation_size">142dp</dimen>
     <dimen name="glia_chat_profile_picture_size">80dp</dimen>
     <dimen name="glia_chat_profile_picture_content_padding">20dp</dimen>


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-648

**Additional info**
There is some sort of visual bug when you hover visitor video over operator video edges that are over operator video are displayed sharp, so edges are now set to sharp to get rid of the issue. (Needs core-SDK team input - or research)

Also sometimes when operator video is created after visitor video (post methods order), visitor video is positioned behind the operator video. Not sure why (might need core-SDK team input on this) - tried to add z-vector and elevation but it still happens. View hierarchy seems to be ignored? (check last image)

**Screenshots:**
![Screenshot_1649770369](https://user-images.githubusercontent.com/49229744/162974816-f0c83f45-375b-4ed3-b8ad-2f1e78c821f0.png)
![Screenshot_1649770379](https://user-images.githubusercontent.com/49229744/162974825-51300b5c-d084-40b2-af68-418502320fc0.png)
![Screenshot_1649770383](https://user-images.githubusercontent.com/49229744/162974832-0f1b1dc7-4ee8-4d01-9005-20ce9736b897.png)
![Screenshot_1649839170](https://user-images.githubusercontent.com/49229744/163136542-8dc5844f-4d2e-4350-902c-837161d624c5.png)

