### PR TITLE
Fix: show survey on resume

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -269,6 +269,9 @@ public class CallController implements
                          String contextUrl,
                          Engagement.MediaType mediaType) {
         Logger.d(TAG, "initCall");
+        if (surveyUseCase.hasResult()) {
+            return;
+        }
         if (isShowOverlayPermissionRequestDialogUseCase.execute()) {
             dialogController.showOverlayPermissionsDialog();
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/survey/GliaSurveyRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/survey/GliaSurveyRepository.java
@@ -54,6 +54,10 @@ public class GliaSurveyRepository implements RequestCallback<Survey> {
         }
     }
 
+    public boolean hasResult() {
+        return result != null;
+    }
+
     public void unregisterListener(OnSurveyListener listener) {
         listeners.remove(listener);
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/survey/domain/GliaSurveyUseCase.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/survey/domain/GliaSurveyUseCase.java
@@ -19,4 +19,8 @@ public class GliaSurveyUseCase {
         surveyRepository.unregisterListener(listener);
     }
 
+    public boolean hasResult() {
+        return surveyRepository.hasResult();
+    }
+
 }


### PR DESCRIPTION
Navigate to survey on resuming CallActivity if engagement ended.

This is alternative solution of https://github.com/salemove/android-sdk-widgets/pull/317 .

[MOB-1383](https://glia.atlassian.net/browse/MOB-1383)
[MUIC-838](https://glia.atlassian.net/browse/MUIC-838)
