### PR TITLE
Feature/mob 1861 new screen sharing screen

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -33,6 +33,7 @@ import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
 import com.glia.widgets.call.Configuration;
+import com.glia.widgets.callvisualizer.ScreenSharingScreenActivity;
 import com.glia.widgets.chat.ChatActivity;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.messagecenter.MessageCenterActivity;
@@ -72,6 +73,8 @@ public class MainFragment extends Fragment {
                 navigateToCall(GliaWidgets.MEDIA_TYPE_VIDEO));
         view.findViewById(R.id.message_center_activity_button).setOnClickListener(v ->
                 navigateToMessageCenter());
+        view.findViewById(R.id.screen_share_test_button).setOnClickListener( v ->
+                navigateToScreenShare());
         view.findViewById(R.id.end_engagement_button).setOnClickListener(v ->
                 GliaWidgets.endEngagement());
         view.findViewById(R.id.initGliaWidgetsButton).setOnClickListener(v ->
@@ -82,6 +85,12 @@ public class MainFragment extends Fragment {
                 deauthenticate());
         view.findViewById(R.id.clear_session_button).setOnClickListener(v ->
                 clearSession());
+    }
+
+    private void navigateToScreenShare() {
+        Intent intent = new Intent(requireContext(), ScreenSharingScreenActivity.class);
+        setNavigationIntentData(intent);
+        startActivity(intent);
     }
 
     @Override

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -104,14 +104,26 @@
         app:layout_constraintTop_toBottomOf="@id/video_call_button" />
 
     <Button
+        android:id="@+id/screen_share_test_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_m"
+        android:paddingEnd="36dp"
+        android:text="@string/main_start_screen_share_test_view"
+        app:icon="@drawable/ic_screensharing"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/message_center_activity_button" />
+
+    <Button
         android:id="@+id/end_engagement_button"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_m"
         android:text="@string/main_end_engagement"
-        app:layout_constraintEnd_toStartOf="@+id/end_guideline"
-        app:layout_constraintStart_toStartOf="@+id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@+id/message_center_activity_button" />
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/screen_share_test_button" />
 
     <Button
         android:id="@+id/initGliaWidgetsButton"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="main_start_in_integrator_app">Start Chat in integrator app</string>
     <string name="main_start_chat_flow">Start new chat flow</string>
     <string name="main_start_message_center_flow">Start new messaging flow</string>
+    <string name="main_start_screen_share_test_view">Open screen share test view</string>
     <string name="main_start_audio_call">Start new audio call</string>
     <string name="main_start_video_call">Start new video call</string>
     <string name="main_end_engagement">End engagement</string>

--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -34,6 +34,10 @@
             android:launchMode="singleTask"
             android:theme="@style/Application.Glia.Chat.Activity"
             android:windowSoftInputMode="adjustResize" />
+        <activity android:name=".callvisualizer.ScreenSharingScreenActivity"
+            android:launchMode="singleTask"
+            android:theme="@style/Application.Glia.Call.Activity"
+            android:windowSoftInputMode="adjustResize"/>
 
         <service
             android:name=".core.chathead.ChatHeadService"

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -9,16 +9,22 @@ import androidx.annotation.Nullable;
 import com.glia.androidsdk.GliaConfig;
 import com.glia.androidsdk.GliaException;
 import com.glia.androidsdk.RequestCallback;
+import com.glia.androidsdk.comms.Media;
+import com.glia.androidsdk.comms.MediaDirection;
+import com.glia.androidsdk.comms.MediaUpgradeOffer;
 import com.glia.androidsdk.omnibrowse.Omnibrowse;
+import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement;
 import com.glia.androidsdk.visitor.Authentication;
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest;
 import com.glia.widgets.chat.adapter.CustomCardAdapter;
 import com.glia.widgets.chat.adapter.WebViewCardAdapter;
+import com.glia.widgets.core.dialog.DialogController;
 import com.glia.widgets.core.visitor.GliaVisitorInfo;
 import com.glia.widgets.core.visitor.GliaWidgetException;
 import com.glia.widgets.core.visitor.VisitorInfoUpdate;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
+import com.glia.widgets.helper.Utils;
 
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -179,7 +185,25 @@ public class GliaWidgets {
 
         Dependencies.glia().getCallVisualizer().on(Omnibrowse.Events.ENGAGEMENT, engagement -> {
             Logger.d(TAG, "New Call Visualizer engagement started");
+
+            Consumer<MediaUpgradeOffer> upgradeOfferConsumer = prepareMediaUpgradeOfferConsumer(engagement);
+            engagement.getMedia().on(Media.Events.MEDIA_UPGRADE_OFFER, upgradeOfferConsumer);
         });
+    }
+
+    @NonNull
+    private static Consumer<MediaUpgradeOffer> prepareMediaUpgradeOfferConsumer(OmnibrowseEngagement engagement) {
+        return offer -> {
+            Logger.d(TAG, "upgradeOfferConsumer, offer: " + offer.toString());
+            DialogController dialogController = Dependencies.getControllerFactory().getDialogController();
+            String operatorName = engagement.getState().getOperator().getName();
+            String formattedOperatorName = Utils.formatOperatorName(operatorName);
+            if (offer.video == MediaDirection.TWO_WAY) {
+                dialogController.showUpgradeVideoDialog2Way(offer, formattedOperatorName);
+            } else if (offer.video == MediaDirection.ONE_WAY) {
+                dialogController.showUpgradeVideoDialog1Way(offer, formattedOperatorName);
+            }
+        };
     }
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenActivity.kt
@@ -1,0 +1,23 @@
+package com.glia.widgets.callvisualizer
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.glia.widgets.databinding.ScreenSharingScreenActivityBinding
+import com.glia.widgets.di.Dependencies
+
+class ScreenSharingScreenActivity : AppCompatActivity(), ScreenSharingScreenView.OnFinishListener {
+
+    private lateinit var binding: ScreenSharingScreenActivityBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ScreenSharingScreenActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val screenSharingView = binding.screenSharingScreenView
+        screenSharingView.onFinishListener = this
+
+        val controller = Dependencies.getControllerFactory().screenSharingViewController
+        screenSharingView.setController(controller)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenContract.kt
@@ -1,0 +1,19 @@
+package com.glia.widgets.callvisualizer
+
+import com.glia.widgets.base.BaseController
+import com.glia.widgets.base.BaseView
+
+interface ScreenSharingScreenContract {
+
+        interface Controller : BaseController {
+            fun setView(view: View)
+            fun onBackArrowClicked()
+            fun onEndScreenSharingButtonClicked()
+        }
+
+        interface View : BaseView<Controller> {
+            fun finish()
+            fun stopScreenSharing()
+        }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenController.kt
@@ -1,0 +1,20 @@
+package com.glia.widgets.callvisualizer
+
+class ScreenSharingScreenController : ScreenSharingScreenContract.Controller {
+
+    private var view: ScreenSharingScreenContract.View? = null
+
+    override fun setView(view: ScreenSharingScreenContract.View) {
+        this.view = view
+    }
+
+    override fun onBackArrowClicked() {
+        view?.finish()
+    }
+
+    override fun onEndScreenSharingButtonClicked() {
+        view?.stopScreenSharing()
+    }
+
+    override fun onDestroy() {}
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ScreenSharingScreenView.kt
@@ -1,0 +1,68 @@
+package com.glia.widgets.callvisualizer
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.glia.widgets.R
+import com.glia.widgets.databinding.ScreenSharingScreenViewBinding
+import com.glia.widgets.view.header.AppBarView
+import com.google.android.material.theme.overlay.MaterialThemeOverlay
+
+class ScreenSharingScreenView (
+    context: Context,
+    attrs: AttributeSet?,
+    defStyleAttr: Int,
+    defStyleRes: Int)
+    : ConstraintLayout(
+    MaterialThemeOverlay.wrap(context, attrs, defStyleAttr, defStyleRes),
+    attrs,
+    defStyleAttr,
+    defStyleRes
+), ScreenSharingScreenContract.View {
+
+    var onFinishListener: OnFinishListener? = null
+    private var controller: ScreenSharingScreenContract.Controller? = null
+
+    private val binding: ScreenSharingScreenViewBinding by lazy {
+        ScreenSharingScreenViewBinding.inflate(LayoutInflater.from(this.context), this)
+    }
+
+    @JvmOverloads
+    constructor(
+        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = R.attr.gliaChatStyle
+    ) : this(context, attrs, defStyleAttr, R.style.Application_Glia_Chat)
+
+
+    init {
+        initCallbacks()
+        prepareView()
+    }
+
+    private fun prepareView() {
+        binding.appBarView.hideLeaveButtons()
+    }
+
+    private fun initCallbacks() {
+        binding.endScreenSharingButton.setOnClickListener { controller?.onEndScreenSharingButtonClicked() }
+        binding.appBarView.setOnBackClickedListener { controller?.onBackArrowClicked() }
+    }
+
+    override fun finish() {
+        this.onFinishListener?.finish()
+    }
+
+    override fun stopScreenSharing() {
+        TODO("Not yet implemented")
+    }
+
+    override fun setController(controller: ScreenSharingScreenContract.Controller?) {
+        this.controller = controller
+        controller?.setView(this)
+    }
+
+
+    interface OnFinishListener {
+        fun finish()
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -1,0 +1,78 @@
+package com.glia.widgets.callvisualizer.controller
+
+import android.app.Activity
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
+import com.glia.widgets.R
+import com.glia.widgets.UiTheme
+import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
+import com.glia.widgets.core.dialog.Dialog
+import com.glia.widgets.core.dialog.DialogController
+import com.glia.widgets.core.dialog.model.DialogState
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.view.Dialogs
+import com.google.android.material.theme.overlay.MaterialThemeOverlay
+
+class CallVisualizerController(
+    private val dialogController: DialogController,
+    private val isCallOrChatScreenActiveUseCase: IsCallOrChatScreenActiveUseCase
+) {
+
+    private var dialogCallback: DialogController.Callback? = null
+    private var alertDialog: AlertDialog? = null
+
+    fun addDialogCallback(resumedActivity: Activity?) {
+        // There are separate dialog callbacks for incoming media requests on Call and Chat screens.
+        if (isCallOrChatScreenActiveUseCase(resumedActivity)) return
+
+        setupDialogCallback(resumedActivity)
+        dialogController.addCallback(dialogCallback)
+    }
+
+    fun removeDialogCallback() {
+        dialogController.removeCallback(dialogCallback)
+    }
+
+    @VisibleForTesting
+    fun setupDialogCallback(resumedActivity: Activity?) {
+        dialogCallback = DialogController.Callback {
+            when (it.mode) {
+                Dialog.MODE_NONE -> dismissAlertDialog()
+                Dialog.MODE_MEDIA_UPGRADE -> resumedActivity?.runOnUiThread {
+                    showUpgradeDialog(resumedActivity, it as DialogState.MediaUpgrade)
+                }
+            }
+        }
+    }
+
+    private fun showUpgradeDialog(
+        resumedActivity: Activity,
+        mediaUpgrade: DialogState.MediaUpgrade
+    ) {
+        Logger.d(TAG, "Show upgrade dialog")
+        val builder = UiTheme.UiThemeBuilder()
+        val theme = builder.build()
+        val contextWithStyle = MaterialThemeOverlay.wrap(
+            resumedActivity,
+            null,
+            R.attr.gliaChatStyle,
+            R.style.Application_Glia_Chat
+        )
+
+        alertDialog = Dialogs.showUpgradeDialog(contextWithStyle, theme, mediaUpgrade, {
+            dialogController.dismissCurrentDialog()
+        }) {
+            dialogController.dismissCurrentDialog()
+        }
+    }
+
+    private fun dismissAlertDialog() {
+        Logger.d(TAG, "Dismiss alert dialog")
+        alertDialog?.dismiss()
+        alertDialog = null
+    }
+
+    companion object {
+        private val TAG = CallVisualizerController::class.java.simpleName
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCase.kt
@@ -1,0 +1,10 @@
+package com.glia.widgets.callvisualizer.domain
+
+import android.app.Activity
+import com.glia.widgets.call.CallActivity
+import com.glia.widgets.chat.ChatActivity
+
+class IsCallOrChatScreenActiveUseCase {
+    operator fun invoke(resumedActivity: Activity?) =
+        (resumedActivity is CallActivity || resumedActivity is ChatActivity)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -2,6 +2,9 @@ package com.glia.widgets.di;
 
 import com.glia.widgets.call.CallController;
 import com.glia.widgets.call.CallViewCallback;
+import com.glia.widgets.callvisualizer.ScreenSharingScreenContract;
+import com.glia.widgets.callvisualizer.ScreenSharingScreenController;
+import com.glia.widgets.callvisualizer.controller.CallVisualizerController;
 import com.glia.widgets.chat.ChatViewCallback;
 import com.glia.widgets.chat.controller.ChatController;
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager;
@@ -41,6 +44,7 @@ public class ControllerFactory {
     private final FilePreviewController filePreviewController;
     private final ChatHeadPosition chatHeadPosition;
     private SurveyController surveyController;
+    private CallVisualizerController callVisualizerController;
 
     private static ServiceChatHeadController serviceChatHeadController;
 
@@ -258,6 +262,16 @@ public class ControllerFactory {
         return surveyController;
     }
 
+    public CallVisualizerController getCallVisualizerController() {
+        if (callVisualizerController == null) {
+            callVisualizerController = new CallVisualizerController(
+                    dialogController,
+                    useCaseFactory.createIsCallOrChatScreenActiveUseCase()
+            );
+        }
+        return callVisualizerController;
+    }
+
     public FloatingVisitorVideoContract.Controller getFloatingVisitorVideoController() {
         return new FloatingVisitorVideoController(
                 useCaseFactory.createAddVisitorMediaStateListenerUseCase(),
@@ -269,5 +283,9 @@ public class ControllerFactory {
 
     public MessageCenterContract.Controller getMessageCenterController() {
         return new MessageCenterController();
+    }
+
+    public ScreenSharingScreenContract.Controller getScreenSharingViewController() {
+        return new ScreenSharingScreenController();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -13,6 +13,7 @@ import com.glia.widgets.core.notification.device.INotificationManager;
 import com.glia.widgets.core.notification.device.NotificationManager;
 import com.glia.widgets.core.permissions.PermissionManager;
 import com.glia.widgets.filepreview.data.source.local.DownloadsFolderDataSource;
+import com.glia.widgets.helper.ActivityWatcher;
 import com.glia.widgets.helper.ApplicationLifecycleManager;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.ResourceProvider;
@@ -23,6 +24,7 @@ import com.glia.widgets.view.unifiedui.theme.UnifiedThemeManager;
 public class Dependencies {
 
     private final static String TAG = "Dependencies";
+
     private static ControllerFactory controllerFactory;
     private static INotificationManager notificationManager;
     private static GliaSdkConfigurationManager sdkConfigurationManager =
@@ -58,6 +60,10 @@ public class Dependencies {
                 new ApplicationLifecycleManager(),
                 controllerFactory.getChatHeadController()
         );
+        ActivityWatcher activityWatcher = new ActivityWatcher(
+                application,
+                controllerFactory.getCallVisualizerController());
+        activityWatcher.init();
         resourceProvider = new ResourceProvider(application.getBaseContext());
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -3,6 +3,7 @@ package com.glia.widgets.di;
 import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.call.domain.ToggleVisitorAudioMediaMuteUseCase;
 import com.glia.widgets.call.domain.ToggleVisitorVideoUseCase;
+import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase;
 import com.glia.widgets.chat.domain.CustomCardAdapterTypeUseCase;
 import com.glia.widgets.chat.domain.CustomCardInteractableUseCase;
 import com.glia.widgets.chat.domain.CustomCardTypeUseCase;
@@ -439,5 +440,9 @@ public class UseCaseFactory {
 
     public QueueTicketStateChangeToUnstaffedUseCase createQueueTicketStateChangeToUnstaffedUseCase() {
         return new QueueTicketStateChangeToUnstaffedUseCase(repositoryFactory.getGliaQueueRepository());
+    }
+
+    public IsCallOrChatScreenActiveUseCase createIsCallOrChatScreenActiveUseCase() {
+        return new IsCallOrChatScreenActiveUseCase();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ActivityWatcher.kt
@@ -1,0 +1,49 @@
+package com.glia.widgets.helper
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.annotation.VisibleForTesting
+import com.glia.widgets.callvisualizer.controller.CallVisualizerController
+import java.lang.ref.WeakReference
+
+class ActivityWatcher(
+    private val app: Application,
+    private val callVisualizerController: CallVisualizerController
+) :
+    Application.ActivityLifecycleCallbacks {
+
+    private var _resumedActivity: WeakReference<Activity?> = WeakReference(null)
+
+    /**
+     * Returns last activity that called [Activity.onResume], but didn't call [Activity.onPause] yet
+     * @return Currently resumed activity.
+     */
+    @VisibleForTesting
+    val resumedActivity: Activity?
+        get() = _resumedActivity.get()
+
+    fun init() {
+        app.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+    override fun onActivityDestroyed(activity: Activity) {}
+
+
+    override fun onActivityResumed(activity: Activity) {
+        _resumedActivity = WeakReference(activity)
+        // There are separate handlers for Media requests on CallActivity and ChatActivity
+        callVisualizerController.addDialogCallback(resumedActivity)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        _resumedActivity.clear()
+        callVisualizerController.removeDialogCallback()
+    }
+
+
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -258,14 +258,14 @@ object Dialogs {
                         R.string.glia_dialog_upgrade_video_1_way_title,
                         mediaUpgrade.operatorName
                     )
-                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog!!)
+                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog ?: R.drawable.ic_baseline_videocam)
                 }
                 MediaUpgrade.MODE_VIDEO_TWO_WAY -> {
                     titleView.text = context.getString(
                         R.string.glia_dialog_upgrade_video_2_way_title,
                         mediaUpgrade.operatorName
                     )
-                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog!!)
+                    titleIconView.setImageResource(theme.iconUpgradeVideoDialog ?: R.drawable.ic_baseline_videocam)
                     titleIconView.contentDescription =
                         context.getString(R.string.glia_chat_video_icon_content_description)
                 }

--- a/widgetssdk/src/main/res/drawable/ic_back.xml
+++ b/widgetssdk/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="21dp"
+    android:viewportWidth="12"
+    android:viewportHeight="21">
+  <path
+      android:pathData="M9.609,20.391C9.867,20.648 10.195,20.789 10.582,20.789C11.356,20.789 11.977,20.18 11.977,19.406C11.977,19.02 11.813,18.668 11.543,18.398L3.34,10.383L11.543,2.391C11.813,2.121 11.977,1.758 11.977,1.383C11.977,0.609 11.356,0 10.582,0C10.195,0 9.867,0.141 9.609,0.398L0.492,9.305C0.164,9.609 0.012,9.984 0,10.394C0,10.805 0.164,11.156 0.492,11.473L9.609,20.391Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/widgetssdk/src/main/res/layout/screen_sharing_screen_activity.xml
+++ b/widgetssdk/src/main/res/layout/screen_sharing_screen_activity.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.glia.widgets.callvisualizer.ScreenSharingScreenView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/screen_sharing_screen_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/glia_base_light_color"/>

--- a/widgetssdk/src/main/res/layout/screen_sharing_screen_view.xml
+++ b/widgetssdk/src/main/res/layout/screen_sharing_screen_view.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+    <com.glia.widgets.view.header.AppBarView
+        android:id="@+id/app_bar_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        app:titleText="@string/call_visualizer_screen_sharing_title"
+        app:backIcon="@drawable/ic_back"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/screen_sharing_label"
+        style="@style/Application.Glia.Header2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/call_visualizer_label"
+        android:layout_marginBottom="@dimen/glia_large"
+        android:layout_marginStart="@dimen/glia_pre_xx_large"
+        android:layout_marginEnd="@dimen/glia_pre_xx_large"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/end_screen_sharing_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/end_screen_sharing_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/Application.Glia.Header2"
+        android:paddingTop="@dimen/glia_medium"
+        android:paddingBottom="@dimen/glia_medium"
+        android:layout_marginStart="@dimen/glia_pre_xx_large"
+        android:layout_marginEnd="@dimen/glia_pre_xx_large"
+        android:text="@string/call_visualizer_button"
+        app:icon="@drawable/ic_screensharing"
+        app:iconGravity="textStart"
+        app:cornerRadius="5dp"
+        android:textAllCaps="false"
+        android:textColor="@color/glia_base_light_color"
+        app:backgroundTint="@color/glia_system_negative_color"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintTop_toBottomOf="@id/screen_sharing_label"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</merge>

--- a/widgetssdk/src/main/res/values/dimens.xml
+++ b/widgetssdk/src/main/res/values/dimens.xml
@@ -8,6 +8,7 @@
     <dimen name="glia_large">16dp</dimen>
     <dimen name="glia_large_x_large">24dp</dimen>
     <dimen name="glia_x_large">32dp</dimen>
+    <dimen name="glia_pre_xx_large">42dp</dimen>
     <dimen name="glia_xx_large">64dp</dimen>
 
     <dimen name="glia_visitor_video_height">182dp</dimen>

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -227,4 +227,9 @@
     <string name="message_center_check_messages_btn">Check messages</string>
     <string name="message_center_send_message_btn">Send</string>
 
+    <!-- Call Visualizer -->
+    <string name="call_visualizer_screen_sharing_title">Screen Sharing</string>
+    <string name="call_visualizer_label">Your Screen is Being Shared</string>
+    <string name="call_visualizer_button">End Screen Sharing</string>
+
 </resources>

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ScreenSharingScreenControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ScreenSharingScreenControllerTest.kt
@@ -1,0 +1,44 @@
+package com.glia.widgets.callvisualizer
+
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.verifyNoMoreInteractions
+
+internal class ScreenSharingScreenControllerTest {
+
+    private val controller = ScreenSharingScreenController()
+    private val view = mock(ScreenSharingScreenContract.View::class.java)
+
+    @Before
+    fun setup() {
+        controller.setView(view)
+    }
+
+    @Test
+    fun setView() {
+        verifyNoInteractions(view)
+    }
+
+    @Test
+    fun onBackArrowClicked() {
+        controller.onBackArrowClicked()
+        verify(view).finish()
+        verifyNoMoreInteractions(view)
+    }
+
+    @Test
+    fun onEndScreenSharingButtonClicked() {
+        controller.onEndScreenSharingButtonClicked()
+        verify(view).stopScreenSharing()
+        verifyNoMoreInteractions(view)
+    }
+
+    @Test
+    fun onDestroy() {
+        controller.onDestroy()
+        verifyNoInteractions(view)
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.callvisualizer.controller
+
+import android.app.Activity
+import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
+import com.glia.widgets.core.dialog.DialogController
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.*
+
+internal class CallVisualizerControllerTest {
+    private lateinit var callVisualizerController: CallVisualizerController
+    private lateinit var isCallOrChatScreenActiveUseCase: IsCallOrChatScreenActiveUseCase
+    private lateinit var dialogController: DialogController
+
+    @Before
+    fun setUp() {
+        isCallOrChatScreenActiveUseCase = mock(IsCallOrChatScreenActiveUseCase::class.java)
+        dialogController = mock(DialogController::class.java)
+        callVisualizerController = CallVisualizerController(
+            dialogController,
+            isCallOrChatScreenActiveUseCase
+        )
+    }
+
+    @Test
+    fun addDialogCallback_callsSetupDialogCallback_whenIsCallOrChatScreenActiveUseCaseFalse() {
+        val resumedActivity = Activity()
+        `when`(isCallOrChatScreenActiveUseCase(resumedActivity)).thenReturn(false)
+
+        callVisualizerController.addDialogCallback(resumedActivity)
+
+        verify(dialogController, times(1)).addCallback(any(DialogController.Callback::class.java))
+    }
+
+    @Test
+    fun addDialogCallback_doesNotCallSetupDialogCallback_whenIsCallOrChatScreenActiveUseCaseTrue() {
+        val resumedActivity = Activity()
+        `when`(isCallOrChatScreenActiveUseCase(resumedActivity)).thenReturn(true)
+
+        callVisualizerController.addDialogCallback(resumedActivity)
+
+        verify(dialogController, never()).addCallback(any(DialogController.Callback::class.java))
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/domain/IsCallOrChatScreenActiveUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.glia.widgets.callvisualizer.domain
+
+import com.glia.widgets.call.CallActivity
+import com.glia.widgets.chat.ChatActivity
+import com.glia.widgets.filepreview.ui.FilePreviewActivity
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+internal class IsCallOrChatScreenActiveUseCaseTest {
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsFalse_whenNotCallOrChatActivity() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+        val resumedActivity = mock(FilePreviewActivity::class.java)
+
+        Assert.assertFalse(useCase(resumedActivity))
+    }
+
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsTrue_whenChatActivity() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+        val resumedActivity = mock(ChatActivity::class.java)
+
+        Assert.assertTrue(useCase(resumedActivity))
+    }
+
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsTrue_whenCallActivity() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+        val resumedActivity = mock(CallActivity::class.java)
+
+        Assert.assertTrue(useCase(resumedActivity))
+    }
+
+    @Test
+    fun isCallOrChatScreenActiveUseCase_returnsFalse_whenActivityNull() {
+        val useCase = IsCallOrChatScreenActiveUseCase()
+
+        Assert.assertFalse(useCase(null))
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/helper/ActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/helper/ActivityWatcherTest.kt
@@ -1,0 +1,35 @@
+package com.glia.widgets.helper
+
+import android.app.Activity
+import android.app.Application
+import com.glia.widgets.callvisualizer.controller.CallVisualizerController
+import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+internal class ActivityWatcherTest {
+
+    @Test
+    fun resumedActivity_cleared_whenActivityPaused() {
+        val app = mock(Application::class.java)
+        val controller = mock(CallVisualizerController::class.java)
+        val activityWatcher = ActivityWatcher(app, controller)
+
+        activityWatcher.onActivityResumed(mock(Activity::class.java))
+        activityWatcher.onActivityPaused(mock(Activity::class.java))
+
+        assertNull(activityWatcher.resumedActivity)
+    }
+
+    @Test
+    fun resumedActivity_saved_whenActivityResumed() {
+        val app = mock(Application::class.java)
+        val controller = mock(CallVisualizerController::class.java)
+        val activityWatcher = ActivityWatcher(app, controller)
+
+        activityWatcher.onActivityResumed(mock(Activity::class.java))
+
+        assertNotNull(activityWatcher.resumedActivity)
+    }
+}


### PR DESCRIPTION
NOTE:

The icon is wrong atm, because MOB-1682 has not merged yet and the icon was added in that task

Name duplication stems from ScreenSharingController already existing, any renaming recommendations are welcome. Maybe EndScreenSharing?


![app menu](https://user-images.githubusercontent.com/9782505/218945987-a8ee40b5-0737-443f-a1fa-4d8f52dfe46c.png)
![End screen sharing screen](https://user-images.githubusercontent.com/9782505/218945993-02b91dc0-e07c-47c7-ae02-ea6397e46061.png)
