### PR TITLE
Update Lottie dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     gson = '2.8.6'
     preferenceVersion = '1.1.1'
     picassoVersion = '2.8'
-    lottieVersion = '4.1.0'
+    lottieVersion = '5.2.0'
 
     leakCanaryVersion = '2.6'
     espressoVersion = '3.4.0'

--- a/widgetssdk/src/main/res/layout/chat_head_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_head_view.xml
@@ -67,7 +67,6 @@
         app:lottie_autoPlay="true"
         app:lottie_loop="true"
         app:lottie_rawRes="@raw/chat_typing_indicator"
-        app:lottie_scale="0.5"
         tools:visibility="gone" />
 
     <TextView

--- a/widgetssdk/src/main/res/layout/chat_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_view.xml
@@ -66,8 +66,8 @@
 
     <com.airbnb.lottie.LottieAnimationView
         android:id="@+id/operator_typing_animation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
         android:layout_marginStart="@dimen/glia_medium"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -75,7 +75,6 @@
         app:lottie_autoPlay="true"
         app:lottie_loop="true"
         app:lottie_rawRes="@raw/chat_typing_indicator"
-        app:lottie_scale="0.5"
         tools:visibility="gone" />
 
     <View


### PR DESCRIPTION
MOB-1468

**Jira issue:**
https://glia.atlassian.net/browse/MOB-1468

**Additional info:**
`lottie-scale` property is completely removed from new versions and there is no equivalent, they recommend combining size with ImageView's `ScaleType` 

**Screenshots:**
