### PR TITLE
Call Screen. Implement Remote configuration for remaining widgets

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallButtonLabelView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallButtonLabelView.kt
@@ -1,40 +1,19 @@
 package com.glia.widgets.call
 
 import android.content.Context
-import android.graphics.Typeface
 import android.util.AttributeSet
-import androidx.appcompat.widget.AppCompatTextView
-import com.glia.widgets.helper.Utils
 import com.glia.widgets.view.unifiedui.exstensions.applyTextTheme
-import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
-import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.glia.widgets.view.unifiedui.theme.call.BarButtonStatesTheme
 
 class CallButtonLabelView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
-    AppCompatTextView(context, attrs) {
+    ThemedStateText(context, attrs) {
 
-    private var defaultLabelTheme: TextTheme? = null
     private var barButtonStatesTheme: BarButtonStatesTheme? = null
-
-    init {
-        defaultLabelTheme = TextTheme(
-            textColor = ColorTheme(values = listOf(currentTextColor)),
-            backgroundColor = null,
-            textSize = Utils.pxToSp(context, textSize),
-            textStyle = typeface.style,
-            textAlignment = textAlignment
-        )
-    }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
         applyNewState()
-    }
-
-    override fun setTypeface(tf: Typeface?) {
-        tf?.apply { defaultLabelTheme = defaultLabelTheme?.copy(textStyle = style) }
-        super.setTypeface(tf)
     }
 
     override fun setEnabled(enabled: Boolean) {
@@ -55,10 +34,6 @@ class CallButtonLabelView @JvmOverloads constructor(context: Context, attrs: Att
         this.barButtonStatesTheme = barButtonStatesTheme
     }
 
-    private fun applyDefaultTheme() {
-        applyTextTheme(defaultLabelTheme)
-    }
-
     private fun applyNewState() {
         when {
             !isEnabled -> applyDisabledTheme()
@@ -68,15 +43,15 @@ class CallButtonLabelView @JvmOverloads constructor(context: Context, attrs: Att
     }
 
     private fun applyEnabledTheme() {
-        barButtonStatesTheme?.enabled?.title?.also(::applyTextTheme) ?: applyDefaultTheme()
+        barButtonStatesTheme?.enabled?.title?.also(::applyTextTheme) ?: restoreDefaultTheme()
     }
 
     private fun applyDisabledTheme() {
-        barButtonStatesTheme?.disabled?.title?.also(::applyTextTheme) ?: applyDefaultTheme()
+        barButtonStatesTheme?.disabled?.title?.also(::applyTextTheme) ?: restoreDefaultTheme()
     }
 
     private fun applyActivatedTheme() {
-        barButtonStatesTheme?.activated?.title?.also(::applyTextTheme) ?: applyDefaultTheme()
+        barButtonStatesTheme?.activated?.title?.also(::applyTextTheme) ?: restoreDefaultTheme()
     }
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
@@ -22,6 +22,8 @@ class CallState {
     public final Engagement.MediaType requestedMediaType;
     public final boolean isSpeakerOn;
     public final boolean isOnHold;
+    //    Need this to not update all views when only time is changed.
+    public final boolean isOnlyTimeChanged;
 
     @NonNull
     @Override
@@ -56,14 +58,15 @@ class CallState {
                 Objects.equals(companyName, callState.companyName) &&
                 Objects.equals(requestedMediaType, callState.requestedMediaType) &&
                 isSpeakerOn == callState.isSpeakerOn &&
-                isOnHold == callState.isOnHold;
+                isOnHold == callState.isOnHold &&
+                isOnlyTimeChanged == callState.isOnlyTimeChanged;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(integratorCallStarted, isVisible, messagesNotSeen,
                 callStatus, landscapeLayoutControlsVisible, isMuted, hasVideo,
-                companyName, requestedMediaType, isSpeakerOn, isOnHold);
+                companyName, requestedMediaType, isSpeakerOn, isOnHold, isOnlyTimeChanged);
     }
 
     public boolean showOperatorStatusView() {
@@ -241,6 +244,7 @@ class CallState {
                                     callStatus.getVisitorMediaState()
                             )
                     )
+                    .setOnlyTimeChanged(true)
                     .createCallState();
         } else if (isVideoCall()) {
             return new Builder()
@@ -254,6 +258,7 @@ class CallState {
                                     callStatus.getVisitorMediaState()
                             )
                     )
+                    .setOnlyTimeChanged(true)
                     .createCallState();
         } else if (isTransferring()) {
             return new Builder()
@@ -264,6 +269,7 @@ class CallState {
                                     callStatus.getVisitorMediaState()
                             )
                     )
+                    .setOnlyTimeChanged(true)
                     .createCallState();
         } else {
             return this;
@@ -282,6 +288,7 @@ class CallState {
                                     callStatus.getVisitorMediaState()
                             )
                     )
+                    .setOnlyTimeChanged(true)
                     .createCallState();
         } else {
             return this;
@@ -395,6 +402,8 @@ class CallState {
         private Engagement.MediaType requestedMediaType;
         private boolean isSpeakerOn;
         private boolean isOnHold;
+        //May be helpful when converting to Kotlin, as android studio makes fields nullable.
+        private boolean isOnlyTimeChanged = false;
 
         public Builder setIntegratorCallStarted(boolean integratorCallStarted) {
             this.integratorCallStarted = integratorCallStarted;
@@ -451,6 +460,11 @@ class CallState {
             return this;
         }
 
+        public Builder setOnlyTimeChanged(boolean isOnlyTimeChanged) {
+            this.isOnlyTimeChanged = isOnlyTimeChanged;
+            return this;
+        }
+
         public Builder copyFrom(CallState callState) {
             integratorCallStarted = callState.integratorCallStarted;
             isVisible = callState.isVisible;
@@ -463,6 +477,8 @@ class CallState {
             requestedMediaType = callState.requestedMediaType;
             isSpeakerOn = callState.isSpeakerOn;
             isOnHold = callState.isOnHold;
+            //as we are updating this field only when only time is changed, so needs to make it false every time.
+            isOnlyTimeChanged = false;
             return this;
         }
 
@@ -483,5 +499,6 @@ class CallState {
         this.requestedMediaType = builder.requestedMediaType;
         this.isSpeakerOn = builder.isSpeakerOn;
         this.isOnHold = builder.isOnHold;
+        this.isOnlyTimeChanged = builder.isOnlyTimeChanged;
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/ThemedStateText.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/ThemedStateText.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.call
+
+import android.content.Context
+import android.graphics.Typeface
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
+import com.glia.widgets.helper.Utils
+import com.glia.widgets.view.unifiedui.exstensions.applyTextTheme
+import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
+
+open class ThemedStateText @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null
+) : AppCompatTextView(context, attrs) {
+
+    private var defaultTheme: TextTheme? = null
+
+    init {
+        defaultTheme = TextTheme(
+            textColor = ColorTheme(values = listOf(currentTextColor)),
+            backgroundColor = null,
+            textSize = Utils.pxToSp(context, textSize),
+            textStyle = typeface.style,
+            textAlignment = textAlignment
+        )
+    }
+
+    override fun setTypeface(tf: Typeface?) {
+        tf?.apply { defaultTheme = defaultTheme?.copy(textStyle = style) }
+        super.setTypeface(tf)
+    }
+
+    fun restoreDefaultTheme() {
+        applyTextTheme(defaultTheme)
+    }
+
+    internal fun applyThemeAsDefault(theme: TextTheme?) {
+        theme.also(::applyTextTheme)?.also { defaultTheme = it }
+    }
+
+    internal fun applyThemeOrDefault(theme: TextTheme?) {
+        theme.also(::applyTextTheme) ?: restoreDefaultTheme()
+    }
+}
+

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/call/CallRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/call/CallRemoteConfig.kt
@@ -30,7 +30,7 @@ internal data class CallRemoteConfig(
     val topTextRemoteConfig: TextRemoteConfig?,
 
     @SerializedName("connect")
-    val connect: EngagementStatesRemoteConfig
+    val connect: EngagementStatesRemoteConfig?
 ) {
     fun toCallTheme(): CallTheme = CallTheme(
         background = background?.toLayerTheme(),
@@ -40,6 +40,6 @@ internal data class CallRemoteConfig(
         header = headerRemoteConfig?.toHeaderTheme(),
         operator = operator?.toTextTheme(),
         topText = topTextRemoteConfig?.toTextTheme(),
-        connect = connect.toEngagementStatesTheme()
+        connect = connect?.toEngagementStatesTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/chat/MessageBalloonRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/chat/MessageBalloonRemoteConfig.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.view.unifiedui.config.chat
 
-import com.glia.widgets.view.unifiedui.config.base.AlignmentTypeRemoteConfig
 import com.glia.widgets.view.unifiedui.config.base.LayerRemoteConfig
 import com.glia.widgets.view.unifiedui.config.base.TextRemoteConfig
 import com.glia.widgets.view.unifiedui.theme.chat.MessageBalloonTheme
@@ -16,9 +15,6 @@ internal data class MessageBalloonRemoteConfig(
     @SerializedName("status")
     val status: TextRemoteConfig?,
 
-    @SerializedName("alignment")
-    val alignmentTypeRemoteConfig: AlignmentTypeRemoteConfig?,
-
     @SerializedName("userImage")
     val userImageRemoteConfig: UserImageRemoteConfig?
 ) {
@@ -26,7 +22,6 @@ internal data class MessageBalloonRemoteConfig(
         background = background?.toLayerTheme(),
         text = textRemoteConfig?.toTextTheme(),
         status = status?.toTextTheme(),
-        alignment = alignmentTypeRemoteConfig?.nativeAlignment,
         userImage = userImageRemoteConfig?.toUserImageTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/MessageBalloonTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/MessageBalloonTheme.kt
@@ -7,6 +7,5 @@ internal data class MessageBalloonTheme(
     val background: LayerTheme?,
     val text: TextTheme?,
     val status: TextTheme?,
-    val alignment: Int?,
     val userImage: UserImageTheme?
 )

--- a/widgetssdk/src/main/res/layout-land/call_view.xml
+++ b/widgetssdk/src/main/res/layout-land/call_view.xml
@@ -39,7 +39,7 @@
         app:layout_constraintVertical_bias="0.350"
         app:rippleTint="@color/glia_base_light_color" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/connecting_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -54,7 +54,7 @@
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toBottomOf="@id/operator_status_view" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/operator_name_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -69,7 +69,7 @@
         app:layout_constraintTop_toBottomOf="@id/operator_status_view"
         app:layout_goneMarginTop="@dimen/glia_call_operator_name_gone_margin_top" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/on_hold_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -109,7 +109,7 @@
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toBottomOf="@id/company_name_view" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/call_timer_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/widgetssdk/src/main/res/layout/call_view.xml
+++ b/widgetssdk/src/main/res/layout/call_view.xml
@@ -59,7 +59,7 @@
         app:layout_constraintTop_toBottomOf="@id/top_app_bar"
         app:rippleTint="@color/glia_base_light_color" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/connecting_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -74,7 +74,7 @@
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toBottomOf="@id/operator_status_view" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/operator_name_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -89,7 +89,7 @@
         app:layout_constraintTop_toBottomOf="@id/operator_status_view"
         app:layout_goneMarginTop="@dimen/glia_call_operator_name_gone_margin_top" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/on_hold_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -129,7 +129,7 @@
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toBottomOf="@id/company_name_view" />
 
-    <TextView
+    <com.glia.widgets.call.ThemedStateText
         android:id="@+id/call_timer_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
- Implement Remote `Configuration` for remaining widgets on `Call` screen
- Update `MessageBalloonRemoteConfig.kt`
- Add Custom view to ease theme management for different states
- Add `CallState.isOnlyTimeChanged` parameter to avoid entire view re-rendering on timer update

MOB-1649

**Jira issue:**
https://glia.atlassian.net/browse/MOB-1649
