### PR TITLE
Make SDK compatible with compileSDKVersion 30

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 30
     buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "com.glia.exampleapp"
         minSdkVersion 24
-        targetSdkVersion 31
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,15 +32,15 @@ apply from: "${rootDir}/scripts/publish-settings.gradle"
 ext {
     gliaSdkVersion = '0.24.3'
 
-    appCompatVersion = '1.4.1'
-    materialVersion = '1.5.0'
+    appCompatVersion = '1.3.1'
+    materialVersion = '1.4.0'
     constraintLayoutVersion = '2.1.3'
-    navVersion = '2.4.1'
-    lifecycle_process = '2.4.1'
+    navVersion = '2.3.5'
+    lifecycle_process = '2.3.1'
     rxAndroid = '2.1.0'
     rxJava = '2.2.6'
     gson = '2.8.6'
-    preferenceVersion = '1.2.0'
+    preferenceVersion = '1.1.1'
     picassoVersion = '2.71828'
     lottieVersion = '4.1.0'
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-721

**Additional info:**
Some google libraries that we use in Widget SDK require clients to have compileSDKVersion to be 31+. And even though devs can override the library version it was agreed to downgrade those libraries to the latest version that would work with compileSDKVersion 30.

Changed the test app compile SDK version to 30 to make sure that no breaking changes would be introduced.

**Screenshots:**
No visual changes