### PR TITLE
Add GitHub Action for manual version increment

### DIFF
--- a/.github/workflows/increment-project-version.yml
+++ b/.github/workflows/increment-project-version.yml
@@ -1,0 +1,21 @@
+name: Increment project version
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'Version increment type'
+        required: true
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Runs the increment project version workflow in Bitrise
+        run: |
+          curl https://app.bitrise.io/app/${{ secrets.BITRISE_APP_ID }}/build/start.json --data '{"hook_info":{"type":"bitrise","build_trigger_token":"${{ secrets.BITRISE_BUILD_TRIGGER_TOKEN }}"},"build_params":{"branch":"master","workflow_id":"authenticated_increment_project_version","environments":[{"mapped_to":"VERSION_INCREMENT_TYPE","value":"${{ github.event.inputs.type }}","is_expand":true}]},"triggered_by":"curl"}'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,7 +9,7 @@ workflows:
         inputs:
         - gradle_file: $PROJECT_LOCATION/build.gradle
         - gradlew_path: $PROJECT_LOCATION/gradlew
-        - gradle_task: ':bumpVersionMinorLevel'
+        - gradle_task: saveWidgetsVersion --type=$VERSION_INCREMENT_TYPE
     - script@1:
         inputs:
         - content: >-
@@ -62,6 +62,22 @@ workflows:
     - opts:
         is_expand: false
       INTEGRATOR_VARIANT: debug
+  authenticated_increment_project_version:
+    description: Task builds an SDK and uploads it to Nexus.
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@6: {}
+    - cache-pull@2: {}
+    - install-missing-android-tools@3:
+        inputs:
+        - gradlew_path: $PROJECT_LOCATION/gradlew
+    - cache-push@2: {}
+    after_run:
+    - _increment_project_version
+    envs:
+    - opts:
+        is_expand: false
+      VERSION_INCREMENT_TYPE: patch
   browserstack_upload:
     steps:
     - activate-ssh-key@4:


### PR DESCRIPTION
Sometimes we will need to increment the minor version. However, right now the `_increment_project_version` will increment with type set as `patch` by default. This workflow lets you choose on a dropdown what type you want to use for the version increment. Bitrise then executes an authenticated version of incrementing project version. This is needed because _increment_project_version on its own cannot work, as it needs the SSH key.