### PR TITLE
Add unit testing to release process

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -144,7 +144,21 @@ workflows:
     - install-missing-android-tools@3:
         inputs:
         - gradlew_path: $PROJECT_LOCATION/gradlew
-    - script@1.1.6:
+    - android-build@1:
+        inputs:
+        - variant: $INTEGRATOR_VARIANT
+        - module: $EXAMPLE_APP_MODULE
+    - android-unit-test@1:
+        inputs:
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
+        - project_location: $PROJECT_LOCATION
+    - android-unit-test@1:
+        inputs:
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
+        - project_location: $PROJECT_LOCATION
+    - script@1:
         title: Publish Android SDK to Nexus Repository Manager (Staging)
         inputs:
         - content: >-
@@ -164,7 +178,7 @@ workflows:
 
             ./gradlew clean
             widgetssdk:publishReleasePublicationToSonatypeRepository
-    - cache-push@2.3: {}
+    - cache-push@2: {}
   pull_request:
     steps:
     - activate-ssh-key@4:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,7 @@ workflows:
 
             sudo update-alternatives --set java
             /usr/lib/jvm/java-11-openjdk-amd64/bin/java
-               
+
             export JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
 
             envman add --key JAVA_HOME --value
@@ -139,9 +139,9 @@ workflows:
     description: Task builds an SDK and uploads it to Nexus.
     steps:
     - activate-ssh-key@4: {}
-    - git-clone@4: {}
-    - cache-pull@2.1: {}
-    - install-missing-android-tools@2.3.8:
+    - git-clone@6: {}
+    - cache-pull@2: {}
+    - install-missing-android-tools@3:
         inputs:
         - gradlew_path: $PROJECT_LOCATION/gradlew
     - script@1.1.6:


### PR DESCRIPTION
In order to ensure that the release process of the widgets is done
with a working version of the SDK, unit tests for both SDK and testing
app have been added to the `publish_to_nexus` workflow, which is the
one in charge of releasing the widgets to Maven Central.

MOB-1510