### PR TITLE
Apply custom color for survey input box background and text

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyAdapter.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyAdapter.java
@@ -441,27 +441,9 @@ public class SurveyAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
             comment = itemView.findViewById(R.id.et_comment);
             requiredError = itemView.findViewById(R.id.required_error);
 
-            TextConfiguration titleConfiguration = style.getInputQuestion().getTitle();
-            this.title.setTextColor(titleConfiguration.getTextColor());
-            float textSize = titleConfiguration.getTextSize();
-            this.title.setTextSize(textSize);
-            if (titleConfiguration.isBold()) this.title.setTypeface(Typeface.DEFAULT_BOLD);
-
-            comment.setOnFocusChangeListener((v, hasFocus) -> setAnswer(comment.getText().toString()));
-            comment.addTextChangedListener(new TextWatcher() {
-                @Override
-                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                }
-
-                @Override
-                public void onTextChanged(CharSequence s, int start, int before, int count) {
-                }
-
-                @Override
-                public void afterTextChanged(Editable s) {
-                    setAnswer(s.toString());
-                }
-            });
+            InputQuestionConfiguration inputQuestionConfig = style.getInputQuestion();
+            setupTitle(inputQuestionConfig);
+            setupInputBoxText(inputQuestionConfig.getOptionButton());
         }
 
         @Override
@@ -504,9 +486,40 @@ public class SurveyAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
                                 ColorStateList.valueOf(normalColor);
                 int width = context.getResources().getDimensionPixelSize(R.dimen.glia_px);
                 shape.setStroke(width, strokeColor);
-                shape.setColor(ContextCompat.getColor(context, R.color.glia_base_light_color));
+                shape.setColor(Color.parseColor(inputQuestionConfig.getOptionButton().getNormalLayer().getBackgroundColor()));
                 comment.setBackground(shape);
             }
+        }
+
+        private void setupTitle(InputQuestionConfiguration inputQuestionConfig) {
+            TextConfiguration titleConfiguration = inputQuestionConfig.getTitle();
+            this.title.setTextColor(titleConfiguration.getTextColor());
+            float textSize = titleConfiguration.getTextSize();
+            this.title.setTextSize(textSize);
+            if (titleConfiguration.isBold()) this.title.setTypeface(Typeface.DEFAULT_BOLD);
+        }
+
+        private void setupInputBoxText(OptionButtonConfiguration optionButtonStyle) {
+            comment.setTextColor(optionButtonStyle.getNormalText().getTextColor());
+            if (optionButtonStyle.getNormalText().isBold()) this.comment.setTypeface(Typeface.DEFAULT_BOLD);
+            comment.setHintTextColor(ContextCompat.getColor(comment.getContext(), R.color.glia_base_shade_color));
+            float textSize = optionButtonStyle.getNormalText().getTextSize();
+            comment.setTextSize(textSize);
+            comment.setOnFocusChangeListener((v, hasFocus) -> setAnswer(comment.getText().toString()));
+            comment.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                }
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                }
+
+                @Override
+                public void afterTextChanged(Editable s) {
+                    setAnswer(s.toString());
+                }
+            });
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyAdapter.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyAdapter.java
@@ -493,15 +493,15 @@ public class SurveyAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 
         private void setupTitle(InputQuestionConfiguration inputQuestionConfig) {
             TextConfiguration titleConfiguration = inputQuestionConfig.getTitle();
-            this.title.setTextColor(titleConfiguration.getTextColor());
+            title.setTextColor(titleConfiguration.getTextColor());
             float textSize = titleConfiguration.getTextSize();
-            this.title.setTextSize(textSize);
-            if (titleConfiguration.isBold()) this.title.setTypeface(Typeface.DEFAULT_BOLD);
+            title.setTextSize(textSize);
+            if (titleConfiguration.isBold()) title.setTypeface(Typeface.DEFAULT_BOLD);
         }
 
         private void setupInputBoxText(OptionButtonConfiguration optionButtonStyle) {
             comment.setTextColor(optionButtonStyle.getNormalText().getTextColor());
-            if (optionButtonStyle.getNormalText().isBold()) this.comment.setTypeface(Typeface.DEFAULT_BOLD);
+            if (optionButtonStyle.getNormalText().isBold()) comment.setTypeface(Typeface.DEFAULT_BOLD);
             comment.setHintTextColor(ContextCompat.getColor(comment.getContext(), R.color.glia_base_shade_color));
             float textSize = optionButtonStyle.getNormalText().getTextSize();
             comment.setTextSize(textSize);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
@@ -43,6 +43,11 @@ public class InputQuestionConfiguration implements Parcelable {
             return this;
         }
 
+        /**
+         * Use this method to configure the input box style
+         *
+         * @param optionButton - input box style
+         */
         public Builder optionButton(OptionButtonConfiguration optionButton) {
             this.optionButton = optionButton;
             return this;


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-1281

**Additional info:**
Agreed on the following expected behavior:

On Android in Dark Mode the input box will stay white with dark text. And there will be an ability for integrators to set custom color for input box background and text.

