### PR TITLE
Fix incorrect changelog in release process

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -284,6 +284,29 @@ workflows:
 
             ./gradlew clean
             widgetssdk:publishReleasePublicationToSonatypeRepository
+    - git-tag@1:
+        inputs:
+        - tag: $NEW_VERSION
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            # fail if any commands fails
+
+            set -e
+
+            # make pipelines' return status equal the last command to exit with
+            a non-zero status, or zero if all commands exit successfully
+
+            set -o pipefail
+
+            # debug log
+
+            set -x
+
+
+            git fetch --tags
     - generate-changelog@0: {}
     - github-release@0:
         inputs:


### PR DESCRIPTION
The changelog was incorrectly generated before the new tag was created, so the changelog showed old commits. Two new steps have been added: one generates a new tag according to the value saved in $NEW_VERSION on workflow trigger, and another after it fetches all tags. This makes the changelog generation step aware of the new tag and generates it correctly.

MOB-1680