### PR TITLE
MOB-1824 Display alert dialog for Call Visualizer media engagement request

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -9,16 +9,22 @@ import androidx.annotation.Nullable;
 import com.glia.androidsdk.GliaConfig;
 import com.glia.androidsdk.GliaException;
 import com.glia.androidsdk.RequestCallback;
+import com.glia.androidsdk.comms.Media;
+import com.glia.androidsdk.comms.MediaDirection;
+import com.glia.androidsdk.comms.MediaUpgradeOffer;
 import com.glia.androidsdk.omnibrowse.Omnibrowse;
+import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement;
 import com.glia.androidsdk.visitor.Authentication;
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest;
 import com.glia.widgets.chat.adapter.CustomCardAdapter;
 import com.glia.widgets.chat.adapter.WebViewCardAdapter;
+import com.glia.widgets.core.dialog.DialogController;
 import com.glia.widgets.core.visitor.GliaVisitorInfo;
 import com.glia.widgets.core.visitor.GliaWidgetException;
 import com.glia.widgets.core.visitor.VisitorInfoUpdate;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
+import com.glia.widgets.helper.Utils;
 
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -175,10 +181,7 @@ public class GliaWidgets {
                 }
             };
             engagementRequest.accept((String) null, onResult);
-        });
-
-        Dependencies.glia().getCallVisualizer().on(Omnibrowse.Events.ENGAGEMENT, engagement -> {
-            Logger.d(TAG, "New Call Visualizer engagement started");
+            Dependencies.getControllerFactory().getCallVisualizerController().init();
         });
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerCallback.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerCallback.kt
@@ -1,0 +1,8 @@
+package com.glia.widgets.callvisualizer
+
+import com.glia.androidsdk.comms.MediaUpgradeOffer
+
+interface CallVisualizerCallback {
+    fun onOneWayMediaUpgradeRequest(mediaUpgradeOffer: MediaUpgradeOffer, operatorName: String)
+    fun onTwoWayMediaUpgradeRequest(mediaUpgradeOffer: MediaUpgradeOffer, operatorName: String)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerRepository.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.callvisualizer
+
+import com.glia.androidsdk.comms.Media
+import com.glia.androidsdk.comms.MediaDirection
+import com.glia.androidsdk.comms.MediaUpgradeOffer
+import com.glia.androidsdk.omnibrowse.Omnibrowse
+import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement
+import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.Logger
+import java.util.function.Consumer
+
+class CallVisualizerRepository {
+
+    private lateinit var callback: CallVisualizerCallback
+
+    companion object {
+        private val TAG = CallVisualizerRepository::class.java.simpleName
+    }
+
+    fun init(callVisualizerCallback: CallVisualizerCallback) {
+        this.callback = callVisualizerCallback
+        Dependencies.glia().callVisualizer.on(Omnibrowse.Events.ENGAGEMENT)
+        { engagement: OmnibrowseEngagement ->
+            Logger.d(TAG, "New Call Visualizer engagement started")
+            val upgradeOfferConsumer = prepareMediaUpgradeOfferConsumer(engagement)
+            engagement.media.on(Media.Events.MEDIA_UPGRADE_OFFER, upgradeOfferConsumer)
+        }
+        Logger.d(TAG, "CallVisualizerRepository initialized")
+    }
+
+    private fun prepareMediaUpgradeOfferConsumer(engagement: OmnibrowseEngagement): Consumer<MediaUpgradeOffer> {
+        return Consumer { offer: MediaUpgradeOffer ->
+            Logger.d(
+                TAG,
+                "upgradeOfferConsumer, offer: $offer"
+            )
+            val operatorName = engagement.state.operator.name
+            if (offer.video == MediaDirection.TWO_WAY) {
+                callback.onTwoWayMediaUpgradeRequest(offer, operatorName)
+            } else if (offer.video == MediaDirection.ONE_WAY) {
+                callback.onOneWayMediaUpgradeRequest(offer, operatorName)
+            }
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -1,0 +1,34 @@
+package com.glia.widgets.callvisualizer.controller
+
+import com.glia.androidsdk.comms.MediaUpgradeOffer
+import com.glia.widgets.callvisualizer.CallVisualizerCallback
+import com.glia.widgets.callvisualizer.CallVisualizerRepository
+import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
+import com.glia.widgets.core.dialog.DialogController
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.Utils
+
+class CallVisualizerController(
+    private val callVisualizerRepository: CallVisualizerRepository,
+    private val dialogController: DialogController,
+    val isCallOrChatScreenActiveUseCase: IsCallOrChatScreenActiveUseCase
+) : CallVisualizerCallback {
+    companion object {
+        private val TAG = CallVisualizerController::class.java.simpleName
+    }
+
+    fun init() {
+        Logger.d(TAG, "CallVisualizerController initialized")
+        callVisualizerRepository.init(this)
+    }
+
+    override fun onOneWayMediaUpgradeRequest(mediaUpgradeOffer: MediaUpgradeOffer, operatorName: String) {
+        val formattedOperatorName = Utils.formatOperatorName(operatorName)
+        dialogController.showUpgradeVideoDialog2Way(mediaUpgradeOffer, formattedOperatorName)
+    }
+
+    override fun onTwoWayMediaUpgradeRequest(mediaUpgradeOffer: MediaUpgradeOffer, operatorName: String) {
+        val formattedOperatorName = Utils.formatOperatorName(operatorName)
+        dialogController.showUpgradeVideoDialog1Way(mediaUpgradeOffer, formattedOperatorName)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCase.kt
@@ -1,0 +1,10 @@
+package com.glia.widgets.callvisualizer.domain
+
+import android.app.Activity
+import com.glia.widgets.call.CallActivity
+import com.glia.widgets.chat.ChatActivity
+
+class IsCallOrChatScreenActiveUseCase {
+    operator fun invoke(resumedActivity: Activity?) =
+        (resumedActivity is CallActivity || resumedActivity is ChatActivity)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -2,6 +2,7 @@ package com.glia.widgets.di;
 
 import com.glia.widgets.call.CallController;
 import com.glia.widgets.call.CallViewCallback;
+import com.glia.widgets.callvisualizer.controller.CallVisualizerController;
 import com.glia.widgets.chat.ChatViewCallback;
 import com.glia.widgets.chat.controller.ChatController;
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager;
@@ -41,6 +42,7 @@ public class ControllerFactory {
     private final FilePreviewController filePreviewController;
     private final ChatHeadPosition chatHeadPosition;
     private SurveyController surveyController;
+    private CallVisualizerController callVisualizerController;
 
     private static ServiceChatHeadController serviceChatHeadController;
 
@@ -256,6 +258,17 @@ public class ControllerFactory {
             );
         }
         return surveyController;
+    }
+
+    public CallVisualizerController getCallVisualizerController() {
+        if (callVisualizerController == null) {
+            callVisualizerController = new CallVisualizerController(
+                    repositoryFactory.getCallVisualizerRepository(),
+                    dialogController,
+                    useCaseFactory.createIsCallOrChatScreenActiveUseCase()
+            );
+        }
+        return callVisualizerController;
     }
 
     public FloatingVisitorVideoContract.Controller getFloatingVisitorVideoController() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -13,6 +13,7 @@ import com.glia.widgets.core.notification.device.INotificationManager;
 import com.glia.widgets.core.notification.device.NotificationManager;
 import com.glia.widgets.core.permissions.PermissionManager;
 import com.glia.widgets.filepreview.data.source.local.DownloadsFolderDataSource;
+import com.glia.widgets.helper.ActivityWatcherForDialogs;
 import com.glia.widgets.helper.ApplicationLifecycleManager;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.ResourceProvider;
@@ -23,6 +24,7 @@ import com.glia.widgets.view.unifiedui.theme.UnifiedThemeManager;
 public class Dependencies {
 
     private final static String TAG = "Dependencies";
+
     private static ControllerFactory controllerFactory;
     private static INotificationManager notificationManager;
     private static GliaSdkConfigurationManager sdkConfigurationManager =
@@ -58,6 +60,10 @@ public class Dependencies {
                 new ApplicationLifecycleManager(),
                 controllerFactory.getChatHeadController()
         );
+        ActivityWatcherForDialogs activityWatcherForDialogs = new ActivityWatcherForDialogs(
+                application,
+                controllerFactory.getCallVisualizerController());
+        activityWatcherForDialogs.init(Dependencies.controllerFactory.getDialogController());
         resourceProvider = new ResourceProvider(application.getBaseContext());
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -1,5 +1,6 @@
 package com.glia.widgets.di;
 
+import com.glia.widgets.callvisualizer.CallVisualizerRepository;
 import com.glia.widgets.chat.data.ChatScreenRepository;
 import com.glia.widgets.chat.data.ChatScreenRepositoryImpl;
 import com.glia.widgets.chat.data.GliaChatRepository;
@@ -34,6 +35,7 @@ public class RepositoryFactory {
     private static GliaEngagementStateRepository gliaEngagementStateRepository;
     private static FileAttachmentRepository fileAttachmentRepository;
     private static GliaOperatorRepository operatorRepository;
+    private CallVisualizerRepository callVisualizerRepository;
 
     private final GliaCore gliaCore;
     private final DownloadsFolderDataSource downloadsFolderDataSource;
@@ -150,5 +152,13 @@ public class RepositoryFactory {
         }
 
         return operatorRepository;
+    }
+
+    public CallVisualizerRepository getCallVisualizerRepository() {
+        if (callVisualizerRepository == null) {
+            callVisualizerRepository = new CallVisualizerRepository();
+        }
+
+        return callVisualizerRepository;
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -3,6 +3,7 @@ package com.glia.widgets.di;
 import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.call.domain.ToggleVisitorAudioMediaMuteUseCase;
 import com.glia.widgets.call.domain.ToggleVisitorVideoUseCase;
+import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase;
 import com.glia.widgets.chat.domain.CustomCardAdapterTypeUseCase;
 import com.glia.widgets.chat.domain.CustomCardInteractableUseCase;
 import com.glia.widgets.chat.domain.CustomCardTypeUseCase;
@@ -439,5 +440,9 @@ public class UseCaseFactory {
 
     public QueueTicketStateChangeToUnstaffedUseCase createQueueTicketStateChangeToUnstaffedUseCase() {
         return new QueueTicketStateChangeToUnstaffedUseCase(repositoryFactory.getGliaQueueRepository());
+    }
+
+    public IsCallOrChatScreenActiveUseCase createIsCallOrChatScreenActiveUseCase() {
+        return new IsCallOrChatScreenActiveUseCase();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ActivityWatcherForDialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ActivityWatcherForDialogs.kt
@@ -1,0 +1,123 @@
+package com.glia.widgets.helper
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
+import com.glia.widgets.R
+import com.glia.widgets.UiTheme
+import com.glia.widgets.callvisualizer.controller.CallVisualizerController
+import com.glia.widgets.core.dialog.Dialog
+import com.glia.widgets.core.dialog.DialogController
+import com.glia.widgets.core.dialog.model.DialogState
+import com.glia.widgets.view.Dialogs
+import com.google.android.material.theme.overlay.MaterialThemeOverlay
+import java.lang.ref.WeakReference
+
+class ActivityWatcherForDialogs(
+    private val app: Application,
+    private val callVisualizerController: CallVisualizerController
+) : Application.ActivityLifecycleCallbacks {
+
+    companion object {
+        private val TAG = ActivityWatcherForDialogs::class.java.simpleName
+    }
+
+    private var dialogController: DialogController? = null
+
+    @VisibleForTesting
+    var dialogCallback: DialogController.Callback? = null
+
+    @VisibleForTesting
+    var alertDialog: AlertDialog? = null
+
+    /**
+     * Returns last activity that called [Activity.onResume], but didn't call [Activity.onPause] yet
+     * @return Currently resumed activity.
+     */
+    @VisibleForTesting
+    var resumedActivity: WeakReference<Activity?> = WeakReference(null)
+
+    fun init(dialogController: DialogController) {
+        app.registerActivityLifecycleCallbacks(this)
+        this.dialogController = dialogController
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+    override fun onActivityDestroyed(activity: Activity) {}
+
+
+    override fun onActivityResumed(activity: Activity) {
+        resumedActivity = WeakReference(activity)
+        addDialogCallback(resumedActivity)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        resumedActivity.clear()
+        removeDialogCallback()
+    }
+
+
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+    private fun addDialogCallback(resumedActivity: WeakReference<Activity?>) {
+        // There are separate dialog callbacks for incoming media requests on Call and Chat screens.
+        if (callVisualizerController.isCallOrChatScreenActiveUseCase(resumedActivity.get())) return
+
+        setupDialogCallback(resumedActivity)
+        dialogController?.addCallback(dialogCallback)
+    }
+
+    private fun removeDialogCallback() {
+        dialogController?.removeCallback(dialogCallback)
+    }
+
+    @VisibleForTesting
+    fun setupDialogCallback(resumedActivity: WeakReference<Activity?>) {
+        val activity = resumedActivity.get() ?: return
+
+        dialogCallback = DialogController.Callback {
+            when (it.mode) {
+                Dialog.MODE_NONE -> dismissAlertDialog()
+                Dialog.MODE_MEDIA_UPGRADE -> activity.runOnUiThread {
+                    showUpgradeDialog(resumedActivity, it as DialogState.MediaUpgrade)
+                }
+                else -> {
+                    Logger.d(TAG, "Unexpected dialog mode received")
+                }
+            }
+        }
+    }
+
+    private fun showUpgradeDialog(
+        resumedActivity: WeakReference<Activity?>,
+        mediaUpgrade: DialogState.MediaUpgrade
+    ) {
+        val activity = resumedActivity.get() ?: return
+
+        Logger.d(TAG, "Show upgrade dialog")
+        val builder = UiTheme.UiThemeBuilder()
+        val theme = builder.build()
+        val contextWithStyle = MaterialThemeOverlay.wrap(
+            activity,
+            null,
+            R.attr.gliaChatStyle,
+            R.style.Application_Glia_Chat
+        )
+
+        alertDialog = Dialogs.showUpgradeDialog(contextWithStyle, theme, mediaUpgrade, {
+            dialogController?.dismissCurrentDialog()
+        }) {
+            dialogController?.dismissCurrentDialog()
+        }
+    }
+
+    private fun dismissAlertDialog() {
+        Logger.d(TAG, "Dismiss alert dialog")
+        alertDialog?.dismiss()
+        alertDialog = null
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -258,14 +258,14 @@ object Dialogs {
                         R.string.glia_dialog_upgrade_video_1_way_title,
                         mediaUpgrade.operatorName
                     )
-                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog!!)
+                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog ?: R.drawable.ic_baseline_videocam)
                 }
                 MediaUpgrade.MODE_VIDEO_TWO_WAY -> {
                     titleView.text = context.getString(
                         R.string.glia_dialog_upgrade_video_2_way_title,
                         mediaUpgrade.operatorName
                     )
-                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog!!)
+                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog ?: R.drawable.ic_baseline_videocam)
                     titleIconView.contentDescription =
                         context.getString(R.string.glia_chat_video_icon_content_description)
                 }

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.glia.widgets.callvisualizer.domain
+
+import com.glia.widgets.call.CallActivity
+import com.glia.widgets.chat.ChatActivity
+import com.glia.widgets.filepreview.ui.FilePreviewActivity
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+internal class IsCallOrChatScreenActiveUseCaseTest {
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsFalse_whenNotCallOrChatActivity() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+        val resumedActivity = mock(FilePreviewActivity::class.java)
+
+        Assert.assertFalse(useCase(resumedActivity))
+    }
+
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsTrue_whenChatActivity() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+        val resumedActivity = mock(ChatActivity::class.java)
+
+        Assert.assertTrue(useCase(resumedActivity))
+    }
+
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsTrue_whenCallActivity() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+        val resumedActivity = mock(CallActivity::class.java)
+
+        Assert.assertTrue(useCase(resumedActivity))
+    }
+
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsFalse_whenActivityNull() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+
+        Assert.assertFalse(useCase(null))
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/helper/ActivityWatcherForDialogsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/helper/ActivityWatcherForDialogsTest.kt
@@ -1,0 +1,87 @@
+package com.glia.widgets.helper
+
+import android.app.Activity
+import android.app.Application
+import com.glia.widgets.callvisualizer.CallVisualizerRepository
+import com.glia.widgets.callvisualizer.controller.CallVisualizerController
+import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
+import com.glia.widgets.core.dialog.Dialog
+import com.glia.widgets.core.dialog.DialogController
+import com.glia.widgets.core.dialog.model.DialogState
+import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.lang.ref.WeakReference
+
+internal class ActivityWatcherForDialogsTest {
+
+    @Test
+    fun resumedActivity_cleared_whenActivityPaused() {
+        val app = mock(Application::class.java)
+        val callVisualizerRepository = mock(CallVisualizerRepository::class.java)
+        val dialogController = mock(DialogController::class.java)
+        val controller = CallVisualizerController(
+            callVisualizerRepository,
+            dialogController,
+            IsCallOrChatScreenActiveUseCase())
+        val activityWatcherForDialogs = ActivityWatcherForDialogs(app, controller)
+
+        activityWatcherForDialogs.onActivityResumed(mock(Activity::class.java))
+        activityWatcherForDialogs.onActivityPaused(mock(Activity::class.java))
+
+        assertNull(activityWatcherForDialogs.resumedActivity.get())
+    }
+
+    @Test
+    fun resumedActivity_saved_whenActivityResumed() {
+        val app = mock(Application::class.java)
+        val callVisualizerRepository = mock(CallVisualizerRepository::class.java)
+        val dialogController = mock(DialogController::class.java)
+        val controller = CallVisualizerController(
+            callVisualizerRepository,
+            dialogController,
+            IsCallOrChatScreenActiveUseCase())
+        val activityWatcherForDialogs = ActivityWatcherForDialogs(app, controller)
+
+        activityWatcherForDialogs.onActivityResumed(mock(Activity::class.java))
+
+        assertNotNull(activityWatcherForDialogs.resumedActivity.get())
+    }
+
+    @Test
+    fun alertDialog_dismissed_whenEmitDialogStateModeNone() {
+        val app = mock(Application::class.java)
+        val callVisualizerRepository = mock(CallVisualizerRepository::class.java)
+        val dialogController = mock(DialogController::class.java)
+        val controller = CallVisualizerController(
+            callVisualizerRepository,
+            dialogController,
+            IsCallOrChatScreenActiveUseCase())
+        val activityWatcherForDialogs = ActivityWatcherForDialogs(app, controller)
+        activityWatcherForDialogs.alertDialog = mock(androidx.appcompat.app.AlertDialog::class.java)
+        activityWatcherForDialogs.setupDialogCallback(WeakReference(mock(Activity::class.java)))
+
+        activityWatcherForDialogs.dialogCallback?.emitDialogState(DialogState(Dialog.MODE_NONE))
+
+        assertNull(activityWatcherForDialogs.alertDialog)
+    }
+
+    @Test
+    fun alertDialog_created_whenEmitDialogStateModeMediaUpgrade() {
+        val app = mock(Application::class.java)
+        val callVisualizerRepository = mock(CallVisualizerRepository::class.java)
+        val dialogController = mock(DialogController::class.java)
+        val controller = CallVisualizerController(
+            callVisualizerRepository,
+            dialogController,
+            IsCallOrChatScreenActiveUseCase())
+        val activityWatcherForDialogs = ActivityWatcherForDialogs(app, controller)
+        activityWatcherForDialogs.alertDialog = mock(androidx.appcompat.app.AlertDialog::class.java)
+        activityWatcherForDialogs.setupDialogCallback(WeakReference(mock(Activity::class.java)))
+
+        activityWatcherForDialogs.dialogCallback?.emitDialogState(DialogState(Dialog.MODE_MEDIA_UPGRADE))
+
+        assertNotNull(activityWatcherForDialogs.alertDialog)
+    }
+}


### PR DESCRIPTION
[MOB-1824](https://glia.atlassian.net/browse/MOB-1824)


[MOB-1824]: https://glia.atlassian.net/browse/MOB-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Changes overview:

- Created and registered `ActivityWatcherForDialogs` for showing dialogs on top of any Activity except `CallActivity` and `ChatActivity`. `ActivityWatcherForDialogs` contains the logic to register/unregister dialog callback and dialogs implementation inside dialog callback
- Subscribe to `Media.Events.MEDIA_UPGRADE_OFFER` in `CallVisualizerRepository`, trigger appropriate dialogs on incoming event 
- Created `CallVisualizerController` with `CallVisualizerRepository`
- Made media request dialogs support runtime theme mechanism (see `MaterialThemeOverlay.wrap` and default values for drawables to `Dialogs.kt`)
- Added unit tests