### PR TITLE
Remove Call and Chat tasks from device's recents menu when engagement…

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -61,7 +61,6 @@ public class CallController implements
     private TimeCounter.FormattedTimerStatusListener callTimerStatusListener;
     private TimeCounter.RawTimerStatusListener inactivityTimerStatusListener;
     private TimeCounter.RawTimerStatusListener connectingTimerStatusListener;
-    private MinimizeHandler.OnMinimizeCalledListener minimizeCalledListener;
     private MessagesNotSeenHandler.MessagesNotSeenHandlerListener messagesNotSeenHandlerListener;
     private final MediaUpgradeOfferRepository mediaUpgradeOfferRepository;
     private final TimeCounter callTimer;
@@ -262,7 +261,6 @@ public class CallController implements
         emitViewState(callState.initCall(companyName, mediaType));
         createNewTimerStatusCallback();
         initControllerCallbacks();
-        initMinimizeCallback();
         initMessagesNotSeenCallback();
         onEngagementUseCase.execute(this);
         addOperatorMediaStateListenerUseCase.execute(operatorMediaStateListener);
@@ -271,7 +269,7 @@ public class CallController implements
         mediaUpgradeOfferRepository.addCallback(mediaUpgradeOfferRepositoryCallback);
         inactivityTimeCounter.addRawValueListener(inactivityTimerStatusListener);
         connectingTimerCounter.addRawValueListener(connectingTimerStatusListener);
-        minimizeHandler.addListener(minimizeCalledListener);
+        minimizeHandler.addListener(this::minimizeView);
         messagesNotSeenHandler.addListener(messagesNotSeenHandlerListener);
     }
 
@@ -295,7 +293,6 @@ public class CallController implements
             inactivityTimeCounter.clear();
             connectingTimerCounter.clear();
             inactivityTimerStatusListener = null;
-            minimizeCalledListener = null;
             minimizeHandler.clear();
             messagesNotSeenHandler.removeListener(messagesNotSeenHandlerListener);
             messagesNotSeenHandlerListener = null;
@@ -615,10 +612,6 @@ public class CallController implements
                 emitViewState(callState.changeNumberOfMessages(count));
     }
 
-    private void initMinimizeCallback() {
-        minimizeCalledListener = () -> onDestroy(true);
-    }
-
     private void showUpgradeAudioDialog(MediaUpgradeOffer mediaUpgradeOffer) {
         if (callState.isMediaEngagementStarted()) {
             dialogController.showUpgradeAudioDialog(mediaUpgradeOffer, callState.callStatus.getFormattedOperatorName());
@@ -734,5 +727,9 @@ public class CallController implements
     private void showLandscapeControls() {
         emitViewState(callState.landscapeControlsVisibleChanged(true));
         restartInactivityTimeCounter();
+    }
+
+    private void minimizeView() {
+        if (viewCallback != null) viewCallback.minimizeView();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.java
@@ -102,6 +102,7 @@ public class CallView extends ConstraintLayout {
 
     private OnBackClickedListener onBackClickedListener;
     private OnEndListener onEndListener;
+    private OnMinimizeListener onMinimizeListener;
     private OnNavigateToChatListener onNavigateToChatListener;
     private CallView.OnNavigateToSurveyListener onNavigateToSurveyListener;
 
@@ -171,9 +172,6 @@ public class CallView extends ConstraintLayout {
         minimizeButton.setOnClickListener(v -> {
             if (callController != null) {
                 callController.minimizeButtonClicked();
-            }
-            if (onEndListener != null) {
-                onEndListener.onEnd();
             }
         });
         muteButton.setOnClickListener(v -> {
@@ -380,6 +378,13 @@ public class CallView extends ConstraintLayout {
             public void destroyView() {
                 if (onEndListener != null) {
                     onEndListener.onEnd();
+                }
+            }
+
+            @Override
+            public void minimizeView() {
+                if (onMinimizeListener != null) {
+                    onMinimizeListener.onMinimize();
                 }
             }
         };
@@ -781,6 +786,10 @@ public class CallView extends ConstraintLayout {
         this.onEndListener = onEndListener;
     }
 
+    public void setOnMinimizeListener(OnMinimizeListener onMinimizeListener) {
+        this.onMinimizeListener = onMinimizeListener;
+    }
+
     public void setOnNavigateToChatListener(OnNavigateToChatListener onNavigateToChatListener) {
         this.onNavigateToChatListener = onNavigateToChatListener;
     }
@@ -1059,6 +1068,10 @@ public class CallView extends ConstraintLayout {
 
     public interface OnEndListener {
         void onEnd();
+    }
+
+    public interface OnMinimizeListener {
+        void onMinimize();
     }
 
     public interface OnNavigateToChatListener {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallViewCallback.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallViewCallback.java
@@ -13,4 +13,6 @@ public interface CallViewCallback {
     void navigateToSurvey(@NonNull Survey survey);
 
     void destroyView();
+
+    void minimizeView();
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -22,7 +22,6 @@ public class ChatActivity extends AppCompatActivity {
     private ChatView.OnBackClickedListener onBackClickedListener = () -> {
         if (chatView.backPressed()) finish();
     };
-    private ChatView.OnEndListener onEndListener = this::finish;
     private ChatView.OnNavigateToCallListener onNavigateToCallListener =
             (UiTheme theme, String mediaType) -> {
                 navigateToCall(theme, mediaType);
@@ -49,7 +48,13 @@ public class ChatActivity extends AppCompatActivity {
         chatView.setConfiguration(configuration);
         chatView.setTheme(configuration.getRunTimeTheme());
         chatView.setOnBackClickedListener(onBackClickedListener);
-        chatView.setOnEndListener(onEndListener);
+
+        // In case the engagement ends, Activity is removed from the device's Recents menu
+        // to avoid app users to accidentally start queueing for another call when they resume
+        // the app from the Recents menu and the app's backstack was empty.
+        chatView.setOnEndListener(this::finishAndRemoveTask);
+
+        chatView.setOnMinimizeListener(this::finish);
         chatView.setOnNavigateToCallListener(onNavigateToCallListener);
         chatView.setOnNavigateToSurveyListener(onNavigateToSurveyListener);
         chatView.startChat(
@@ -76,7 +81,6 @@ public class ChatActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         onBackClickedListener = null;
-        onEndListener = null;
         onNavigateToCallListener = null;
         onNavigateToSurveyListener = null;
         chatView.onDestroyView(isFinishing());

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.java
@@ -135,6 +135,7 @@ public class ChatView extends ConstraintLayout implements
     private Integer defaultStatusbarColor;
     private OnBackClickedListener onBackClickedListener;
     private OnEndListener onEndListener;
+    private OnMinimizeListener onMinimizeListener;
     private OnNavigateToCallListener onNavigateToCallListener;
     private OnNavigateToSurveyListener onNavigateToSurveyListener;
     private final SingleChoiceCardView.OnOptionClickedListener onOptionClickedListener = new SingleChoiceCardView.OnOptionClickedListener() {
@@ -318,6 +319,10 @@ public class ChatView extends ConstraintLayout implements
         this.onEndListener = onEndListener;
     }
 
+    public void setOnMinimizeListener(OnMinimizeListener onMinimizeListener) {
+        this.onMinimizeListener = onMinimizeListener;
+    }
+
     /**
      * Add a listener here for when the user has accepted an audio or video call and should navigate
      * to a call.
@@ -494,6 +499,13 @@ public class ChatView extends ConstraintLayout implements
             public void destroyView() {
                 if (onEndListener != null) {
                     onEndListener.onEnd();
+                }
+            }
+
+            @Override
+            public void minimizeView() {
+                if (onMinimizeListener != null) {
+                    onMinimizeListener.onMinimize();
                 }
             }
 
@@ -1359,6 +1371,10 @@ public class ChatView extends ConstraintLayout implements
          * on the end engagement button or the leave queue button.
          */
         void onEnd();
+    }
+
+    public interface OnMinimizeListener {
+        void onMinimize();
     }
 
     public interface OnNavigateToCallListener {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
@@ -24,6 +24,8 @@ public interface ChatViewCallback {
 
     void destroyView();
 
+    void minimizeView();
+
     void smoothScrollToBottom();
 
     void scrollToBottomImmediate();

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
@@ -102,7 +102,6 @@ public class ChatController implements
     private ChatViewCallback viewCallback;
     private MediaUpgradeOfferRepositoryCallback mediaUpgradeOfferRepositoryCallback;
     private TimeCounter.FormattedTimerStatusListener timerStatusListener;
-    private MinimizeHandler.OnMinimizeCalledListener minimizeCalledListener;
     private final MediaUpgradeOfferRepository mediaUpgradeOfferRepository;
     private final TimeCounter callTimer;
     private final MinimizeHandler minimizeHandler;
@@ -348,9 +347,8 @@ public class ChatController implements
         loadHistoryUseCase.execute(this);
         addFileAttachmentsObserverUseCase.execute(fileAttachmentObserver);
         initMediaUpgradeCallback();
-        initMinimizeCallback();
         mediaUpgradeOfferRepository.addCallback(mediaUpgradeOfferRepositoryCallback);
-        minimizeHandler.addListener(minimizeCalledListener);
+        minimizeHandler.addListener(this::minimizeView);
         createNewTimerCallback();
         callTimer.addFormattedValueListener(timerStatusListener);
         subscribeToQueueingStateChangeUseCase.execute(queueTicketsEventsListener);
@@ -367,10 +365,6 @@ public class ChatController implements
                 chatState.queueId,
                 chatState.contextUrl
         );
-    }
-
-    private void initMinimizeCallback() {
-        this.minimizeCalledListener = () -> onDestroy(true);
     }
 
     private synchronized void emitViewState(ChatState state) {
@@ -405,7 +399,6 @@ public class ChatController implements
             mediaUpgradeOfferRepositoryCallback = null;
             timerStatusListener = null;
             callTimer.clear();
-            minimizeCalledListener = null;
             minimizeHandler.clear();
 
             loadHistoryUseCase.unregisterListener(this);
@@ -727,6 +720,10 @@ public class ChatController implements
             Logger.d(TAG, "destroyingView");
             viewCallback.destroyView();
         }
+    }
+
+    private void minimizeView() {
+        if (viewCallback != null) viewCallback.minimizeView();
     }
 
     private void operatorOnlineStartChatUi(String operatorName, String profileImgUrl) {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.java
@@ -42,8 +42,25 @@ public class SurveyActivity extends AppCompatActivity implements SurveyView.Call
     }
 
     @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+
+        // Back press behaves the same way as Callback.onFinish(). See the comment below.
+        finishAndRemoveTask();
+    }
+
+    @Override
     public void onTitleUpdated(String title) {
         setTitle(title);
+    }
+
+    @Override
+    public void onFinish() {
+
+        // In case the engagement ends, Activity is removed from the device's Recents menu
+        // to avoid app users to accidentally start queueing for another call when they resume
+        // the app from the Recents menu and the app's backstack was empty.
+        finishAndRemoveTask();
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.java
@@ -23,22 +23,13 @@ public class SurveyActivity extends AppCompatActivity implements SurveyView.Call
         prepareSurveyView();
     }
 
-    private void hideSoftKeyboard() {
-        Utils.hideSoftKeyboard(this, getWindow().getDecorView().getWindowToken());
-    }
-
-    private void prepareSurveyView() {
-        surveyView = findViewById(R.id.survey_view);
-        surveyView.setCallback(this);
-        SurveyContract.Controller surveyController =
-                Dependencies.getControllerFactory().getSurveyController();
-        surveyView.setController(surveyController);
-        Bundle extras = getIntent().getExtras();
-        UiTheme uiTheme = extras.getParcelable(GliaWidgets.UI_THEME);
-        surveyView.setTheme(uiTheme);
-
-        Survey survey = extras.getParcelable(GliaWidgets.SURVEY);
-        surveyController.init(survey);
+    @Override
+    protected void onDestroy() {
+        hideSoftKeyboard();
+        if (surveyView != null) {
+            surveyView.onDestroyView();
+        }
+        super.onDestroy();
     }
 
     @Override
@@ -63,12 +54,21 @@ public class SurveyActivity extends AppCompatActivity implements SurveyView.Call
         finishAndRemoveTask();
     }
 
-    @Override
-    protected void onDestroy() {
-        hideSoftKeyboard();
-        if (surveyView != null) {
-            surveyView.onDestroyView();
-        }
-        super.onDestroy();
+    private void hideSoftKeyboard() {
+        Utils.hideSoftKeyboard(this, getWindow().getDecorView().getWindowToken());
+    }
+
+    private void prepareSurveyView() {
+        surveyView = findViewById(R.id.survey_view);
+        surveyView.setCallback(this);
+        SurveyContract.Controller surveyController =
+                Dependencies.getControllerFactory().getSurveyController();
+        surveyView.setController(surveyController);
+        Bundle extras = getIntent().getExtras();
+        UiTheme uiTheme = extras.getParcelable(GliaWidgets.UI_THEME);
+        surveyView.setTheme(uiTheme);
+
+        Survey survey = extras.getParcelable(GliaWidgets.SURVEY);
+        surveyController.init(survey);
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
@@ -1,7 +1,6 @@
 package com.glia.widgets.survey;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
@@ -214,12 +213,8 @@ public class SurveyView extends ConstraintLayout
 
     @Override
     public void finish() {
-        Activity activity = Utils.getActivity(getContext());
-        if (activity != null) {
-            // In case the engagement ends, Activity is removed from the device's Recents menu
-            // to avoid app users to accidentally start queueing for another call when they resume
-            // the app from the Recents menu and the app's backstack was empty.
-            activity.finishAndRemoveTask();
+        if (callback != null) {
+            callback.onFinish();
         }
     }
 
@@ -232,5 +227,7 @@ public class SurveyView extends ConstraintLayout
 
     public interface Callback {
         void onTitleUpdated(String title);
+
+        void onFinish();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
@@ -215,7 +215,12 @@ public class SurveyView extends ConstraintLayout
     @Override
     public void finish() {
         Activity activity = Utils.getActivity(getContext());
-        if (activity != null) activity.finish();
+        if (activity != null) {
+            // In case the engagement ends, Activity is removed from the device's Recents menu
+            // to avoid app users to accidentally start queueing for another call when they resume
+            // the app from the Recents menu and the app's backstack was empty.
+            activity.finishAndRemoveTask();
+        }
     }
 
     public void onDestroyView() {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/MinimizeHandler.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/MinimizeHandler.java
@@ -15,10 +15,6 @@ public class MinimizeHandler {
         listeners.add(listener);
     }
 
-    public void removeListener(OnMinimizeCalledListener listener) {
-        listeners.remove(listener);
-    }
-
     public void clear() {
         Logger.d(TAG, "clear");
         listeners.clear();


### PR DESCRIPTION
… ends.

**Jira issue:**
https://glia.atlassian.net/browse/MUIC-711

**Additional info:**

In case the engagement ends, Activity is removed from the device's Recents menu to avoid app users to accidentally start queueing for another call when they resume the app from the Recents menu and the app's backstack was empty. Backstack can be empty if the app was started from the bubble.