### PR TITLE
Add global RxErrorHandler to handle undeliverable exceptions.

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/helper/FileHelper.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/helper/FileHelper.java
@@ -26,6 +26,14 @@ public class FileHelper {
     public static Maybe<Bitmap> decodeSampledBitmapFromInputStream(InputStream inputStream) {
         return Maybe.create(emitter -> {
                     Bitmap rawBitmap = BitmapFactory.decodeStream(inputStream);
+
+                    if (rawBitmap == null) {
+                        emitter.onError(
+                                new IOException("InputStream could not be decoded")
+                        );
+                        return;
+                    }
+
                     int rawHeight = rawBitmap.getHeight();
                     int rawWidth = rawBitmap.getWidth();
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-767

**Additional info:**
* fix image loading crash when loading was interrupted
* add global RxErrorHandler to handle undeliverable exceptions that otherwise cause app crashes.
