### PR TITLE
Auto accept Call Visualizer engagement

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import com.glia.androidsdk.GliaConfig;
 import com.glia.androidsdk.GliaException;
 import com.glia.androidsdk.RequestCallback;
+import com.glia.androidsdk.omnibrowse.Omnibrowse;
 import com.glia.androidsdk.visitor.Authentication;
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest;
 import com.glia.widgets.chat.adapter.CustomCardAdapter;
@@ -137,6 +138,7 @@ public class GliaWidgets {
         Dependencies.glia().init(createGliaConfig(gliaWidgetsConfig));
         Dependencies.init();
         Dependencies.getGliaThemeManager().applyJsonConfig(gliaWidgetsConfig.getUiJsonRemoteConfig());
+        listenCallVisualizerEvents();
         Logger.d(TAG, "init");
     }
 
@@ -161,6 +163,23 @@ public class GliaWidgets {
         } else {
             throw new RuntimeException("Site key or app token is missing");
         }
+    }
+
+    private static void listenCallVisualizerEvents() {
+        Dependencies.glia().getCallVisualizer().on(Omnibrowse.Events.ENGAGEMENT_REQUEST, engagementRequest -> {
+            Consumer<GliaException> onResult = error -> {
+                if (error != null) {
+                    Logger.e(TAG, "Error during accepting engagement request, reason" + error.getMessage());
+                } else {
+                    Logger.d(TAG, "Incoming Call Visualizer engagement auto accepted");
+                }
+            };
+            engagementRequest.accept((String) null, onResult);
+        });
+
+        Dependencies.glia().getCallVisualizer().on(Omnibrowse.Events.ENGAGEMENT, engagement -> {
+            Logger.d(TAG, "New Call Visualizer engagement started");
+        });
     }
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.java
@@ -16,6 +16,7 @@ import com.glia.androidsdk.chat.ChatMessage;
 import com.glia.androidsdk.comms.EngagementOptions;
 import com.glia.androidsdk.engagement.Survey;
 import com.glia.androidsdk.fcm.PushNotifications;
+import com.glia.androidsdk.omnibrowse.Omnibrowse;
 import com.glia.androidsdk.queuing.Queue;
 import com.glia.androidsdk.queuing.QueueTicket;
 import com.glia.androidsdk.site.SiteInfo;
@@ -93,4 +94,6 @@ public interface GliaCore {
     void getOperator(@NonNull String operatorId, @NonNull RequestCallback<Operator> callback);
 
     Authentication getAuthentication(@NonNull Authentication.Behavior behavior);
+
+    Omnibrowse getCallVisualizer();
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.java
@@ -16,6 +16,7 @@ import com.glia.androidsdk.chat.ChatMessage;
 import com.glia.androidsdk.comms.EngagementOptions;
 import com.glia.androidsdk.engagement.Survey;
 import com.glia.androidsdk.fcm.PushNotifications;
+import com.glia.androidsdk.omnibrowse.Omnibrowse;
 import com.glia.androidsdk.queuing.Queue;
 import com.glia.androidsdk.queuing.QueueTicket;
 import com.glia.androidsdk.site.SiteInfo;
@@ -185,5 +186,10 @@ class GliaCoreImpl implements GliaCore {
     @Override
     public Authentication getAuthentication(@NonNull Authentication.Behavior behavior) {
         return new Authentication(Glia.authentication(behavior));
+    }
+
+    @Override
+    public Omnibrowse getCallVisualizer() {
+        return Glia.omnibrowse;
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.java
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.java
@@ -3,6 +3,7 @@ package com.glia.widgets;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import android.app.Application;
 import android.content.Context;
@@ -11,6 +12,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 
 import com.glia.androidsdk.GliaConfig;
 import com.glia.androidsdk.SiteApiKey;
+import com.glia.androidsdk.omnibrowse.Omnibrowse;
 import com.glia.widgets.di.ControllerFactory;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.di.GliaCore;
@@ -58,6 +60,8 @@ public class GliaWidgetsTest {
                 .setRegion(region)
                 .setContext(context)
                 .build();
+        Omnibrowse callVisualizer = mock(Omnibrowse.class);
+        when(gliaCore.getCallVisualizer()).thenReturn(callVisualizer);
 
         GliaWidgets.init(widgetsConfig);
 


### PR DESCRIPTION
[MOB-1822](https://glia.atlassian.net/browse/MOB-1822)

1. Start listening for engagement requests once SDK is initialized
2. Auto-accept incoming Call Visualizer engagement request
3. Listen for new engagement without effecting the integrator app (there is no specific handling yet within this ticket, just listen)

There is an [open question](https://salemove.slack.com/archives/C04BTHLDL9Y/p1674721827031499) regarding visitor context assets related to this ticket.


[MOB-1822]: https://glia.atlassian.net/browse/MOB-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ