### PR TITLE
Add workflow to increment Core SDK version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -231,6 +231,39 @@ workflows:
     - opts:
         is_expand: false
       INTEGRATOR_VARIANT: debug
+  upgrade_dependencies:
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@6: {}
+    - cache-pull@2: {}
+    - install-missing-android-tools@3:
+        inputs:
+        - gradlew_path: $PROJECT_LOCATION/gradlew
+    - gradle-runner@2:
+        inputs:
+        - gradlew_path: $PROJECT_LOCATION/gradlew
+        - gradle_file: $PROJECT_LOCATION/build.gradle
+        - gradle_task: saveCoreSdkVersion --coreSdkVersion=$NEW_VERSION
+    - script@1:
+        inputs:
+        - content: |2-
+             #!/bin/bash
+
+            BRANCH_NAME="core-sdk-version-increment/${NEW_VERSION}"
+            MESSAGE="Increment Core SDK version to ${NEW_VERSION}"
+
+            git checkout -b $BRANCH_NAME
+            git add -A
+            git commit -m "$MESSAGE"
+            git push origin "$BRANCH_NAME":"$BRANCH_NAME"
+
+            curl \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+              https://api.github.com/repos/salemove/android-sdk-widgets/pulls \
+              -d "{\"title\":\"${MESSAGE}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"master\"}"
+    - cache-push@2: {}
 app:
   envs:
   - opts:

--- a/scripts/create-pr-for-increment-project-version.sh
+++ b/scripts/create-pr-for-increment-project-version.sh
@@ -1,0 +1,17 @@
+ #!/bin/bash
+
+NEW_VERSION=$1
+BRANCH_NAME="version-update/${NEW_VERSION}"
+MESSAGE="Update project version to ${NEW_VERSION}"
+
+git checkout -b $BRANCH_NAME
+git add -A
+git commit -m "$MESSAGE"
+git push origin "$BRANCH_NAME":"$BRANCH_NAME"
+
+curl \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+  https://api.github.com/repos/salemove/android-sdk-widgets/pulls \
+  -d "{\"title\":\"${MESSAGE}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"master\"}"

--- a/scripts/version-updater.gradle
+++ b/scripts/version-updater.gradle
@@ -54,4 +54,3 @@ class UpdateCoreSdkVersion extends DefaultTask {
 }
 
 tasks.register('saveCoreSdkVersion', UpdateCoreSdkVersion)
-


### PR DESCRIPTION
Using the previous work done in Gradle, a new workflow has been added to `bitrise.yml` that increments the Core SDK version. A pull request is created also by directly calling the GitHub API. This will be used in the Core SDK release process, in order to increment the Core SDK version used in the widgets once the Core SDK is released. This workflow requires an environment variable called `NEW_VERSION`.

MOB-1510