### PR TITLE
Fix: hide keyboard on survey screen

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyContract.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyContract.java
@@ -25,6 +25,8 @@ public interface SurveyContract {
 
         void scrollTo(int index);
 
+        void hideSoftKeyboard();
+
         void finish();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyController.java
@@ -90,21 +90,36 @@ public class SurveyController implements SurveyContract.Controller {
                 .filter(item -> item.getQuestion().getId().equals(answer.getQuestionId()))
                 .findFirst()
                 .ifPresent(item -> {
-                    item.setAnswer(answer);
-                    if (item.isShowError()) {
-                        boolean showError;
-                        try {
-                            gliaSurveyAnswerUseCase.validate(item);
-                            showError = false;
-                        } catch (SurveyValidationException ignore) {
-                            showError = true;
-                        }
-                        item.setShowError(showError);
-                        if (item.getAnswerCallback() != null) {
-                            item.getAnswerCallback().answerCallback(showError);
-                        }
-                    }
+                    setAnswer(item, answer);
+                    hideSoftKeyboardIfNeeds(item);
                 });
+    }
+
+    private void hideSoftKeyboardIfNeeds(QuestionItem item) {
+        if (item.getQuestion().getType() != Survey.Question.QuestionType.TEXT) {
+            view.hideSoftKeyboard();
+        }
+    }
+
+    private void setAnswer(QuestionItem item, Survey.Answer answer) {
+        item.setAnswer(answer);
+        if (item.isShowError()) {
+            validate(item);
+        }
+    }
+
+    private void validate(QuestionItem item) {
+        boolean showError;
+        try {
+            gliaSurveyAnswerUseCase.validate(item);
+            showError = false;
+        } catch (SurveyValidationException ignore) {
+            showError = true;
+        }
+        item.setShowError(showError);
+        if (item.getAnswerCallback() != null) {
+            item.getAnswerCallback().answerCallback(showError);
+        }
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
@@ -208,6 +208,11 @@ public class SurveyView extends ConstraintLayout
     }
 
     @Override
+    public void hideSoftKeyboard() {
+        Utils.hideSoftKeyboard(getContext(), getWindowToken());
+    }
+
+    @Override
     public void finish() {
         Activity activity = Utils.getActivity(getContext());
         if (activity != null) activity.finish();


### PR DESCRIPTION
Fix: hide keyboard if the visitor interacts with other elements after the text field

[MUIC-764](https://glia.atlassian.net/browse/MUIC-764)
