### PR TITLE
Fix on hold indicator size

### DIFF
--- a/widgetssdk/src/main/res/layout/operator_status_view.xml
+++ b/widgetssdk/src/main/res/layout/operator_status_view.xml
@@ -57,6 +57,7 @@
         android:contentDescription="@string/glia_call_operator_status_on_hold_description"
         android:scaleType="fitCenter"
         android:tint="?attr/gliaBaseLightColor"
+        app:contentPadding="@dimen/glia_chat_profile_picture_large_content_padding"
         app:layout_constraintBottom_toBottomOf="@id/profile_picture_view"
         app:layout_constraintEnd_toEndOf="@id/profile_picture_view"
         app:layout_constraintStart_toStartOf="@id/profile_picture_view"


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-758

**Additional info:**
On hold indicator needs padding aswell. Shapeable Imageview content padding is buggy at the moment so this is temporary solution.