### PR TITLE
Fix end engagement dialog

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -126,6 +126,7 @@ public class CallController implements
 
     private final String TAG = "CallController";
     private volatile CallState callState;
+    private boolean isVisitorEndEngagement = false;
 
     private final CompositeDisposable disposables = new CompositeDisposable();
 
@@ -327,6 +328,7 @@ public class CallController implements
 
     public void endEngagementDialogYesClicked() {
         Logger.d(TAG, "endEngagementDialogYesClicked");
+        isVisitorEndEngagement = true;
         stop();
         dialogController.dismissDialogs();
     }
@@ -467,8 +469,10 @@ public class CallController implements
         if (viewCallback != null && survey != null) {
             viewCallback.navigateToSurvey(survey);
             Dependencies.getControllerFactory().destroyControllers();
-        } else {
+        } else if (!isVisitorEndEngagement) {
             dialogController.showEngagementEndedDialog();
+        } else {
+            Dependencies.getControllerFactory().destroyControllers();
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.java
@@ -202,6 +202,7 @@ public class ChatController implements
     private final SiteInfoUseCase siteInfoUseCase;
     private final GliaSurveyUseCase surveyUseCase;
 
+    private boolean isVisitorEndEngagement = false;
     private Disposable disposable = null;
 
     // TODO pending photoCaptureFileUri - need to move some place better
@@ -552,6 +553,7 @@ public class ChatController implements
 
     public void endEngagementDialogYesClicked() {
         Logger.d(TAG, "endEngagementDialogYesClicked");
+        isVisitorEndEngagement = true;
         stop();
         dialogController.dismissDialogs();
     }
@@ -1179,8 +1181,10 @@ public class ChatController implements
         if (viewCallback != null && survey != null) {
             viewCallback.navigateToSurvey(survey);
             Dependencies.getControllerFactory().destroyControllers();
-        } else {
+        } else if (!isVisitorEndEngagement) {
             dialogController.showEngagementEndedDialog();
+        } else {
+            Dependencies.getControllerFactory().destroyControllers();
         }
     }
 


### PR DESCRIPTION
Fix: Not show the "End engagement" dialog if the engagement ends by a Visitor

[MOB-1284](https://glia.atlassian.net/browse/MOB-1284)
[MUIC-768](https://glia.atlassian.net/browse/MUIC-768)