### PR TITLE
Update Bitrise deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,16 @@
+name: Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version in semantic versioning format (i.e. 1.0.2)'
+        required: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Runs the deployment workflow in Bitrise
+        run: |
+          curl https://app.bitrise.io/app/${{ secrets.BITRISE_APP_ID }}/build/start.json --data '{"hook_info":{"type":"bitrise","build_trigger_token":"${{ secrets.BITRISE_BUILD_TRIGGER_TOKEN }}"},"build_params":{"branch":"master","workflow_id":"publish_to_nexus","environments":[{"mapped_to":"NEW_VERSION","value":"${{ github.event.inputs.version }}","is_expand":true}]},"triggered_by":"curl"}'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,6 +1,6 @@
 ---
 format_version: '8'
-default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
 project_type: android
 workflows:
   browserstack_upload:
@@ -11,18 +11,18 @@ workflows:
     - cache-pull@2: {}
     - install-missing-android-tools@3.0:
         inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
+        - gradlew_path: $PROJECT_LOCATION/gradlew
     - android-build@1.0:
         inputs:
-        - variant: "$INTEGRATOR_VARIANT"
-        - module: "$EXAMPLE_APP_MODULE"
+        - variant: $INTEGRATOR_VARIANT
+        - module: $EXAMPLE_APP_MODULE
     - browserstack-upload@0:
         inputs:
-        - custom_id: "$BROWSERSTACK_APP_ID"
+        - custom_id: $BROWSERSTACK_APP_ID
         title: Upload APP to BrowserStack
     - deploy-to-bitrise-io@1:
         inputs:
-        - notify_email_list: "$BUILD_EMAILS"
+        - notify_email_list: $BUILD_EMAILS
     - cache-push@2: {}
     envs:
     - opts:
@@ -35,73 +35,73 @@ workflows:
     - git-clone@4: {}
     - script@1:
         inputs:
-        - content: |-
-            sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
-            sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+        - content: >-
+            sudo update-alternatives --set javac
+            /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+
+            sudo update-alternatives --set java
+            /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+
             export JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
-            envman add --key JAVA_HOME --value '/usr/lib/jvm/java-11-openjdk-amd64'
+
+            envman add --key JAVA_HOME --value
+            '/usr/lib/jvm/java-11-openjdk-amd64'
     - cache-pull@2: {}
     - install-missing-android-tools@2:
         inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
+        - gradlew_path: $PROJECT_LOCATION/gradlew
     - android-build@0:
         inputs:
-        - variant: "$INTEGRATOR_VARIANT"
-        - module: "$EXAMPLE_APP_MODULE"
+        - variant: $INTEGRATOR_VARIANT
+        - module: $EXAMPLE_APP_MODULE
     - android-lint@0:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$WIDGET_SDK_MODULE"
-        - variant: "$SDK_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
         title: Run Lint for SDK
     - android-unit-test@1:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$WIDGET_SDK_MODULE"
-        - variant: "$SDK_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
         title: Unit Test for SDK
     - android-lint@0:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$EXAMPLE_APP_MODULE"
-        - variant: "$INTEGRATOR_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
         title: Run Lint for APP
     - android-unit-test@1:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$EXAMPLE_APP_MODULE"
-        - variant: "$INTEGRATOR_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
         title: Unit Test for APP
     - deploy-to-bitrise-io@1:
         inputs:
-        - notify_email_list: "$BUILD_EMAILS"
+        - notify_email_list: $BUILD_EMAILS
     - cache-push@2: {}
     envs:
     - opts:
         is_expand: false
       INTEGRATOR_VARIANT: master
-  increment_project_version:
+  _increment_project_version:
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@6: {}
-    - cache-pull@2: {}
-    - install-missing-android-tools@3:
-        inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
     - gradle-runner@2:
         inputs:
-        - gradle_file: "$PROJECT_LOCATION/build.gradle"
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
-        - gradle_task: ":bumpVersionMinorLevel"
+        - gradle_file: $PROJECT_LOCATION/build.gradle
+        - gradlew_path: $PROJECT_LOCATION/gradlew
+        - gradle_task: ':bumpVersionMinorLevel'
     - script@1:
         inputs:
-        - content: |-
+        - content: >-
             #!/usr/bin/env bash
             # fail if any commands fails
             set -e
-            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
-            #set -o pipefail
+            # make pipelines' return status equal the last command to exit with
+            a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
             # debug log
             set -x
 
@@ -127,7 +127,6 @@ workflows:
               -H "Authorization: Bearer $GITHUB_API_TOKEN" \
               https://api.github.com/repos/salemove/android-sdk-widgets/pulls/$PULL_REQUEST_NUMBER/requested_reviewers \
               -d "{\"team_reviewers\":[\"tm-mobile-android\"]}"
-    - cache-push@2: {}
     envs:
     - opts:
         is_expand: false
@@ -140,42 +139,42 @@ workflows:
     - cache-pull@2: {}
     - install-missing-android-tools@2:
         inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
+        - gradlew_path: $PROJECT_LOCATION/gradlew
     - android-build@0:
         inputs:
-        - variant: "$INTEGRATOR_VARIANT"
-        - module: "$EXAMPLE_APP_MODULE"
+        - variant: $INTEGRATOR_VARIANT
+        - module: $EXAMPLE_APP_MODULE
     - android-lint@0:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$WIDGET_SDK_MODULE"
-        - variant: "$SDK_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
         title: Run Lint for SDK
     - android-unit-test@1:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$WIDGET_SDK_MODULE"
-        - variant: "$SDK_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
         title: Unit Test for SDK
     - android-lint@0:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$EXAMPLE_APP_MODULE"
-        - variant: "$INTEGRATOR_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
         title: Run Lint for APP
     - android-unit-test@1:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$EXAMPLE_APP_MODULE"
-        - variant: "$INTEGRATOR_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
         title: Unit Test for APP
     - browserstack-upload@0:
         inputs:
-        - custom_id: "$BROWSERSTACK_APP_ID"
+        - custom_id: $BROWSERSTACK_APP_ID
         title: Upload APP to BrowserStack
     - deploy-to-bitrise-io@1:
         inputs:
-        - notify_email_list: "$BUILD_EMAILS"
+        - notify_email_list: $BUILD_EMAILS
     - cache-push@2: {}
     envs:
     - opts:
@@ -189,36 +188,48 @@ workflows:
     - cache-pull@2: {}
     - install-missing-android-tools@3:
         inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
+        - gradlew_path: $PROJECT_LOCATION/gradlew
     - android-build@1:
         inputs:
-        - variant: "$INTEGRATOR_VARIANT"
-        - module: "$EXAMPLE_APP_MODULE"
+        - variant: $INTEGRATOR_VARIANT
+        - module: $EXAMPLE_APP_MODULE
     - android-unit-test@1:
         inputs:
-        - module: "$WIDGET_SDK_MODULE"
-        - variant: "$SDK_VARIANT"
-        - project_location: "$PROJECT_LOCATION"
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
+        - project_location: $PROJECT_LOCATION
     - android-unit-test@1:
         inputs:
-        - module: "$EXAMPLE_APP_MODULE"
-        - variant: "$INTEGRATOR_VARIANT"
-        - project_location: "$PROJECT_LOCATION"
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
+        - project_location: $PROJECT_LOCATION
     - script@1:
         title: Publish Android SDK to Nexus Repository Manager (Staging)
         inputs:
-        - content: |-
+        - content: >-
             #!/usr/bin/env bash
             # fail if any commands fails
             set -e
             # debug log
             set -x
 
-            # this will run Gradle script to deploy library and related artifacts to Maven Central
-            ./gradlew clean widgetssdk:publishReleasePublicationToSonatypeRepository
+            # this will run Gradle script to deploy library and related
+            artifacts to Maven Central
+            ./gradlew clean
+            widgetssdk:publishReleasePublicationToSonatypeRepository
+    - generate-changelog@0: {}
+    - github-release@0:
+        inputs:
+        - username: $GITHUB_USERNAME
+        - tag: $NEW_VERSION
+        - commit: $GIT_CLONE_COMMIT_HASH
+        - name: Glia Android Widgets $NEW_VERSION
+        - body: $BITRISE_CHANGELOG
+        - draft: 'no'
+        - api_token: $GITHUB_API_TOKEN
     - cache-push@2: {}
     after_run:
-    - increment_project_version
+    - _increment_project_version
   pull_request:
     steps:
     - activate-ssh-key@4:
@@ -227,39 +238,39 @@ workflows:
     - cache-pull@2: {}
     - install-missing-android-tools@2:
         inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
+        - gradlew_path: $PROJECT_LOCATION/gradlew
     - android-build@0:
         inputs:
-        - variant: "$INTEGRATOR_VARIANT"
-        - module: "$EXAMPLE_APP_MODULE"
+        - variant: $INTEGRATOR_VARIANT
+        - module: $EXAMPLE_APP_MODULE
     - android-lint@0:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$WIDGET_SDK_MODULE"
-        - variant: "$SDK_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
         title: Run Lint for SDK
     - android-unit-test@1:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$WIDGET_SDK_MODULE"
-        - variant: "$SDK_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $WIDGET_SDK_MODULE
+        - variant: $SDK_VARIANT
         title: Unit Test for SDK
     - android-lint@0:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$EXAMPLE_APP_MODULE"
-        - variant: "$INTEGRATOR_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
         title: Run Lint for APP
     - android-unit-test@1:
         inputs:
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$EXAMPLE_APP_MODULE"
-        - variant: "$INTEGRATOR_VARIANT"
+        - project_location: $PROJECT_LOCATION
+        - module: $EXAMPLE_APP_MODULE
+        - variant: $INTEGRATOR_VARIANT
         title: Unit Test for APP
     - gradle-runner@2:
         inputs:
-        - gradlew_path: "./gradlew"
-        - gradle_task: ":$WIDGET_SDK_MODULE:assembleDebugAndroidTest"
+        - gradlew_path: ./gradlew
+        - gradle_task: ':$WIDGET_SDK_MODULE:assembleDebugAndroidTest'
         title: Assemble SDK for instrumentation tests
     - virtual-device-testing-for-android@1:
         title: UI Test for APP
@@ -278,19 +289,20 @@ workflows:
     - cache-pull@2: {}
     - install-missing-android-tools@3:
         inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
+        - gradlew_path: $PROJECT_LOCATION/gradlew
     - gradle-runner@2:
         inputs:
-        - gradlew_path: "$PROJECT_LOCATION/gradlew"
-        - gradle_file: "$PROJECT_LOCATION/build.gradle"
+        - gradlew_path: $PROJECT_LOCATION/gradlew
+        - gradle_file: $PROJECT_LOCATION/build.gradle
         - gradle_task: saveCoreSdkVersion --coreSdkVersion=$NEW_VERSION
     - script@1:
         inputs:
-        - content: |-
+        - content: >-
             #!/usr/bin/env bash
             # fail if any commands fails
             set -e
-            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            # make pipelines' return status equal the last command to exit with
+            a non-zero status, or zero if all commands exit successfully
             set -o pipefail
             # debug log
             set -x
@@ -314,7 +326,7 @@ app:
   envs:
   - opts:
       is_expand: false
-    PROJECT_LOCATION: "."
+    PROJECT_LOCATION: .
   - opts:
       is_expand: false
     EXAMPLE_APP_MODULE: app
@@ -335,7 +347,5 @@ trigger_map:
   workflow: master
 - push_branch: develop
   workflow: develop
-- pull_request_target_branch: "*"
+- pull_request_target_branch: '*'
   workflow: pull_request
-- tag: v*.*.*
-  workflow: publish_to_nexus


### PR DESCRIPTION
Instead of going to GitHub and manually generating a release, the deployment workflow will be in charge of generating the release, the tag, and the changelog. The only thing needed from our side is to send it the NEW_VERSION environment variable. To make this even easier, a new GitHub Action is created to do exactly that. Just send the version through GitHub’s interface, and it will do everything. The tag trigger is not available anymore.

Apart from that, the increment_project_version is updated so that it doesn’t have unnecessary steps. This time it will succeed always.

I don't know why always Bitrise changes its formatting. The changes to the bitrise.yml are here https://github.com/salemove/android-sdk-widgets/compare/MOB-1589?expand=1#diff-61d1ee831cb1df242161a7d23171914a1d5d628c7659b52db957d80a9394bd68R240

MOB-1589