### PR TITLE
Fix nullable operator image issue

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -623,7 +623,7 @@ class ChatController(
         viewCallback?.minimizeView()
     }
 
-    private fun operatorConnected(operatorName: String, profileImgUrl: String) {
+    private fun operatorConnected(operatorName: String, profileImgUrl: String?) {
         val items: MutableList<ChatItem> = chatState.chatItems.toMutableList()
         if (chatState.operatorStatusItem != null) {
             // remove previous operator status item
@@ -654,7 +654,7 @@ class ChatController(
         emitChatItems(chatState.changeItems(items))
     }
 
-    private fun operatorChanged(operatorName: String, profileImgUrl: String) {
+    private fun operatorChanged(operatorName: String, profileImgUrl: String?) {
         val items: MutableList<ChatItem> = chatState.chatItems.toMutableList()
         val operatorStatusItem = OperatorStatusItem.OperatorJoinedStatusItem(
             chatState.companyName,

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class Utils {
+    @Nullable
     public static String getOperatorImageUrl(Operator operator) {
         return operator.getPicture() != null ? operator.getPicture().getURL().orElse(null) : null;
     }


### PR DESCRIPTION
After migration to Kotlin, the support for the operator picture being nullable was lost in one place. Because of that in case of the operator not having an image (as in acceptance tests) the chat state does not get updated on the engagement start
