### PR TITLE
Fix chat head visibility issue on screen rotation

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/ChatFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/ChatFragment.java
@@ -61,7 +61,7 @@ public class ChatFragment extends Fragment {
 
     @Override
     public void onResume() {
-        chatView.onResume(true);
+        chatView.onResume();
         super.onResume();
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
@@ -262,6 +262,9 @@ public class CallView extends ConstraintLayout {
         if (dialogController != null) {
             dialogController.removeCallback(dialogCallback);
         }
+        if (serviceChatHeadController != null) {
+            serviceChatHeadController.onPause(this);
+        }
     }
 
     private void destroyControllers(boolean isFinishing) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -15,7 +15,6 @@ import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.view.head.ChatHeadLayout;
 
 public class ChatActivity extends AppCompatActivity {
-    private static final String KEY_WAS_ACTIVITY_FINISHING = "was_activity_finishing";
     private ChatView chatView;
     private ChatView.OnBackClickedListener onBackClickedListener = () -> {
         if (chatView.backPressed()) finish();
@@ -28,8 +27,6 @@ public class ChatActivity extends AppCompatActivity {
             };
 
     private GliaSdkConfiguration configuration;
-
-    private boolean wasActivityFinishing = true;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -57,7 +54,7 @@ public class ChatActivity extends AppCompatActivity {
 
     @Override
     protected void onResume() {
-        chatView.onResume(wasActivityFinishing);
+        chatView.onResume();
         super.onResume();
     }
 
@@ -74,18 +71,6 @@ public class ChatActivity extends AppCompatActivity {
         onNavigateToCallListener = null;
         chatView.onDestroyView(isFinishing());
         super.onDestroy();
-    }
-
-    @Override
-    protected void onSaveInstanceState(@NonNull Bundle outState) {
-        outState.putBoolean(KEY_WAS_ACTIVITY_FINISHING, isFinishing());
-        super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
-        wasActivityFinishing = savedInstanceState.getBoolean(KEY_WAS_ACTIVITY_FINISHING, true);
-        super.onRestoreInstanceState(savedInstanceState);
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
@@ -333,7 +333,7 @@ public class ChatView extends ConstraintLayout implements
      * Use this method to notify the view when your activity or fragment is back in its resumed
      * state.
      */
-    public void onResume(boolean needToInitialize) {
+    public void onResume() {
         if (controller != null) {
             controller.onResume();
         }
@@ -344,7 +344,7 @@ public class ChatView extends ConstraintLayout implements
         if (dialogController != null) {
             dialogController.addCallback(dialogCallback);
         }
-        if (needToInitialize && serviceChatHeadController != null) {
+        if (serviceChatHeadController != null) {
             serviceChatHeadController.onResume(this);
         }
     }
@@ -358,6 +358,9 @@ public class ChatView extends ConstraintLayout implements
         }
         if (dialogController != null) {
             dialogController.removeCallback(dialogCallback);
+        }
+        if (serviceChatHeadController != null) {
+            serviceChatHeadController.onPause(this);
         }
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-710

**Additional info:**
     We need to keep track of the currently active (topmost) view. This can be either ChatView
     or CallView. CallView has translucent theme and this changes the usual lifecycle of an activity.
     When the translucent CallActivity is on top of the ChatActivity and config change happens (e.g screen rotation)
     then ChatActivity onResume and onPause are called right after CallActivity's onResume. Current
     solution ignores such onResume calls because another activity is already in resumed state.
