### PR TITLE
Fix: show dialogs by list

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
@@ -52,65 +52,69 @@ public class DialogController {
 
     public void showExitQueueDialog() {
         Logger.d(TAG, "Show Exit Queue Dialog");
-        dialogManager.offer(new DialogState(Dialog.MODE_EXIT_QUEUE));
+        dialogManager.addAndEmit(new DialogState(Dialog.MODE_EXIT_QUEUE));
     }
 
     public void showExitChatDialog(String operatorName) {
         Logger.d(TAG, "Show Exit Chat Dialog");
-        dialogManager.offer(new DialogState.OperatorName(Dialog.MODE_END_ENGAGEMENT, operatorName));
+        dialogManager.addAndEmit(new DialogState.OperatorName(Dialog.MODE_END_ENGAGEMENT, operatorName));
     }
 
     public void showUpgradeAudioDialog(MediaUpgradeOffer mediaUpgradeOffer, String operatorName) {
         Logger.d(TAG, "Show Upgrade Audio Dialog");
-        dialogManager.offer(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_AUDIO));
+        dialogManager.addAndEmit(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_AUDIO));
     }
 
     public void showUpgradeVideoDialog2Way(MediaUpgradeOffer mediaUpgradeOffer, String operatorName) {
         Logger.d(TAG, "Show Upgrade 2WayVideo Dialog");
-        dialogManager.offer(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_VIDEO_TWO_WAY));
+        dialogManager.addAndEmit(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_VIDEO_TWO_WAY));
     }
 
     public void showUpgradeVideoDialog1Way(MediaUpgradeOffer mediaUpgradeOffer, String operatorName) {
         Logger.d(TAG, "Show Upgrade 1WayVide Dialog");
-        dialogManager.offer(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_VIDEO_ONE_WAY));
+        dialogManager.addAndEmit(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_VIDEO_ONE_WAY));
     }
 
     public void showNoMoreOperatorsAvailableDialog() {
-            Logger.d(TAG, "Show No More Operators Dialog");
-            dialogManager.offer(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+        Logger.d(TAG, "Show No More Operators Dialog");
+        if (isOverlayDialogShown() || isExitQueueDialogShown()) {
+            dialogManager.add(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+        } else {
+            dialogManager.addAndEmit(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+        }
     }
 
     public void showEngagementEndedDialog() {
             Logger.d(TAG, "Show Engagement EngagementEndedEvent Dialog");
-            dialogManager.offer(new DialogState(Dialog.MODE_ENGAGEMENT_ENDED));
+            dialogManager.addAndEmit(new DialogState(Dialog.MODE_ENGAGEMENT_ENDED));
     }
 
     public void showUnexpectedErrorDialog() {
         // PRIORITISE THIS ERROR AS IT IS ENGAGEMENT FATAL ERROR INDICATOR (eg. GliaException:{"details":"Queue is closed","error":"Unprocessable entity"}) for example
         Logger.d(TAG, "Show Unexpected error Dialog");
-        dialogManager.offer(new DialogState(Dialog.MODE_UNEXPECTED_ERROR));
+        dialogManager.addAndEmit(new DialogState(Dialog.MODE_UNEXPECTED_ERROR));
     }
 
     public void showOverlayPermissionsDialog() {
             Logger.d(TAG, "Show Overlay permissions Dialog");
             setOverlayPermissionRequestDialogShownUseCase.execute();
-            dialogManager.offer(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+            dialogManager.addAndEmit(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
     }
 
     public void showStartScreenSharingDialog() {
             Logger.d(TAG, "Show Start Screen Sharing Dialog");
-            dialogManager.offer(new DialogState(Dialog.MODE_START_SCREEN_SHARING));
+            dialogManager.addAndEmit(new DialogState(Dialog.MODE_START_SCREEN_SHARING));
     }
 
     public void showEnableCallNotificationChannelDialog() {
             Logger.d(TAG, "Show Enable Notification Channel Dialog");
             setEnableCallNotificationChannelDialogShownUseCase.execute();
-            dialogManager.offer(new DialogState(Dialog.MODE_ENABLE_NOTIFICATION_CHANNEL));
+            dialogManager.addAndEmit(new DialogState(Dialog.MODE_ENABLE_NOTIFICATION_CHANNEL));
     }
 
     public void showEnableScreenSharingNotificationsAndStartSharingDialog() {
         Logger.d(TAG, "Show Enable Notification Channel Dialog");
-        dialogManager.offer(new DialogState(Dialog.MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING));
+        dialogManager.addAndEmit(new DialogState(Dialog.MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING));
     }
 
     public void addCallback(Callback callback) {
@@ -124,6 +128,14 @@ public class DialogController {
     public void removeCallback(Callback callback) {
         Logger.d(TAG, "removeCallback");
         viewCallbacks.remove(callback);
+    }
+
+    private boolean isOverlayDialogShown() {
+        return Dialog.MODE_OVERLAY_PERMISSION == dialogManager.getCurrentMode();
+    }
+
+    private boolean isExitQueueDialogShown() {
+        return Dialog.MODE_EXIT_QUEUE == dialogManager.getCurrentMode();
     }
 
     public interface Callback {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogManager.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogManager.java
@@ -1,6 +1,7 @@
 package com.glia.widgets.core.dialog;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.glia.widgets.core.dialog.model.DialogState;
 
@@ -10,7 +11,8 @@ import java.util.concurrent.LinkedBlockingDeque;
 public final class DialogManager {
     @NonNull
     private final Callback callback;
-    private final Deque<DialogState> stateDeque;
+    @VisibleForTesting
+    final Deque<DialogState> stateDeque;
     private final DialogState none = new DialogState(Dialog.MODE_NONE);
 
     public DialogManager(@NonNull Callback callback) {
@@ -18,7 +20,13 @@ public final class DialogManager {
         stateDeque = new LinkedBlockingDeque<>();
     }
 
-    public void offer(DialogState state) {
+    /**
+     * Used to add state to the queue.
+     *
+     * It will emit a new state immediately. The previous state is saved in the queue
+     * and will be emitted after the {@link #dismissCurrent()} is called.
+     */
+    public void addAndEmit(@NonNull DialogState state) {
         if (isDialogShown()) {
             emitNone();
         }
@@ -26,6 +34,30 @@ public final class DialogManager {
         stateDeque.removeLastOccurrence(state);
         stateDeque.offer(state);
         callback.emitDialog(state);
+    }
+
+    /**
+     * Used to add state to the queue.
+     *
+     * If the current {@link #getCurrentMode()} state is not {@link Dialog#MODE_NONE} it will add
+     * the state to the queue. The new state will emit after the {@link #dismissCurrent()} called.
+     *
+     * If the current {@link #getCurrentMode()} state is {@link Dialog#MODE_NONE}
+     * it will emit a new state immediately.
+     */
+    public void add(@NonNull DialogState state) {
+        boolean isDialogShown = isDialogShown();
+        DialogState currentState = remove();
+
+        stateDeque.removeFirstOccurrence(state);
+        stateDeque.offer(state);
+        if (currentState != null && !state.equals(currentState)) {
+            stateDeque.offer(currentState);
+        }
+
+        if (!isDialogShown) {
+            callback.emitDialog(state);
+        }
     }
 
     private DialogState remove() {
@@ -36,6 +68,9 @@ public final class DialogManager {
         return stateDeque.peekLast();
     }
 
+    /**
+     * Used to emit next DialogState.
+     */
     public void showNext() {
         if (stateDeque.isEmpty()) return;
 
@@ -50,17 +85,26 @@ public final class DialogManager {
         callback.emitDialog(none);
     }
 
+    /**
+     * Used to remove the current state and emit the next state from the queue.
+     */
     public void dismissCurrent() {
         emitNone();
         remove();
         showNext();
     }
 
+    /**
+     * Used to clear the queue and emit {@link Dialog#MODE_NONE} state.
+     */
     public void dismissAll() {
         stateDeque.clear();
         emitNone();
     }
 
+    /**
+     * @return the current mode of the {@link DialogState}.
+     */
     @Dialog.Mode
     public int getCurrentMode() {
         DialogState state = getCurrent();
@@ -69,6 +113,9 @@ public final class DialogManager {
         return state.getMode();
     }
 
+    /**
+     * @return true if the queue is not empty.
+     */
     public boolean isDialogShown() {
         return !stateDeque.isEmpty();
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/dialog/DialogManagerTest.java
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/dialog/DialogManagerTest.java
@@ -1,0 +1,244 @@
+package com.glia.widgets.core.dialog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.glia.widgets.core.dialog.model.DialogState;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+public class DialogManagerTest {
+    private DialogManager manager;
+    private DialogManager.Callback managerCallback;
+
+    @Before
+    public void setUp() {
+        managerCallback = mock(DialogManager.Callback.class);
+        manager = new DialogManager(managerCallback);
+    }
+
+    @Test
+    public void addAndEmit_emmitCallbackOnce_ifStackIsEmpty() {
+        manager.addAndEmit(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        verify(managerCallback).emitDialog(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void addAndEmit_emmitCallbackTwice_ifStackIsNotEmpty() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+
+        manager.addAndEmit(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        ArgumentCaptor<DialogState> captor = ArgumentCaptor.forClass(DialogState.class);
+        verify(managerCallback, times(2)).emitDialog(captor.capture());
+
+        List<DialogState> values = captor.getAllValues();
+        assertEquals(new DialogState(Dialog.MODE_NONE), values.get(0));
+        assertEquals(new DialogState(Dialog.MODE_OVERLAY_PERMISSION), values.get(1));
+    }
+
+    @Test
+    public void addAndEmit_addStateToStack_ifStackIsEmpty() {
+        manager.addAndEmit(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        assertEquals(manager.stateDeque.size(), 1);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void addAndEmit_addStateToStack_ifStackIsNotEmpty() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+
+        manager.addAndEmit(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        assertEquals(manager.stateDeque.size(), 2);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void addAndEmit_removeLastOccurrence_ifStateInStack() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+
+        manager.addAndEmit(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        assertEquals(manager.stateDeque.size(), 3);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void add_emmitCallback_ifStackIsEmpty() {
+        manager.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        verify(managerCallback).emitDialog(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void add_notEmmitCallback_ifStackIsNotEmpty() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+
+        manager.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        verify(managerCallback, never()).emitDialog(any());
+    }
+
+    @Test
+    public void add_addToStack_ifStackIsEmpty() {
+        manager.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        assertEquals(manager.stateDeque.size(), 1);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void add_addToStack_ifStackIsNotEmpty() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+
+        manager.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        assertEquals(manager.stateDeque.size(), 3);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+    }
+
+    @Test
+    public void add_removeLastOccurrence_ifStateInStack() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+
+        manager.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        assertEquals(manager.stateDeque.size(), 3);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+    }
+
+    @Test
+    public void add_notChangeStack_ifNewStateEqualLastState() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        manager.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        assertEquals(manager.stateDeque.size(), 3);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void showNext_notEmmitCallbackOnce_ifStackEmpty() {
+        manager.showNext();
+
+        verify(managerCallback, never()).emitDialog(any());
+    }
+
+    @Test
+    public void showNext_emmitCallbackOnce_ifStackNotEmpty() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        manager.showNext();
+
+        verify(managerCallback).emitDialog(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+    }
+
+    @Test
+    public void dismissCurrent_emmitCallbackWithNoneState_onExecute() {
+        manager.dismissCurrent();
+
+        verify(managerCallback).emitDialog(new DialogState(Dialog.MODE_NONE));
+    }
+
+    @Test
+    public void dismissCurrent_emmitCallbackWithPreviousState_onExecute() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        manager.dismissCurrent();
+
+        ArgumentCaptor<DialogState> captor = ArgumentCaptor.forClass(DialogState.class);
+        verify(managerCallback, times(2)).emitDialog(captor.capture());
+        assertEquals(new DialogState(Dialog.MODE_MEDIA_UPGRADE), captor.getValue());
+    }
+
+    @Test
+    public void dismissCurrent_removeLastStateFromStack_onExecute() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        manager.dismissCurrent();
+
+        assertEquals(manager.stateDeque.size(), 1);
+        assertEquals(manager.stateDeque.removeFirst(), new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+    }
+
+    @Test
+    public void dismissAll_emmitCallbackWithNoneState_onExecute() {
+        manager.dismissAll();
+
+        verify(managerCallback).emitDialog(new DialogState(Dialog.MODE_NONE));
+    }
+
+    @Test
+    public void dismissAll_clearStack_onExecute() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        manager.dismissAll();
+
+        assertTrue(manager.stateDeque.isEmpty());
+    }
+
+    @Test
+    public void getCurrentMode_returnLastStackValue_ifStackIsNotEmpty() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+        manager.stateDeque.add(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
+
+        int currentMode = manager.getCurrentMode();
+
+        assertEquals(Dialog.MODE_OVERLAY_PERMISSION, currentMode);
+    }
+
+    @Test
+    public void getCurrentMode_returnLastStackValue_ifStackIsEmpty() {
+        int currentMode = manager.getCurrentMode();
+
+        assertEquals(Dialog.MODE_NONE, currentMode);
+    }
+
+    @Test
+    public void isDialogShown_returnTrue_ifStackIsNotEmpty() {
+        manager.stateDeque.add(new DialogState(Dialog.MODE_MEDIA_UPGRADE));
+
+        boolean result = manager.isDialogShown();
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void isDialogShown_returnFalse_ifStackIsEmpty() {
+        boolean result = manager.isDialogShown();
+
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
Added possibility to show dialogs one by one.
Used to show the No More Operators Dialog (returned to previous logic).