### PR TITLE
Call Activity Configuration Impl

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -18,6 +18,7 @@ import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
+import com.glia.widgets.call.Configuration;
 import com.glia.widgets.chat.ChatActivity;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.view.head.ChatHeadLayout;
@@ -82,7 +83,7 @@ public class MainFragment extends Fragment {
     ) {
         GliaSdkConfiguration configuration = getConfiguration();
 
-        CallActivity.Configuration activityConfig = CallActivity.Configuration.Builder
+        Configuration activityConfig = Configuration.Builder
                 .builder()
                 .setWidgetsConfiguration(configuration)
                 .setMediaType(mediaType)

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -14,9 +14,12 @@ import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.preference.PreferenceManager;
 
+import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.widgets.GliaWidgets;
+import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
 import com.glia.widgets.chat.ChatActivity;
+import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.view.head.ChatHeadLayout;
 
 public class MainFragment extends Fragment {
@@ -74,11 +77,37 @@ public class MainFragment extends Fragment {
         startActivity(intent);
     }
 
-    private void navigateToCall(String mediaType) {
-        Intent intent = new Intent(requireContext(), CallActivity.class);
-        setNavigationIntentData(intent);
-        intent.putExtra(GliaWidgets.MEDIA_TYPE, mediaType);
+    private void navigateToCall(
+            String mediaType
+    ) {
+        GliaSdkConfiguration configuration = getConfiguration();
+
+        CallActivity.Configuration activityConfig = CallActivity.Configuration.Builder
+                .builder()
+                .setWidgetsConfiguration(configuration)
+                .setMediaType(mediaType)
+                .build();
+
+        Intent intent = CallActivity.getIntent(
+                requireContext(),
+                activityConfig
+        );
+
         startActivity(intent);
+    }
+
+    private GliaSdkConfiguration getConfiguration() {
+        SharedPreferences sharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(requireContext());
+
+        return new GliaSdkConfiguration.Builder()
+                .companyName(getCompanyNameFromPrefs(sharedPreferences))
+                .contextUrl(getContextUrlFromPrefs(sharedPreferences))
+                .queueId(getQueueIdFromPrefs(sharedPreferences))
+                .runTimeTheme(getRuntimeThemeFromPrefs(sharedPreferences))
+                .screenSharingMode(getScreenSharingModeFromPrefs(sharedPreferences))
+                .useOverlay(getUseOverlay(sharedPreferences))
+                .build();
     }
 
     private void setNavigationIntentData(Intent intent) {
@@ -87,42 +116,66 @@ public class MainFragment extends Fragment {
 
         intent.putExtra(
                 GliaWidgets.COMPANY_NAME,
-                Utils.getStringFromPrefs(
-                        R.string.pref_company_name,
-                        "",
-                        sharedPreferences,
-                        getResources()
-                )
+                getCompanyNameFromPrefs(sharedPreferences)
         );
         intent.putExtra(
                 GliaWidgets.QUEUE_ID,
-                Utils.getStringFromPrefs(
-                        R.string.pref_queue_id,
-                        getString(R.string.default_queue_id),
-                        sharedPreferences,
-                        getResources()
-                )
+                getQueueIdFromPrefs(sharedPreferences)
         );
         intent.putExtra(
                 GliaWidgets.CONTEXT_URL,
-                Utils.getStringFromPrefs(
-                        R.string.pref_context_url,
-                        getString(R.string.default_queue_id),
-                        sharedPreferences,
-                        getResources()
-                )
+                getContextUrlFromPrefs(sharedPreferences)
         );
         intent.putExtra(
                 GliaWidgets.UI_THEME,
-                Utils.getUiThemeByPrefs(sharedPreferences, getResources())
+                getRuntimeThemeFromPrefs(sharedPreferences)
         );
         intent.putExtra(
                 GliaWidgets.USE_OVERLAY,
-                Utils.getUseOverlay(sharedPreferences, getResources())
+                getUseOverlay(sharedPreferences)
         );
         intent.putExtra(
                 GliaWidgets.SCREEN_SHARING_MODE,
-                Utils.getScreenSharingModeFromPrefs(sharedPreferences, getResources())
+                getScreenSharingModeFromPrefs(sharedPreferences)
+        );
+    }
+
+    private Boolean getUseOverlay(SharedPreferences sharedPreferences) {
+        return Utils.getUseOverlay(sharedPreferences, getResources());
+    }
+
+    private ScreenSharing.Mode getScreenSharingModeFromPrefs(SharedPreferences sharedPreferences) {
+        return Utils.getScreenSharingModeFromPrefs(sharedPreferences, getResources());
+    }
+
+    private UiTheme getRuntimeThemeFromPrefs(SharedPreferences sharedPreferences) {
+        return Utils.getUiThemeByPrefs(sharedPreferences, getResources());
+    }
+
+    private String getQueueIdFromPrefs(SharedPreferences sharedPreferences) {
+        return Utils.getStringFromPrefs(
+                R.string.pref_queue_id,
+                getString(R.string.default_queue_id),
+                sharedPreferences,
+                getResources()
+        );
+    }
+
+    private String getContextUrlFromPrefs(SharedPreferences sharedPreferences) {
+        return Utils.getStringFromPrefs(
+                R.string.pref_context_url,
+                getString(R.string.default_queue_id),
+                sharedPreferences,
+                getResources()
+        );
+    }
+
+    private String getCompanyNameFromPrefs(SharedPreferences sharedPreferences) {
+        return Utils.getStringFromPrefs(
+                R.string.pref_company_name,
+                "",
+                sharedPreferences,
+                getResources()
         );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
@@ -21,6 +21,7 @@ import com.glia.widgets.R;
 import com.glia.widgets.chat.ChatActivity;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.helper.Logger;
+import com.glia.widgets.helper.Utils;
 import com.glia.widgets.survey.SurveyActivity;
 
 import java.security.InvalidParameterException;
@@ -225,7 +226,7 @@ public class CallActivity extends AppCompatActivity {
                 Configuration.Builder
                         .builder()
                         .setWidgetsConfiguration(sdkConfiguration)
-                        .setMediaType(toMediaType(mediaType))
+                        .setMediaType(Utils.toMediaType(mediaType))
                         .build()
         );
     }
@@ -238,17 +239,6 @@ public class CallActivity extends AppCompatActivity {
                 .from(context)
                 .setConfiguration(configuration)
                 .getIntent();
-    }
-
-    public static Engagement.MediaType toMediaType(String mediaType) {
-        switch (mediaType) {
-            case GliaWidgets.MEDIA_TYPE_VIDEO:
-                return Engagement.MediaType.VIDEO;
-            case GliaWidgets.MEDIA_TYPE_AUDIO:
-                return Engagement.MediaType.AUDIO;
-            default:
-                throw new InvalidParameterException("Invalid Media Type");
-        }
     }
 
     public static class Configuration {
@@ -290,7 +280,7 @@ public class CallActivity extends AppCompatActivity {
             }
 
             public Builder setMediaType(String mediaType) {
-                this.mediaType = toMediaType(mediaType);
+                this.mediaType = Utils.toMediaType(mediaType);
                 return this;
             }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
@@ -58,7 +58,7 @@ public class CallActivity extends AppCompatActivity {
         setContentView(R.layout.call_activity);
         callView = findViewById(R.id.call_view);
         configuration =
-                IntentReader.from(this)
+                CallIntentReader.from(this)
                         .getConfiguration();
 
         if (!callView.shouldShowMediaEngagementView(configuration.isUpgradeToCall)) {
@@ -234,7 +234,7 @@ public class CallActivity extends AppCompatActivity {
             Context context,
             CallActivity.Configuration configuration
     ) {
-        return IntentBuilder
+        return CallIntentBuilder
                 .from(context)
                 .setConfiguration(configuration)
                 .getIntent();
@@ -318,88 +318,6 @@ public class CallActivity extends AppCompatActivity {
             public static Builder builder() {
                 return new Builder();
             }
-        }
-    }
-
-    private static class IntentBuilder {
-        private final Context context;
-        private Configuration configuration;
-
-        private IntentBuilder(@NonNull Context context) {
-            this.context = context;
-        }
-
-        public static IntentBuilder from(@NonNull Context context) {
-            return new IntentBuilder(context);
-        }
-
-        public IntentBuilder setConfiguration(@NonNull Configuration configuration) {
-            this.configuration = configuration;
-            return this;
-        }
-
-        public Intent getIntent() {
-            if (configuration == null) throw new RuntimeException("Configuration " +
-                    "missing");
-
-            Intent intent = new Intent(context, CallActivity.class);
-            intent.putExtra(GliaWidgets.COMPANY_NAME, configuration.sdkConfiguration.getCompanyName());
-            intent.putExtra(GliaWidgets.QUEUE_ID, configuration.sdkConfiguration.getQueueId());
-            intent.putExtra(GliaWidgets.CONTEXT_URL, configuration.sdkConfiguration.getContextUrl());
-            intent.putExtra(GliaWidgets.UI_THEME, configuration.sdkConfiguration.getRunTimeTheme());
-            intent.putExtra(GliaWidgets.USE_OVERLAY, configuration.sdkConfiguration.getUseOverlay());
-            intent.putExtra(GliaWidgets.SCREEN_SHARING_MODE, configuration.sdkConfiguration.getScreenSharingMode());
-            intent.putExtra(GliaWidgets.MEDIA_TYPE, configuration.getMediaType());
-            intent.putExtra(GliaWidgets.IS_UPGRADE_TO_CALL, configuration.getIsUpgradeToCall());
-            return intent;
-        }
-    }
-
-    private static class IntentReader {
-        private final AppCompatActivity activity;
-
-        private IntentReader(@NonNull AppCompatActivity activity) {
-            this.activity = activity;
-        }
-
-        public Configuration getConfiguration() {
-            return Configuration.Builder
-                    .builder()
-                    .setWidgetsConfiguration(getSdkConfiguration())
-                    .setMediaType(getMediaType())
-                    .setIsUpgradeToCall(getIsUpgradeToCall())
-                    .build();
-        }
-
-        public static IntentReader from(@NonNull AppCompatActivity activity) {
-            return new IntentReader(activity);
-        }
-
-        @NonNull
-        private Intent getIntent() {
-            return activity.getIntent();
-        }
-
-        @Nullable
-        private GliaSdkConfiguration getSdkConfiguration() {
-            return new GliaSdkConfiguration
-                    .Builder()
-                    .intent(getIntent())
-                    .build();
-        }
-
-        private Engagement.MediaType getMediaType() {
-            if (getIntent().hasExtra(GliaWidgets.MEDIA_TYPE)) {
-                return (Engagement.MediaType) getIntent().getSerializableExtra(GliaWidgets.MEDIA_TYPE);
-            }
-            return Engagement.MediaType.AUDIO;
-        }
-
-        private Boolean getIsUpgradeToCall() {
-            if (getIntent().hasExtra(GliaWidgets.IS_UPGRADE_TO_CALL)) {
-                return getIntent().getBooleanExtra(GliaWidgets.IS_UPGRADE_TO_CALL, false);
-            }
-            return false;
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentBuilder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentBuilder.java
@@ -10,7 +10,7 @@ import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 
 class CallIntentBuilder {
     private final Context context;
-    private CallActivity.Configuration configuration;
+    private Configuration configuration;
 
     private CallIntentBuilder(@NonNull Context context) {
         this.context = context;
@@ -20,7 +20,7 @@ class CallIntentBuilder {
         return new CallIntentBuilder(context);
     }
 
-    public CallIntentBuilder setConfiguration(@NonNull CallActivity.Configuration configuration) {
+    public CallIntentBuilder setConfiguration(@NonNull Configuration configuration) {
         this.configuration = configuration;
         return this;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentBuilder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentBuilder.java
@@ -1,0 +1,55 @@
+package com.glia.widgets.call;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import com.glia.widgets.GliaWidgets;
+import com.glia.widgets.core.configuration.GliaSdkConfiguration;
+
+class CallIntentBuilder {
+    private final Context context;
+    private CallActivity.Configuration configuration;
+
+    private CallIntentBuilder(@NonNull Context context) {
+        this.context = context;
+    }
+
+    public static CallIntentBuilder from(@NonNull Context context) {
+        return new CallIntentBuilder(context);
+    }
+
+    public CallIntentBuilder setConfiguration(@NonNull CallActivity.Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    public Intent getIntent() {
+        validateActivityConfiguration();
+        validateWidgetsSdkConfiguration();
+        GliaSdkConfiguration sdkConfiguration = configuration.getSdkConfiguration();
+        return new Intent(context, CallActivity.class)
+                .putExtra(GliaWidgets.COMPANY_NAME, sdkConfiguration.getCompanyName())
+                .putExtra(GliaWidgets.QUEUE_ID, sdkConfiguration.getQueueId())
+                .putExtra(GliaWidgets.CONTEXT_URL, sdkConfiguration.getContextUrl())
+                .putExtra(GliaWidgets.UI_THEME, sdkConfiguration.getRunTimeTheme())
+                .putExtra(GliaWidgets.USE_OVERLAY, sdkConfiguration.getUseOverlay())
+                .putExtra(GliaWidgets.SCREEN_SHARING_MODE, sdkConfiguration.getScreenSharingMode())
+                .putExtra(GliaWidgets.MEDIA_TYPE, configuration.getMediaType())
+                .putExtra(GliaWidgets.IS_UPGRADE_TO_CALL, configuration.getIsUpgradeToCall());
+    }
+
+    private void validateActivityConfiguration() {
+        if (configuration == null) {
+            throw new RuntimeException("Configuration missing");
+        }
+    }
+
+    private void validateWidgetsSdkConfiguration() {
+        GliaSdkConfiguration sdkConfiguration = configuration.getSdkConfiguration();
+        if (sdkConfiguration == null) {
+            throw new RuntimeException("WidgetsSdk Configuration missing");
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentReader.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentReader.java
@@ -1,0 +1,59 @@
+package com.glia.widgets.call;
+
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.glia.androidsdk.Engagement;
+import com.glia.widgets.GliaWidgets;
+import com.glia.widgets.core.configuration.GliaSdkConfiguration;
+
+class CallIntentReader {
+    private final AppCompatActivity activity;
+
+    private CallIntentReader(@NonNull AppCompatActivity activity) {
+        this.activity = activity;
+    }
+
+    public CallActivity.Configuration getConfiguration() {
+        return CallActivity.Configuration.Builder
+                .builder()
+                .setWidgetsConfiguration(getSdkConfiguration())
+                .setMediaType(getMediaType())
+                .setIsUpgradeToCall(getIsUpgradeToCall())
+                .build();
+    }
+
+    public static CallIntentReader from(@NonNull AppCompatActivity activity) {
+        return new CallIntentReader(activity);
+    }
+
+    @NonNull
+    private Intent getIntent() {
+        return activity.getIntent();
+    }
+
+    @Nullable
+    private GliaSdkConfiguration getSdkConfiguration() {
+        return new GliaSdkConfiguration
+                .Builder()
+                .intent(getIntent())
+                .build();
+    }
+
+    private Engagement.MediaType getMediaType() {
+        if (getIntent().hasExtra(GliaWidgets.MEDIA_TYPE)) {
+            return (Engagement.MediaType) getIntent().getSerializableExtra(GliaWidgets.MEDIA_TYPE);
+        }
+        return Engagement.MediaType.AUDIO;
+    }
+
+    private Boolean getIsUpgradeToCall() {
+        if (getIntent().hasExtra(GliaWidgets.IS_UPGRADE_TO_CALL)) {
+            return getIntent().getBooleanExtra(GliaWidgets.IS_UPGRADE_TO_CALL, false);
+        }
+        return false;
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentReader.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentReader.java
@@ -17,9 +17,8 @@ class CallIntentReader {
         this.activity = activity;
     }
 
-    public CallActivity.Configuration getConfiguration() {
-        return CallActivity.Configuration.Builder
-                .builder()
+    public Configuration getConfiguration() {
+        return new Configuration.Builder()
                 .setWidgetsConfiguration(getSdkConfiguration())
                 .setMediaType(getMediaType())
                 .setIsUpgradeToCall(getIsUpgradeToCall())

--- a/widgetssdk/src/main/java/com/glia/widgets/call/Configuration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/Configuration.java
@@ -1,0 +1,76 @@
+package com.glia.widgets.call;
+
+import com.glia.androidsdk.Engagement;
+import com.glia.widgets.core.configuration.GliaSdkConfiguration;
+import com.glia.widgets.helper.Utils;
+
+public class Configuration {
+    private final GliaSdkConfiguration sdkConfiguration;
+    private final Engagement.MediaType mediaType;
+    private final boolean isUpgradeToCall;
+
+    private Configuration(Builder builder) {
+        this.sdkConfiguration = builder.widgetsConfiguration;
+        this.mediaType = builder.mediaType;
+        this.isUpgradeToCall = builder.isUpgradeToCall != null ? builder.isUpgradeToCall : false;
+    }
+
+    public GliaSdkConfiguration getSdkConfiguration() {
+        return this.sdkConfiguration;
+    }
+
+    public Engagement.MediaType getMediaType() {
+        return this.mediaType;
+    }
+
+    public boolean getIsUpgradeToCall() {
+        return this.isUpgradeToCall;
+    }
+
+    public static class Builder {
+        private GliaSdkConfiguration widgetsConfiguration;
+        private Engagement.MediaType mediaType;
+        private Boolean isUpgradeToCall;
+
+        public Builder setWidgetsConfiguration(GliaSdkConfiguration configuration) {
+            this.widgetsConfiguration = configuration;
+            return this;
+        }
+
+        public Builder setMediaType(Engagement.MediaType mediaType) {
+            this.mediaType = mediaType;
+            return this;
+        }
+
+        public Builder setMediaType(String mediaType) {
+            this.mediaType = Utils.toMediaType(mediaType);
+            return this;
+        }
+
+        public Builder setIsUpgradeToCall(Boolean isUpgradeToCall) {
+            this.isUpgradeToCall = isUpgradeToCall;
+            return this;
+        }
+
+        public Builder() {
+            this.isUpgradeToCall = false;
+            this.mediaType = Engagement.MediaType.AUDIO;
+        }
+
+        public Configuration build() {
+            return new Configuration(this);
+        }
+
+        public static Builder from(Configuration configuration) {
+            return builder()
+                    .setWidgetsConfiguration(configuration.sdkConfiguration)
+                    .setMediaType(configuration.mediaType)
+                    .setIsUpgradeToCall(configuration.isUpgradeToCall);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+    }
+}
+

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -13,6 +13,7 @@ import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
+import com.glia.widgets.call.Configuration;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.helper.Utils;
 import com.glia.widgets.survey.SurveyActivity;
@@ -119,8 +120,7 @@ public class ChatActivity extends AppCompatActivity {
         startActivity(
                 CallActivity.getIntent(
                         getApplicationContext(),
-                        CallActivity.Configuration.Builder
-                                .builder()
+                        new Configuration.Builder()
                                 .setWidgetsConfiguration(configuration)
                                 .setMediaType(Utils.toMediaType(mediaType))
                                 .setIsUpgradeToCall(true)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -1,7 +1,5 @@
 package com.glia.widgets.chat;
 
-import static com.glia.widgets.call.CallActivity.toMediaType;
-
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
@@ -16,6 +14,7 @@ import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
+import com.glia.widgets.helper.Utils;
 import com.glia.widgets.survey.SurveyActivity;
 import com.glia.widgets.view.head.ChatHeadLayout;
 
@@ -123,7 +122,7 @@ public class ChatActivity extends AppCompatActivity {
                         CallActivity.Configuration.Builder
                                 .builder()
                                 .setWidgetsConfiguration(configuration)
-                                .setMediaType(toMediaType(mediaType))
+                                .setMediaType(Utils.toMediaType(mediaType))
                                 .setIsUpgradeToCall(true)
                                 .build()
                 )

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -1,5 +1,7 @@
 package com.glia.widgets.chat;
 
+import static com.glia.widgets.call.CallActivity.toMediaType;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
@@ -118,9 +120,12 @@ public class ChatActivity extends AppCompatActivity {
         startActivity(
                 CallActivity.getIntent(
                         getApplicationContext(),
-                        configuration,
-                        mediaType,
-                        true
+                        CallActivity.Configuration.Builder
+                                .builder()
+                                .setWidgetsConfiguration(configuration)
+                                .setMediaType(toMediaType(mediaType))
+                                .setIsUpgradeToCall(true)
+                                .build()
                 )
         );
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -15,10 +15,13 @@ import android.util.TypedValue;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.StyleableRes;
 
+import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.Operator;
 import com.glia.androidsdk.chat.AttachmentFile;
+import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.core.fileupload.model.FileAttachment;
@@ -29,6 +32,7 @@ import com.glia.widgets.view.configuration.survey.SurveyStyle;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.InvalidParameterException;
 import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -38,6 +42,17 @@ import java.util.concurrent.TimeUnit;
 public class Utils {
     public static String getOperatorImageUrl(Operator operator) {
         return operator.getPicture() != null ? operator.getPicture().getURL().orElse(null) : null;
+    }
+
+    public static Engagement.MediaType toMediaType(@NonNull String mediaType) {
+        switch (mediaType) {
+            case GliaWidgets.MEDIA_TYPE_VIDEO:
+                return Engagement.MediaType.VIDEO;
+            case GliaWidgets.MEDIA_TYPE_AUDIO:
+                return Engagement.MediaType.AUDIO;
+            default:
+                throw new InvalidParameterException("Invalid Media Type");
+        }
     }
 
     public static float pxFromDp(final Context context, final float dp) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
@@ -144,7 +144,7 @@ public class ChatHeadView extends ConstraintLayout implements ChatHeadContract.V
     @Override
     public void navigateToCall() {
         CallActivity.Configuration activityConfig =
-                CallActivity.Configuration.Builder.builder()
+                new CallActivity.Configuration.Builder()
                         .setWidgetsConfiguration(sdkConfiguration)
                         .build();
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
@@ -143,13 +143,15 @@ public class ChatHeadView extends ConstraintLayout implements ChatHeadContract.V
 
     @Override
     public void navigateToCall() {
-        getContext().startActivity(
-                getNavigationIntent(
-                        getContext(),
-                        CallActivity.class,
-                        sdkConfiguration
-                )
-        );
+        CallActivity.Configuration activityConfig =
+                CallActivity.Configuration.Builder.builder()
+                        .setWidgetsConfiguration(sdkConfiguration)
+                        .build();
+
+        Intent intent = CallActivity.getIntent(getContext(), activityConfig);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        getContext().startActivity(intent);
     }
 
     private ChatHeadConfiguration createBuildTimeConfiguration(UiTheme buildTimeTheme) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.java
@@ -23,6 +23,7 @@ import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
+import com.glia.widgets.call.Configuration;
 import com.glia.widgets.chat.ChatActivity;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.view.configuration.ChatHeadConfiguration;
@@ -143,8 +144,8 @@ public class ChatHeadView extends ConstraintLayout implements ChatHeadContract.V
 
     @Override
     public void navigateToCall() {
-        CallActivity.Configuration activityConfig =
-                new CallActivity.Configuration.Builder()
+        Configuration activityConfig =
+                new Configuration.Builder()
                         .setWidgetsConfiguration(sdkConfiguration)
                         .build();
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MUIC-318

**Additional info:**
Part of MUIC-318 implementation - created a builder class for Call Activity in order to hold Activity configuration and ease up serialisation process

Note for future implementation: I propose to remove WidgetsConfiguration from Activity Initialisation and receive it via some Provider instead. It will require deprecation notice and a lot of rework on how things are tied up. But the configuration will be held and will not be lost in case activity is started from service (or deeplink)

(with current implementation it will be matter of moving sdkConfiguration out of the builder and activity configuration to proper widgets configuration holder class :) )
