### PR TITLE
Create Mappers to map old UiTheme to new GliaTheme

### DIFF
--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -37,6 +37,10 @@ android {
                 'WrongViewIdFormat',
                 'HardcodedText'
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ChatHeadConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ChatHeadConfiguration.java
@@ -3,7 +3,7 @@ package com.glia.widgets.view.configuration;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-@Deprecated
+@Deprecated // TODO find to which class map this
 public class ChatHeadConfiguration implements Parcelable {
     private final Integer operatorPlaceholderBackgroundColor;
     private final Integer operatorPlaceholderIcon;

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
@@ -9,38 +9,34 @@ import com.glia.widgets.R;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.ResourceProvider;
 
+import kotlinx.parcelize.Parcelize;
+
 @Deprecated
+//Removed textTypeFaceStyle and allCaps because those properties were unused
 public class TextConfiguration implements Parcelable {
+    //text size in PX
     private float textSize;
-    private int textTypeFaceStyle;
     private ColorStateList textColor;
     private ColorStateList hintColor;
     private ColorStateList textColorLink;
     private int textColorHighlight;
     private int fontFamily;
     private Boolean bold;
-    private Boolean allCaps;
 
     private TextConfiguration(
             Builder builder
     ) {
         this.textSize = builder.textSize;
-        this.textTypeFaceStyle = builder.textTypeFaceStyle;
         this.textColor = builder.textColor;
         this.hintColor = builder.hintColor;
         this.textColorLink = builder.textColorLink;
         this.textColorHighlight = builder.textColorHighlight;
         this.fontFamily = builder.fontFamily;
         this.bold = builder.bold;
-        this.allCaps = builder.allCaps;
     }
 
     public float getTextSize() {
         return textSize;
-    }
-
-    public int getTextTypeFaceStyle() {
-        return textTypeFaceStyle;
     }
 
     public ColorStateList getTextColor() {
@@ -67,10 +63,6 @@ public class TextConfiguration implements Parcelable {
         return this.bold;
     }
 
-    public Boolean isAllCaps() {
-        return allCaps;
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -78,7 +70,6 @@ public class TextConfiguration implements Parcelable {
     @Deprecated
     public static class Builder {
         private float textSize;
-        private int textTypeFaceStyle;
         private ColorStateList textColor;
         private ColorStateList hintColor;
         private ColorStateList textColorLink;
@@ -92,14 +83,12 @@ public class TextConfiguration implements Parcelable {
 
         public Builder(TextConfiguration textConfiguration) {
             this.textSize = textConfiguration.textSize;
-            this.textTypeFaceStyle = textConfiguration.textTypeFaceStyle;
             this.textColor = textConfiguration.textColor;
             this.hintColor = textConfiguration.hintColor;
             this.textColorLink = textConfiguration.textColorLink;
             this.textColorHighlight = textConfiguration.textColorHighlight;
             this.fontFamily = textConfiguration.fontFamily;
             this.bold = textConfiguration.bold;
-            this.allCaps = textConfiguration.allCaps;
         }
 
         public Builder textSize(float textSize) {
@@ -108,7 +97,6 @@ public class TextConfiguration implements Parcelable {
         }
 
         public Builder textTypeFaceStyle(int textTypeFaceStyle) {
-            this.textTypeFaceStyle = textTypeFaceStyle;
             return this;
         }
 
@@ -185,38 +173,32 @@ public class TextConfiguration implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeFloat(this.textSize);
-        dest.writeInt(this.textTypeFaceStyle);
         dest.writeParcelable(this.textColor, flags);
         dest.writeParcelable(this.hintColor, flags);
         dest.writeParcelable(this.textColorLink, flags);
         dest.writeInt(this.textColorHighlight);
         dest.writeInt(this.fontFamily);
         dest.writeByte(this.bold ? (byte) 1 : (byte) 0);
-        dest.writeByte(this.allCaps ? (byte) 1 : (byte) 0);
     }
 
     public void readFromParcel(Parcel source) {
         this.textSize = source.readFloat();
-        this.textTypeFaceStyle = source.readInt();
         this.textColor = source.readParcelable(ColorStateList.class.getClassLoader());
         this.hintColor = source.readParcelable(ColorStateList.class.getClassLoader());
         this.textColorLink = source.readParcelable(ColorStateList.class.getClassLoader());
         this.textColorHighlight = source.readInt();
         this.fontFamily = source.readInt();
         this.bold = source.readByte() != 0;
-        this.allCaps = source.readByte() != 0;
     }
 
     protected TextConfiguration(Parcel in) {
         this.textSize = in.readFloat();
-        this.textTypeFaceStyle = in.readInt();
         this.textColor = in.readParcelable(ColorStateList.class.getClassLoader());
         this.hintColor = in.readParcelable(ColorStateList.class.getClassLoader());
         this.textColorLink = in.readParcelable(ColorStateList.class.getClassLoader());
         this.textColorHighlight = in.readInt();
         this.fontFamily = in.readInt();
         this.bold = in.readByte() != 0;
-        this.allCaps = in.readByte() != 0;
     }
 
     public static final Creator<TextConfiguration> CREATOR = new Creator<TextConfiguration>() {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ViewExstensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ViewExstensions.kt
@@ -1,0 +1,101 @@
+package com.glia.widgets.view.unifiedui.exstensions
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.*
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.util.TypedValue
+import android.view.View
+import android.widget.Button
+import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.annotation.RawRes
+import com.glia.widgets.view.unifiedui.theme.base.ThemeButton
+import com.glia.widgets.view.unifiedui.theme.base.ThemeColor
+import com.glia.widgets.view.unifiedui.theme.base.ThemeLayer
+import com.glia.widgets.view.unifiedui.theme.base.ThemeText
+
+
+internal fun View.applyThemeLayer(layer: ThemeLayer?) {
+    layer?.asDrawable()?.also {
+        backgroundTintList = null
+        background = it
+    }
+}
+
+internal fun View.applyThemeColor(color: ThemeColor?) {
+    background = color?.asDrawable() ?: return
+}
+
+internal fun View.applyShadow(@ColorInt color: Int?) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && color != null) {
+        outlineSpotShadowColor = color
+        outlineAmbientShadowColor = color
+    }
+}
+
+internal fun TextView.applyTextThemeColor(color: ThemeColor?) {
+    if (color == null) return
+
+    if (color.isGradient) {
+        paint.shader = LinearGradient(
+            0f,
+            0f,
+            paint.measureText(text.toString()),
+            textSize,
+            color.valuesArray,
+            null,
+            Shader.TileMode.CLAMP
+        )
+    } else {
+        setTextColor(color.primaryColor)
+    }
+
+}
+
+internal fun TextView.applyThemeText(themeText: ThemeText?) {
+    themeText?.apply {
+        if (this@applyThemeText !is Button) {
+            applyThemeColor(backgroundColor)
+        }
+
+        applyTextThemeColor(textColor)
+        textSize?.also { setTextSize(TypedValue.COMPLEX_UNIT_SP, it) }
+        textStyle?.also { typeface = Typeface.create(typeface, it) }
+        textAlignment?.let { this@applyThemeText.textAlignment = it }
+
+    }
+}
+
+internal fun Button.applyThemeButton(themeButton: ThemeButton?) {
+    themeButton?.apply {
+        background?.also { applyThemeLayer(it) }
+        text?.also { applyThemeText(it) }
+        elevation?.also { this@applyThemeButton.elevation = it }
+        applyShadow(shadowColor)
+    }
+}
+
+internal fun Resources.createNewDrawable(bitmap: Bitmap, themeColor: ThemeColor): Drawable {
+    val newBitmap = Bitmap.createBitmap(bitmap.width, bitmap.height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(newBitmap)
+    canvas.drawBitmap(bitmap, 0f, 0f, null)
+
+    val paint = Paint()
+    val shader = LinearGradient(
+        0f,
+        0f,
+        0f,
+        bitmap.height.toFloat(),
+        themeColor.valuesArray,
+        null,
+        Shader.TileMode.CLAMP
+    )
+    paint.shader = shader
+    paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+    canvas.drawRect(0f, 0f, bitmap.width.toFloat(), bitmap.height.toFloat(), paint)
+
+    return BitmapDrawable(this, newBitmap)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/parse/Deserializers.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/parse/Deserializers.kt
@@ -1,6 +1,7 @@
 package com.glia.widgets.view.unifiedui.parse
 
 import android.graphics.Typeface
+import androidx.annotation.ColorInt
 import com.glia.widgets.helper.ResourceProvider
 import com.glia.widgets.view.unifiedui.config.alert.AxisRemoteConfig
 import com.glia.widgets.view.unifiedui.config.base.*
@@ -18,6 +19,11 @@ internal fun <T> tryOrNull(block: () -> T?): T? = try {
     block()
 } catch (ignore: Exception) {
     null
+}
+
+@ColorInt
+internal fun parseColorOrNull(colorHex: String?): Int? = tryOrNull {
+    SystemColor.parseColor(colorHex)
 }
 
 /**

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/parse/RemoteConfigurationParser.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/parse/RemoteConfigurationParser.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.view.unifiedui.parse
 
-import android.widget.TextView
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.view.unifiedui.config.RemoteConfiguration
 import com.glia.widgets.view.unifiedui.config.alert.AxisRemoteConfig
@@ -14,7 +13,6 @@ internal object RemoteConfigurationParser {
      * @return [Gson] instance with applied deserializers to parse remote config.
      */
     val defaultGson: Gson by lazy {
-        TextView(null).textAlignment
         GsonBuilder()
             .registerTypeAdapter(ColorLayerRemoteConfig::class.java, ColorLayerDeserializer())
             .registerTypeAdapter(

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeBaseMappers.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeBaseMappers.kt
@@ -1,59 +1,116 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
+import android.content.res.ColorStateList
+import android.graphics.Typeface
+import com.glia.widgets.view.configuration.ButtonConfiguration
+import com.glia.widgets.view.configuration.LayerConfiguration
+import com.glia.widgets.view.configuration.TextConfiguration
 import com.glia.widgets.view.unifiedui.config.base.*
 import com.glia.widgets.view.unifiedui.config.chat.BadgeRemoteConfig
+import com.glia.widgets.view.unifiedui.parse.parseColorOrNull
 
 
-internal fun ThemeColor?.updateFrom(colorLayerRemoteConfig: ColorLayerRemoteConfig?): ThemeColor? = colorLayerRemoteConfig?.let {
-    ThemeColor(isGradient = it.isGradient, values = it.valuesExpanded)
-} ?: this
+internal fun ThemeColor?.updateFrom(colorLayerRemoteConfig: ColorLayerRemoteConfig?): ThemeColor? =
+    colorLayerRemoteConfig?.let {
+        ThemeColor(isGradient = it.isGradient, values = it.valuesExpanded)
+    } ?: this
 
-internal fun ThemeLayer?.updateFrom(layerRemoteConfig: LayerRemoteConfig?): ThemeLayer? = layerRemoteConfig?.let {
-    ThemeLayer(
-        fill = this?.fill.updateFrom(it.color),
-        stroke = it.borderColor?.primaryColor ?: this?.stroke,
-        borderWidth = it.borderWidth?.valuePx ?: this?.borderWidth,
-        cornerRadius = it.cornerRadius?.valuePx ?: this?.cornerRadius
-    )
-} ?: this
+internal fun ThemeColor?.updateFrom(colorHex: String?): ThemeColor? =
+    parseColorOrNull(colorHex)?.let { ThemeColor(values = listOf(it)) } ?: this
 
-internal fun ThemeText?.updateFrom(textRemoteConfig: TextRemoteConfig?): ThemeText? = textRemoteConfig?.let {
-    ThemeText(
-        textColor = this?.textColor.updateFrom(it.textColor),
-        backgroundColor = this?.backgroundColor.updateFrom(it.backgroundColor),
-        textSize = it.fontSize ?: this?.textSize,
-        textStyle = it.fontStyle ?: this?.textStyle,
-        textAlignment = it.nativeAlignment ?: this?.textAlignment
-    )
-} ?: this
+internal fun ThemeColor?.updateFrom(colorStateList: ColorStateList?): ThemeColor? =
+    colorStateList?.let {
+        ThemeColor(values = listOf(it.defaultColor))
+    } ?: this
 
-internal fun ThemeText?.updateFrom(badgeRemoteConfig: BadgeRemoteConfig?): ThemeText? = badgeRemoteConfig?.let {
-    ThemeText(
-        textColor = this?.textColor.updateFrom(it.fontColor),
-        backgroundColor = this?.backgroundColor.updateFrom(it.backgroundColor),
-        textSize = it.fontSize ?: this?.textSize,
-        textStyle = it.fontStyle ?: this?.textStyle,
-        textAlignment = this?.textAlignment
-    )
-} ?: this
+internal fun ThemeLayer?.updateFrom(layerRemoteConfig: LayerRemoteConfig?): ThemeLayer? =
+    layerRemoteConfig?.let {
+        ThemeLayer(
+            fill = this?.fill.updateFrom(it.color),
+            stroke = it.borderColor?.primaryColor ?: this?.stroke,
+            borderWidth = it.borderWidth?.valuePx ?: this?.borderWidth,
+            cornerRadius = it.cornerRadius?.valuePx ?: this?.cornerRadius
+        )
+    } ?: this
 
-internal fun ThemeButton?.updateFrom(buttonRemoteConfig: ButtonRemoteConfig?) = buttonRemoteConfig?.let {
-    ThemeButton(
-        text = this?.text.updateFrom(it.textRemoteConfig),
-        background = this?.background.updateFrom(it.background),
-        iconColor = this?.iconColor.updateFrom(buttonRemoteConfig.tintColor),
-        elevation = it.elevation ?: this?.elevation,
-        shadowColor = it.shadowColor ?: this?.shadowColor
-    )
-} ?: this
+internal fun ThemeText?.updateFrom(textRemoteConfig: TextRemoteConfig?): ThemeText? =
+    textRemoteConfig?.let {
+        ThemeText(
+            textColor = this?.textColor.updateFrom(it.textColor),
+            backgroundColor = this?.backgroundColor.updateFrom(it.backgroundColor),
+            textSize = it.fontSize ?: this?.textSize,
+            textStyle = it.fontStyle ?: this?.textStyle,
+            textAlignment = it.nativeAlignment ?: this?.textAlignment
+        )
+    } ?: this
 
-internal fun ThemeHeader?.updateFrom(headerRemoteConfig: HeaderRemoteConfig?) = headerRemoteConfig?.let {
-    ThemeHeader(
-        text = this?.text.updateFrom(it.textRemoteConfig),
-        background = this?.background.updateFrom(it.background),
-        backButton = this?.backButton.updateFrom(it.backButtonRemoteConfig),
-        closeButton = this?.closeButton.updateFrom(it.closeButtonRemoteConfig),
-        endScreenSharingButton = this?.endScreenSharingButton.updateFrom(it.endScreenSharingButtonRemoteConfig),
-        endButton = this?.endButton.updateFrom(it.endButtonRemoteConfig),
-    )
-} ?: this
+internal fun ThemeText?.updateFrom(badgeRemoteConfig: BadgeRemoteConfig?): ThemeText? =
+    badgeRemoteConfig?.let {
+        ThemeText(
+            textColor = this?.textColor.updateFrom(it.fontColor),
+            backgroundColor = this?.backgroundColor.updateFrom(it.backgroundColor),
+            textSize = it.fontSize ?: this?.textSize,
+            textStyle = it.fontStyle ?: this?.textStyle,
+            textAlignment = this?.textAlignment
+        )
+    } ?: this
+
+internal fun ThemeButton?.updateFrom(buttonRemoteConfig: ButtonRemoteConfig?) =
+    buttonRemoteConfig?.let {
+        ThemeButton(
+            text = this?.text.updateFrom(it.textRemoteConfig),
+            background = this?.background.updateFrom(it.background),
+            iconColor = this?.iconColor.updateFrom(buttonRemoteConfig.tintColor),
+            elevation = it.elevation ?: this?.elevation,
+            shadowColor = it.shadowColor ?: this?.shadowColor
+        )
+    } ?: this
+
+internal fun ThemeHeader?.updateFrom(headerRemoteConfig: HeaderRemoteConfig?) =
+    headerRemoteConfig?.let {
+        ThemeHeader(
+            text = this?.text.updateFrom(it.textRemoteConfig),
+            background = this?.background.updateFrom(it.background),
+            backButton = this?.backButton.updateFrom(it.backButtonRemoteConfig),
+            closeButton = this?.closeButton.updateFrom(it.closeButtonRemoteConfig),
+            endScreenSharingButton = this?.endScreenSharingButton.updateFrom(it.endScreenSharingButtonRemoteConfig),
+            endButton = this?.endButton.updateFrom(it.endButtonRemoteConfig),
+        )
+    } ?: this
+
+//--------------------------------------------------------------------------------------------------
+//map from Runtime Config classes
+@Deprecated("this a part of deprecated UiTheme")
+internal fun ThemeLayer?.updateFrom(layerConfig: LayerConfiguration?): ThemeLayer? =
+    layerConfig?.let {
+        ThemeLayer(
+            fill = this?.fill.updateFrom(it.backgroundColor),
+            stroke = parseColorOrNull(it.borderColor) ?: this?.stroke,
+            borderWidth = it.borderWidth.toFloat(),
+            cornerRadius = it.cornerRadius.toFloat()
+        )
+    } ?: this
+
+@Deprecated("this a part of deprecated UiTheme")
+internal fun ThemeText?.updateFrom(textConfiguration: TextConfiguration?): ThemeText? =
+    textConfiguration?.let {
+        ThemeText(
+            textColor = this?.textColor.updateFrom(it.textColor),
+            backgroundColor = this?.backgroundColor,
+            textSize = it.textSize,
+            textStyle = if (it.isBold) Typeface.BOLD else this?.textStyle,
+            textAlignment = this?.textAlignment
+        )
+    } ?: this
+
+@Deprecated("this a part of deprecated UiTheme")
+internal fun ThemeButton?.updateFrom(buttonConfiguration: ButtonConfiguration?): ThemeButton? =
+    buttonConfiguration?.let {
+        ThemeButton(
+            text = this?.text.updateFrom(it.textConfiguration),
+            background = it.backgroundColor?.run {  ThemeLayer(fill = ThemeColor(values = listOf(defaultColor))) } ?: this?.background,
+            iconColor = this?.iconColor,
+            elevation = this?.elevation,
+            shadowColor = this?.shadowColor
+        )
+    } ?: this

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeColor.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeColor.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
+import android.graphics.drawable.GradientDrawable
 import android.os.Parcelable
 import androidx.annotation.ColorInt
 import kotlinx.parcelize.Parcelize
@@ -12,6 +13,12 @@ internal data class ThemeColor(
     val primaryColor: Int
         get() = values.first()
 
-    val valuesArray: Array<Int>
-        get() = values.toTypedArray()
+    val valuesArray: IntArray
+        get() = values.toIntArray()
+
+    fun asDrawable(): GradientDrawable = if (isGradient)
+        GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, valuesArray)
+    else
+        GradientDrawable().apply { setColor(primaryColor) }
+
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeLayer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeLayer.kt
@@ -1,14 +1,35 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
+import android.graphics.drawable.GradientDrawable
 import android.os.Parcelable
 import androidx.annotation.ColorInt
+import com.glia.widgets.di.Dependencies
 import kotlinx.parcelize.Parcelize
+import kotlin.math.roundToInt
 
 @Parcelize
 internal data class ThemeLayer(
-    val fill: ThemeColor?,
+    val fill: ThemeColor? = null,
     @ColorInt
-    val stroke: Int?, // Currently it is not possible to draw gradient stroke(change to ThemeColor in case of migrating to Jetpack Compose)
-    val borderWidth: Float?, // width in pixels
-    val cornerRadius: Float? //radius in pixels
-) : Parcelable
+    val stroke: Int? = null, // Currently it is not possible to draw gradient stroke(change to ThemeColor in case of migrating to Jetpack Compose)
+    val borderWidth: Float? = null, // width in pixels
+    val cornerRadius: Float? = null //radius in pixels
+) : Parcelable {
+
+    fun asDrawable(): GradientDrawable? = takeIf { it.fill != null && it.stroke != null }?.run {
+
+        val drawable: GradientDrawable = fill?.asDrawable() ?: GradientDrawable()
+
+        stroke?.also {
+            val borderWidth = borderWidth?.roundToInt() ?: Dependencies.getResourceProvider()
+                .convertDpToPixel(1f)
+                .roundToInt()
+
+            drawable.setStroke(borderWidth, it)
+        }
+
+        cornerRadius?.also { drawable.cornerRadius = it }
+
+        drawable
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeText.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ThemeText.kt
@@ -9,5 +9,5 @@ internal data class ThemeText(
     val backgroundColor: ThemeColor?,
     val textSize: Float?, // Size in SP
     val textStyle: Int?, //Typeface.NORMAL
-    val textAlignment: Int? //TextView.TEXT_ALIGNMENT_TEXT_START
+    val textAlignment: Int?, //TextView.TEXT_ALIGNMENT_TEXT_START
 ) : Parcelable

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyThemeMappers.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyThemeMappers.kt
@@ -1,5 +1,11 @@
 package com.glia.widgets.view.unifiedui.theme.survey
 
+import com.glia.widgets.view.configuration.OptionButtonConfiguration
+import com.glia.widgets.view.configuration.survey.BooleanQuestionConfiguration
+import com.glia.widgets.view.configuration.survey.InputQuestionConfiguration
+import com.glia.widgets.view.configuration.survey.ScaleQuestionConfiguration
+import com.glia.widgets.view.configuration.survey.SingleQuestionConfiguration
+import com.glia.widgets.view.configuration.survey.SurveyStyle
 import com.glia.widgets.view.unifiedui.config.survey.*
 import com.glia.widgets.view.unifiedui.theme.base.updateFrom
 
@@ -58,6 +64,70 @@ internal fun SurveyTheme?.updateFrom(surveyRemoteConfig: SurveyRemoteConfig?): S
         title = this?.title.updateFrom(it.title),
         submitButton = this?.submitButton.updateFrom(it.submitButtonRemoteConfig),
         cancelButton = this?.cancelButton.updateFrom(it.cancelButtonRemoteConfig),
+        booleanQuestion = this?.booleanQuestion.updateFrom(it.booleanQuestion),
+        scaleQuestion = this?.scaleQuestion.updateFrom(it.scaleQuestion),
+        singleQuestion = this?.singleQuestion.updateFrom(it.singleQuestion),
+        inputQuestion = this?.inputQuestion.updateFrom(it.inputQuestion)
+    )
+} ?: this
+
+internal fun ThemeOptionButton?.updateFrom(optionButtonConfiguration: OptionButtonConfiguration?): ThemeOptionButton? =
+    optionButtonConfiguration?.let {
+        ThemeOptionButton(
+            normalText = this?.normalText.updateFrom(it.normalText),
+            normalLayer = this?.normalLayer.updateFrom(it.normalLayer),
+            selectedText = this?.selectedText.updateFrom(it.selectedText),
+            selectedLayer = this?.selectedLayer.updateFrom(it.selectedLayer),
+            highlightedText = this?.highlightedText.updateFrom(it.highlightedText),
+            highlightedLayer = this?.highlightedLayer.updateFrom(it.highlightedLayer),
+            fontSize = this?.fontSize,
+            fontStyle = this?.fontStyle
+        )
+    } ?: this
+
+//mappers from old configs
+internal fun ThemeSurveyBooleanQuestion?.updateFrom(booleanQuestionConfiguration: BooleanQuestionConfiguration?): ThemeSurveyBooleanQuestion? =
+    booleanQuestionConfiguration?.let {
+        ThemeSurveyBooleanQuestion(
+            title = this?.title.updateFrom(it.title),
+            optionButton = this?.optionButton.updateFrom(it.optionButton)
+        )
+    } ?: this
+
+internal fun ThemeSurveyScaleQuestion?.updateFrom(scaleQuestionConfiguration: ScaleQuestionConfiguration?): ThemeSurveyScaleQuestion? =
+    scaleQuestionConfiguration?.let {
+        ThemeSurveyScaleQuestion(
+            title = this?.title.updateFrom(it.title),
+            optionButton = this?.optionButton.updateFrom(it.optionButton)
+        )
+    } ?: this
+
+internal fun ThemeSurveySingleQuestion?.updateFrom(singleQuestionConfiguration: SingleQuestionConfiguration?): ThemeSurveySingleQuestion? =
+    singleQuestionConfiguration?.let {
+        ThemeSurveySingleQuestion(
+            title = this?.title.updateFrom(it.title),
+            tintColor = this?.tintColor.updateFrom(it.tintColor),
+            option = this?.option.updateFrom(it.optionText)
+        )
+    } ?: this
+
+internal fun ThemeSurveyInputQuestion?.updateFrom(inputQuestionConfiguration: InputQuestionConfiguration?): ThemeSurveyInputQuestion? =
+    inputQuestionConfiguration?.let {
+        ThemeSurveyInputQuestion(
+            title = this?.title.updateFrom(it.title),
+            background = this?.background,
+            text = this?.text.updateFrom(it.title),
+            option = this?.option.updateFrom(it.optionButton)
+        )
+    } ?: this
+
+
+internal fun SurveyTheme?.updateFrom(surveyStyle: SurveyStyle?): SurveyTheme? = surveyStyle?.let {
+    SurveyTheme(
+        layer = this?.layer.updateFrom(it.layer),
+        title = this?.title.updateFrom(it.title),
+        submitButton = this?.submitButton.updateFrom(it.submitButton),
+        cancelButton = this?.cancelButton.updateFrom(it.cancelButton),
         booleanQuestion = this?.booleanQuestion.updateFrom(it.booleanQuestion),
         scaleQuestion = this?.scaleQuestion.updateFrom(it.scaleQuestion),
         singleQuestion = this?.singleQuestion.updateFrom(it.singleQuestion),


### PR DESCRIPTION
For now, I've only created mappers for the base config classes. I don't understand the parts of the old and new themes clearly, so I decided to start implementing screen-by-screen and add mappers according to what I find on specific screens.

**Jira issue:**
https://glia.atlassian.net/browse/MOB-1618

**Additional info:**

- Add mappers
- Add ViewBinding to project
- Add extension functions to apply the new theme to views

MOB-1618