### PR TITLE
Use default attributes from XML for Survey buttons (develop)

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ResourceProvider.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ResourceProvider.java
@@ -44,17 +44,13 @@ public class ResourceProvider implements IResourceProvider {
         return ContextCompat.getColorStateList(weakContext.get(), id);
     }
 
-    @Nullable
     @Override
-    public Drawable getDrawable(int id) {
-        return ResourcesCompat.getDrawable((weakContext.get()).getResources(), id, null);
-    }
-
     public int getDimension(int dimensionId) {
         Resources resources = weakContext.get().getResources();
         return (int) (resources.getDimension(dimensionId) / resources.getDisplayMetrics().density);
     }
 
+    @Override
     public float convertDpToPixel(int dp) {
         return dp * ((float) weakContext.get().getResources().getDisplayMetrics().densityDpi / DisplayMetrics.DENSITY_DEFAULT);
     }
@@ -71,6 +67,7 @@ interface IResourceProvider {
 
     ColorStateList getColorStateList(int id);
 
-    @Nullable
-    Drawable getDrawable(@DrawableRes int id);
+    int getDimension(int dimensionId);
+
+    float convertDpToPixel(int dp);
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.java
@@ -130,6 +130,12 @@ public class SurveyView extends FrameLayout
     }
 
     private void applyButtonStyle(ButtonConfiguration configuration, Button button) {
+        if (configuration == null) {
+            // Default attributes from
+            // "Application.GliaAndroidSdkWidgetsExample.Button" styles
+            // will be in use
+            return;
+        }
         ColorStateList backgroundColor = configuration.getBackgroundColor();
         button.setBackgroundTintList(backgroundColor);
         ColorStateList textColor = configuration.getTextConfiguration().getTextColor();

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SurveyStyle.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SurveyStyle.java
@@ -179,13 +179,6 @@ public class SurveyStyle implements Parcelable {
             if (this.title == null) {
                 this.title = prepareDefaultTitleConfiguration(resourceProvider);
             }
-            // Default buttons configuration
-            if (this.submitButton == null) {
-                this.submitButton = prepareDefaultButtonConfiguration(resourceProvider, R.color.glia_brand_primary_color);
-            }
-            if (this.cancelButton == null) {
-                this.cancelButton = prepareDefaultButtonConfiguration(resourceProvider, R.color.glia_system_negative_color);
-            }
             // Default questions configuration
             if (this.booleanQuestion == null) {
                 this.booleanQuestion = new BooleanQuestionConfiguration.Builder().build();


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/SSD-27140

**Additional info:**
Currently, Survey style defaults are overriding two XML attributes: button background and button text color.

This PR changes this to use defaults from XML styles.
