### PR TITLE
Do not replace default color with null for Alert Dialog close icon

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ViewExstensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ViewExstensions.kt
@@ -204,7 +204,7 @@ internal fun ImageView.applyButtonTheme(buttonTheme: ButtonTheme?) {
 }
 
 internal fun ImageView.applyImageColorTheme(colorTheme: ColorTheme?) {
-    colorTheme?.primaryColorStateList.also(::setImageTintList)
+    colorTheme?.primaryColorStateList?.also(::setImageTintList)
 }
 
 internal fun FloatingActionButton.applyBarButtonStatesTheme(barButtonStatesTheme: BarButtonStatesTheme?) {


### PR DESCRIPTION
[MOB-1663](https://glia.atlassian.net/browse/MOB-1663)

**Additional info:**
Close icon in Alert Dialog view is currently invisible. This PR should fix the issue.

**Screenshots:**
Expected:

<img width="273" alt="Screenshot 2022-12-27 at 17 21 34" src="https://user-images.githubusercontent.com/57521863/209687135-a91b1d1b-a76f-48e9-b7cf-3357e2025d23.png">

Actual:

<img width="273" alt="Screenshot 2022-12-27 at 17 22 45" src="https://user-images.githubusercontent.com/57521863/209687138-d65dc7dd-96a3-4e75-a075-a3bc99eae282.png">
