### PR TITLE
Add unavailable status to secure conversations welcome screen

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/GliaQueueRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/GliaQueueRepository.java
@@ -7,6 +7,7 @@ import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.Glia;
 import com.glia.androidsdk.GliaException;
 import com.glia.androidsdk.RequestCallback;
+import com.glia.androidsdk.queuing.Queue;
 import com.glia.androidsdk.queuing.QueueTicket;
 import com.glia.widgets.core.queue.model.GliaQueueingState;
 import com.glia.widgets.di.GliaCore;
@@ -156,5 +157,13 @@ public class GliaQueueRepository {
         };
     }
 
-
+    /**
+     * Emits a list of all Queues
+     */
+    public Single<Queue[]> getQueues() {
+        return Single.create(emitter -> {
+            RequestCallback<Queue[]> requestCallback = (queues, e) -> emitter.onSuccess(queues);
+            gliaCore.getQueues(requestCallback);
+        });
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversations.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversations.kt
@@ -1,9 +1,12 @@
 package com.glia.widgets.core.secureconversations
 
+import android.net.Uri
 import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.secureconversations.SecureConversations
 import com.glia.androidsdk.chat.VisitorMessage
+import com.glia.androidsdk.engagement.EngagementFile
+import java.io.File
 
 /**
  * Wrapper class for {@link com.glia.androidsdk.secureconversations.SecureConversations}
@@ -17,12 +20,20 @@ class SecureConversations(private val secureConversations: SecureConversations) 
     override fun send(
         message: String,
         queueIds: Array<String>,
-        callback: RequestCallback<VisitorMessage>
+        callback: RequestCallback<VisitorMessage?>
     ) {
         secureConversations.send(message, queueIds, callback)
     }
 
     override fun markMessagesRead(callback: RequestCallback<Void>?) {
         secureConversations.markMessagesRead(callback)
+    }
+
+    override fun uploadFile(file: File, callback: RequestCallback<EngagementFile>) {
+        secureConversations.uploadFile(file, callback)
+    }
+
+    override fun uploadFile(fileUri: Uri, callback: RequestCallback<EngagementFile>) {
+        secureConversations.uploadFile(fileUri, callback)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
@@ -1,0 +1,19 @@
+package com.glia.widgets.core.secureconversations
+
+import com.glia.androidsdk.RequestCallback
+import com.glia.androidsdk.chat.ChatMessage
+import com.glia.androidsdk.chat.VisitorMessage
+
+class SecureConversationsRepository(private val secureConversations: SecureConversations) {
+    fun fetchChatTranscript(callback: RequestCallback<Array<ChatMessage>>?) {
+        secureConversations.fetchChatTranscript(callback)
+    }
+
+    fun send(message: String, queueIds: Array<String>, callback: RequestCallback<VisitorMessage?>) {
+        secureConversations.send(message, queueIds, callback)
+    }
+
+    fun markMessagesRead(callback: RequestCallback<Void>?) {
+        secureConversations.markMessagesRead(callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/FetchChatTranscriptUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/FetchChatTranscriptUseCase.kt
@@ -1,0 +1,16 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.androidsdk.RequestCallback
+import com.glia.androidsdk.chat.ChatMessage
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+
+class FetchChatTranscriptUseCase(
+    private val secureConversationsRepository: SecureConversationsRepository
+) {
+
+    fun execute(
+        callback: RequestCallback<Array<ChatMessage>>
+    ) {
+        secureConversationsRepository.fetchChatTranscript(callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/IsMessageCenterAvailableUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/IsMessageCenterAvailableUseCase.kt
@@ -1,0 +1,46 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import androidx.annotation.VisibleForTesting
+import com.glia.androidsdk.Engagement
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.RequestCallback
+import com.glia.androidsdk.queuing.Queue
+import com.glia.androidsdk.queuing.QueueState
+import com.glia.widgets.core.queue.GliaQueueRepository
+import com.glia.widgets.helper.rx.Schedulers
+import io.reactivex.disposables.CompositeDisposable
+
+class IsMessageCenterAvailableUseCase(
+    private val queueId: String,
+    private val queueRepository: GliaQueueRepository,
+    private val schedulers: Schedulers
+) {
+    private val disposable = CompositeDisposable()
+
+    fun execute(callback: RequestCallback<Boolean>) {
+        disposable.add(
+            queueRepository.queues
+                .subscribeOn(schedulers.computationScheduler)
+                .observeOn(schedulers.mainScheduler)
+                .subscribe(
+                    { queues ->
+                        callback.onResult(containsMessagingQueue(queues), null)
+                    },
+                    { error -> callback.onResult(null, GliaException.from(error)) })
+        )
+    }
+
+    @VisibleForTesting
+    fun containsMessagingQueue(queues: Array<Queue>): Boolean {
+        val messagingQueues = queues
+            .filter { queue -> queue.id == queueId }
+            .filterNot { queue -> queue.state.status == QueueState.Status.CLOSED }
+            .filterNot { queue -> queue.state.status == QueueState.Status.UNKNOWN }
+            .filter { queue -> queue.state.medias.any { media -> media == Engagement.MediaType.MESSAGING } }
+        return messagingQueues.isNotEmpty()
+    }
+
+    fun dispose() {
+        disposable.clear()
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadUseCase.kt
@@ -1,0 +1,15 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+
+class MarkMessagesReadUseCase(
+    private val secureConversationsRepository: SecureConversationsRepository
+) {
+
+    fun execute(
+        callback: RequestCallback<Void>
+    ) {
+        secureConversationsRepository.markMessagesRead(callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SendSecureMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SendSecureMessageUseCase.kt
@@ -2,13 +2,18 @@ package com.glia.widgets.core.secureconversations.domain
 
 import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.chat.VisitorMessage
-import com.glia.widgets.GliaWidgets
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
 
-class SendSecureMessageUseCase(val queueId: String) {
-    fun execute(message: String,
-                callback: RequestCallback<VisitorMessage?>
+class SendSecureMessageUseCase(
+    private val queueId: String,
+    private val secureConversationsRepository: SecureConversationsRepository
+) {
+
+    fun execute(
+        message: String,
+        callback: RequestCallback<VisitorMessage?>
     ) {
         val queueIds = arrayOf(queueId)
-        GliaWidgets.getSecureConversations().send(message, queueIds, callback)
+        secureConversationsRepository.send(message, queueIds, callback)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -7,7 +7,6 @@ import com.glia.widgets.chat.controller.ChatController;
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager;
 import com.glia.widgets.core.dialog.DialogController;
 import com.glia.widgets.core.screensharing.ScreenSharingController;
-import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase;
 import com.glia.widgets.filepreview.ui.FilePreviewController;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.TimeCounter;
@@ -269,6 +268,9 @@ public class ControllerFactory {
     }
 
     public MessageCenterContract.Controller getMessageCenterController(String queueId) {
-        return new MessageCenterController(new SendSecureMessageUseCase(queueId));
+        return new MessageCenterController(
+                useCaseFactory.createSendSecureMessageUseCase(queueId),
+                useCaseFactory.createIsMessageCenterAvailableUseCase(queueId)
+                );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -13,6 +13,8 @@ import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepository;
 import com.glia.widgets.core.operator.GliaOperatorMediaRepository;
 import com.glia.widgets.core.queue.GliaQueueRepository;
 import com.glia.widgets.core.screensharing.data.GliaScreenSharingRepository;
+import com.glia.widgets.core.secureconversations.SecureConversations;
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository;
 import com.glia.widgets.core.survey.GliaSurveyRepository;
 import com.glia.widgets.core.visitor.GliaVisitorMediaRepository;
 import com.glia.widgets.filepreview.data.GliaFileRepository;
@@ -24,6 +26,7 @@ public class RepositoryFactory {
 
     private MediaUpgradeOfferRepository mediaUpgradeOfferRepository;
     private ChatScreenRepository chatScreenRepository;
+    private static SecureConversationsRepository secureConversationsRepository;
     private static GliaEngagementRepository gliaEngagementRepository;
     private static GliaVisitorMediaRepository gliaVisitorMediaRepository;
     private static GliaOperatorMediaRepository gliaOperatorMediaRepository;
@@ -150,5 +153,13 @@ public class RepositoryFactory {
         }
 
         return operatorRepository;
+    }
+
+    public SecureConversationsRepository getSecureConversationsRepository() {
+        if (secureConversationsRepository == null) {
+            SecureConversations secureConversations = new GliaCoreImpl().getSecureConversations();
+            secureConversationsRepository = new SecureConversationsRepository(secureConversations);
+        }
+        return secureConversationsRepository;
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -35,6 +35,10 @@ import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
 import com.glia.widgets.core.engagement.domain.MapOperatorUseCase;
 import com.glia.widgets.core.queue.domain.QueueTicketStateChangeToUnstaffedUseCase;
+import com.glia.widgets.core.secureconversations.domain.FetchChatTranscriptUseCase;
+import com.glia.widgets.core.secureconversations.domain.IsMessageCenterAvailableUseCase;
+import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadUseCase;
+import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase;
 import com.glia.widgets.core.survey.domain.GliaSurveyUseCase;
 import com.glia.widgets.core.engagement.domain.ShouldShowMediaEngagementViewUseCase;
 import com.glia.widgets.core.fileupload.domain.AddFileAttachmentsObserverUseCase;
@@ -439,5 +443,24 @@ public class UseCaseFactory {
 
     public QueueTicketStateChangeToUnstaffedUseCase createQueueTicketStateChangeToUnstaffedUseCase() {
         return new QueueTicketStateChangeToUnstaffedUseCase(repositoryFactory.getGliaQueueRepository());
+    }
+
+    public SendSecureMessageUseCase createSendSecureMessageUseCase(String queueId) {
+        return new SendSecureMessageUseCase(queueId, repositoryFactory.getSecureConversationsRepository());
+    }
+
+    public IsMessageCenterAvailableUseCase createIsMessageCenterAvailableUseCase(String queueId) {
+        return new IsMessageCenterAvailableUseCase(
+                queueId,
+                repositoryFactory.getGliaQueueRepository(),
+                schedulers);
+    }
+
+    public FetchChatTranscriptUseCase createFetchChatTranscriptUseCase() {
+        return new FetchChatTranscriptUseCase(repositoryFactory.getSecureConversationsRepository());
+    }
+
+    public MarkMessagesReadUseCase createMarkMessagesReadUseCase() {
+        return new MarkMessagesReadUseCase(repositoryFactory.getSecureConversationsRepository());
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.messagecenter
 
+import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.base.BaseController
 import com.glia.widgets.base.BaseView
 
@@ -14,6 +15,7 @@ interface MessageCenterContract {
         fun onGalleryClicked()
         fun onBrowseClicked()
         fun onTakePhotoClicked()
+        fun isMessageCenterAvailable(callback: RequestCallback<Boolean>)
     }
 
     interface View : BaseView<Controller> {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
@@ -1,12 +1,15 @@
 package com.glia.widgets.messagecenter
 
+import androidx.annotation.VisibleForTesting
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.chat.VisitorMessage
+import com.glia.widgets.core.secureconversations.domain.IsMessageCenterAvailableUseCase
 import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase
 
 class MessageCenterController(
-    private val sendSecureMessageUseCase: SendSecureMessageUseCase
+    private val sendSecureMessageUseCase: SendSecureMessageUseCase,
+    private val isMessageCenterAvailableUseCase: IsMessageCenterAvailableUseCase
 ) : MessageCenterContract.Controller {
     private var view: MessageCenterContract.View? = null
 
@@ -21,19 +24,24 @@ class MessageCenterController(
     override fun onSendMessageClicked(message: String) {
         val callback =
             RequestCallback { _: VisitorMessage?, gliaException: GliaException? ->
-                if (gliaException == null) {
-                    view?.navigateToMessaging()
-                } else {
-                    when (gliaException.cause) {
-                        GliaException.Cause.AUTHENTICATION_ERROR -> view?.showMessageCenterUnavailableDialog()
-                        GliaException.Cause.INTERNAL_ERROR -> view?.showUnexpectedErrorDialog()
-                        else -> {
-                            view?.showUnexpectedErrorDialog()
-                        }
-                    }
-                }
+                handleSendMessageResult(gliaException)
             }
         sendSecureMessageUseCase.execute(message, callback)
+    }
+
+    @VisibleForTesting
+    fun handleSendMessageResult(gliaException: GliaException?) {
+        if (gliaException == null) {
+            view?.navigateToMessaging()
+        } else {
+            when (gliaException.cause) {
+                GliaException.Cause.AUTHENTICATION_ERROR -> view?.showMessageCenterUnavailableDialog()
+                GliaException.Cause.INTERNAL_ERROR -> view?.showUnexpectedErrorDialog()
+                else -> {
+                    view?.showUnexpectedErrorDialog()
+                }
+            }
+        }
     }
 
     override fun onBackArrowClicked() {
@@ -60,5 +68,11 @@ class MessageCenterController(
         TODO("Not yet implemented")
     }
 
-    override fun onDestroy() {}
+    override fun isMessageCenterAvailable(callback: RequestCallback<Boolean>) {
+        isMessageCenterAvailableUseCase.execute(callback)
+    }
+
+    override fun onDestroy() {
+        isMessageCenterAvailableUseCase.dispose()
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -3,8 +3,7 @@ package com.glia.widgets.view
 import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
-import android.view.LayoutInflater
-import android.view.View
+import android.view.*
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
@@ -75,6 +74,7 @@ object Dialogs {
         //With setView(int layoutResId) GliaNegativeButton and GliaPositiveButton didn't get the right themes
         .setView(LayoutInflater.from(context).inflate(layoutRes, null))
         .setCancelable(cancelable)
+        .setBackgroundInsetBottom(Dependencies.getResourceProvider().convertDpToIntPixel(24f))
         .show()
         .also { setDialogBackground(it, backgroundTint) }
         .also(onLayout)
@@ -332,5 +332,45 @@ object Dialogs {
                     ?.also(::setImageTintList)
             }
         }
+    }
+
+    fun showMessageCenterUnavailableDialog(
+        context: Context,
+        theme: UiTheme
+    ): AlertDialog {
+        val baseDarkColor = theme.baseDarkColor?.let { ContextCompat.getColor(context, it) }
+        val fontFamily = theme.fontRes?.let { ResourcesCompat.getFont(context, it) }
+
+        val alertDialog = showDialog(context, R.layout.alert_dialog, theme.baseLightColor, false) {
+            findViewById<TextView>(R.id.dialog_title_view).apply {
+                setText(R.string.glia_dialog_message_center_unavailable_title)
+                baseDarkColor?.also(::setTextColor)
+                fontFamily?.also(::setTypeface)
+                alertTheme?.title.also(::applyTextTheme)
+            }
+            findViewById<TextView>(R.id.dialog_message_view).apply {
+                setText(R.string.glia_dialog_message_center_unavailable_message)
+                baseDarkColor?.also(::setTextColor)
+                fontFamily?.also(::setTypeface)
+                alertTheme?.message.also(::applyTextTheme)
+            }
+            findViewById<ImageButton>(R.id.close_dialog_button).apply {
+                visibility = View.INVISIBLE
+            }
+        }
+
+        val window = alertDialog.window
+        window?.setGravity(Gravity.BOTTOM)
+        enableOutsideTouch(window)
+
+        return alertDialog
+    }
+
+    private fun enableOutsideTouch(window: Window?) {
+        window?.setFlags(
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+        )
+        window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
     }
 }

--- a/widgetssdk/src/main/res/layout/message_center_view.xml
+++ b/widgetssdk/src/main/res/layout/message_center_view.xml
@@ -87,6 +87,12 @@
         app:layout_constraintBottom_toTopOf="@id/message_title"
         app:layout_constraintHorizontal_bias="0.0"/>
 
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/send_message_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:constraint_referenced_ids="message_title,add_attachment_button,message_edit_text, attachments_recycler_view, btn_send_message" />
+
     <TextView
         android:id="@+id/message_title"
         android:layout_width="wrap_content"

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/IsMessageCenterAvailableUseCaseTest.java
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/IsMessageCenterAvailableUseCaseTest.java
@@ -1,0 +1,146 @@
+package com.glia.widgets.core.secureconversations.domain;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.glia.androidsdk.Engagement;
+import com.glia.androidsdk.queuing.Queue;
+import com.glia.androidsdk.queuing.QueueState;
+import com.glia.widgets.core.queue.GliaQueueRepository;
+import com.glia.widgets.helper.rx.Schedulers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class IsMessageCenterAvailableUseCaseTest {
+    private IsMessageCenterAvailableUseCase isMessageCenterAvailableUseCase;
+
+    // Media types
+    private final Engagement.MediaType[] mediaTypesWithMessaging = {
+            Engagement.MediaType.TEXT,
+            Engagement.MediaType.MESSAGING};
+    private final Engagement.MediaType[] mediaTypesWithoutMessaging = {
+            Engagement.MediaType.TEXT,
+            Engagement.MediaType.AUDIO};
+
+    // Queues
+    private final Queue audioQueue = new Queue(
+            "audioQueueId",
+            "Audio Queue",
+            QueueState.Status.OPEN,
+            mediaTypesWithoutMessaging,
+            false);
+    private final Queue videoQueue = new Queue(
+            "videoQueueId",
+            "Video Queue",
+            QueueState.Status.OPEN,
+            mediaTypesWithoutMessaging,
+            false);
+
+    @Before
+    public void setUp() {
+        isMessageCenterAvailableUseCase = new IsMessageCenterAvailableUseCase(
+                "messagingQueueId",
+                mock(GliaQueueRepository.class),
+                mock(Schedulers.class));
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsTrue_QueueIdExistMediaTypeMessaging() {
+        Queue messagingQueue = new Queue(
+                "messagingQueueId",
+                "Messaging Queue",
+                QueueState.Status.OPEN,
+                mediaTypesWithMessaging,
+                false);
+        Queue[] queues = {audioQueue, messagingQueue, videoQueue};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertTrue(isMessageCenterAvailable);
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsFalse_QueueIdDoesNotExistMediaTypeMessaging() {
+        Queue queueMessagingIdNotFromUseCase = new Queue(
+                "messagingQueueIdNotFromUseCase",
+                "Messaging Queue",
+                QueueState.Status.OPEN,
+                mediaTypesWithMessaging,
+                false);
+        Queue[] queues = {audioQueue, queueMessagingIdNotFromUseCase, videoQueue};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertFalse(isMessageCenterAvailable);
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsFalse_QueueIdExistButNoMediaTypeMessaging() {
+        Queue queueWithoutMessagingIdFromUseCase = new Queue(
+                "messagingQueueId",
+                "Messaging Queue",
+                QueueState.Status.OPEN,
+                mediaTypesWithoutMessaging,
+                false);
+        Queue[] queues = {audioQueue, queueWithoutMessagingIdFromUseCase, videoQueue};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertFalse(isMessageCenterAvailable);
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsTrue_QueueUnstaffed() {
+        Queue queueWithMessagingIdFromUseCaseUnstaffed = new Queue(
+                "messagingQueueId",
+                "Messaging Queue",
+                QueueState.Status.UNSTAFFED,
+                mediaTypesWithMessaging,
+                false);
+        Queue[] queues = {audioQueue, queueWithMessagingIdFromUseCaseUnstaffed, videoQueue};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertTrue(isMessageCenterAvailable);
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsTrue_QueueFull() {
+        Queue queueWithMessagingIdFromUseCaseFull = new Queue(
+                "messagingQueueId",
+                "Messaging Queue",
+                QueueState.Status.FULL,
+                mediaTypesWithMessaging,
+                false);
+        Queue[] queues = {audioQueue, queueWithMessagingIdFromUseCaseFull, videoQueue};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertTrue(isMessageCenterAvailable);
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsFalse_QueueClosed() {
+        Queue queueWithMessagingIdFromUseCaseClosed = new Queue(
+                "messagingQueueId",
+                "Messaging Queue",
+                QueueState.Status.CLOSED,
+                mediaTypesWithMessaging,
+                false);
+        Queue[] queues = {audioQueue, queueWithMessagingIdFromUseCaseClosed, videoQueue};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertFalse(isMessageCenterAvailable);
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsFalse_QueueStateUnknown() {
+        Queue queueWithMessagingIdFromUseCaseUnknown = new Queue(
+                "messagingQueueId",
+                "Messaging Queue",
+                QueueState.Status.UNKNOWN,
+                mediaTypesWithMessaging,
+                false);
+        Queue[] queues = {audioQueue, queueWithMessagingIdFromUseCaseUnknown, videoQueue};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertFalse(isMessageCenterAvailable);
+    }
+
+    @Test
+    public void containsMessagingQueue_ReturnsFalse_QueuesEmpty() {
+        Queue[] queues = {};
+        boolean isMessageCenterAvailable = isMessageCenterAvailableUseCase.containsMessagingQueue(queues);
+        assertFalse(isMessageCenterAvailable);
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
@@ -1,0 +1,55 @@
+package com.glia.widgets.messagecenter
+
+import com.glia.androidsdk.GliaException
+import com.glia.widgets.core.secureconversations.domain.IsMessageCenterAvailableUseCase
+import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+
+internal class MessageCenterControllerTest {
+    private lateinit var messageCenterController: MessageCenterController
+    private lateinit var sendSecureMessageUseCase: SendSecureMessageUseCase
+    private lateinit var isMessageCenterAvailableUseCase: IsMessageCenterAvailableUseCase
+    private lateinit var viewContract: MessageCenterContract.View
+
+    @Before
+    fun setUp() {
+        sendSecureMessageUseCase = Mockito.mock(SendSecureMessageUseCase::class.java)
+        isMessageCenterAvailableUseCase = Mockito.mock(
+            IsMessageCenterAvailableUseCase::class.java
+        )
+        messageCenterController =
+            MessageCenterController(sendSecureMessageUseCase, isMessageCenterAvailableUseCase)
+        viewContract = Mockito.mock(MessageCenterContract.View::class.java)
+        messageCenterController.setView(viewContract)
+    }
+
+    @Test
+    fun handleMessageSendResult_CallsNavigateToMessaging_WhenErrorNull() {
+        messageCenterController.handleSendMessageResult(null)
+        Mockito.verify(viewContract, Mockito.times(1)).navigateToMessaging()
+    }
+
+    @Test
+    fun handleMessageSendResult_CallsNavigateToMessaging_WhenAuthError() {
+        val gliaException = GliaException("Message", GliaException.Cause.AUTHENTICATION_ERROR)
+        messageCenterController.handleSendMessageResult(gliaException)
+        Mockito.verify(viewContract, Mockito.times(1)).showMessageCenterUnavailableDialog()
+    }
+
+    @Test
+    fun handleMessageSendResult_CallsNavigateToMessaging_WhenInternalError() {
+        val gliaException = GliaException("Message", GliaException.Cause.INTERNAL_ERROR)
+        messageCenterController.handleSendMessageResult(gliaException)
+        Mockito.verify(viewContract, Mockito.times(1)).showUnexpectedErrorDialog()
+    }
+
+    @Test
+    fun handleMessageSendResult_CallsNavigateToMessaging_WhenOtherError() {
+        val gliaException = GliaException("Message", GliaException.Cause.INVALID_INPUT)
+        messageCenterController.handleSendMessageResult(gliaException)
+        Mockito.verify(viewContract, Mockito.times(1)).showUnexpectedErrorDialog()
+    }
+}


### PR DESCRIPTION
[MOB-1725](https://glia.atlassian.net/browse/MOB-1725)

**Additional info:**
Add unavailable status to secure conversations welcome screen:

- сheck if secure conversations feature is available
- hide views if unavailable
- show alert if unavailable

**Screenshots:**

https://user-images.githubusercontent.com/57521863/210087931-e9094a0e-ea3c-4f63-9fcf-9f3cf5613a23.mov



[MOB-1725]: https://glia.atlassian.net/browse/MOB-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ