### PR TITLE
Request screen sharing permission in Call Visualizer flow

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -133,6 +133,7 @@ internal class CallView(
     private var onNavigateToChatListener: OnNavigateToChatListener? = null
     private var onNavigateToSurveyListener: OnNavigateToSurveyListener? = null
     private var onTitleUpdatedListener: OnTitleUpdatedListener? = null
+    private var onRequestScreenSharingPermissionCallback: OnRequestScreenSharingPermissionCallback? = null
     private var defaultStatusBarColor: Int? = null
 
     private var operatorVideoView: VideoView? = null
@@ -414,7 +415,10 @@ internal class CallView(
                 resources.getText(R.string.glia_dialog_screen_sharing_offer_message).toString(),
                 R.string.glia_dialog_screen_sharing_offer_accept,
                 R.string.glia_dialog_screen_sharing_offer_decline,
-                { screenSharingController!!.onScreenSharingAccepted(context) }
+                {
+                    onRequestScreenSharingPermissionCallback?.askPermission()
+                    screenSharingController!!.onScreenSharingAccepted(context)
+                }
             ) { screenSharingController!!.onScreenSharingDeclined() }
     }
 
@@ -587,6 +591,12 @@ internal class CallView(
 
     fun setOnNavigateToSurveyListener(onNavigateToSurveyListener: OnNavigateToSurveyListener) {
         this.onNavigateToSurveyListener = onNavigateToSurveyListener
+    }
+
+    fun setOnRequestScreenSharingPermissionCallback(
+        onRequestScreenSharingPermissionCallback: OnRequestScreenSharingPermissionCallback?
+    ) {
+        this.onRequestScreenSharingPermissionCallback = onRequestScreenSharingPermissionCallback
     }
 
     fun setOnTitleUpdatedListener(onTitleUpdatedListener: OnTitleUpdatedListener) {
@@ -831,6 +841,10 @@ internal class CallView(
 
     fun interface OnTitleUpdatedListener {
         fun onTitleUpdated(title: String?)
+    }
+
+    interface OnRequestScreenSharingPermissionCallback {
+        fun askPermission()
     }
 
     @Deprecated("", ReplaceWith("shouldShowMediaEngagementView(isUpgradeToCall)"))

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -416,8 +416,9 @@ internal class CallView(
                 R.string.glia_dialog_screen_sharing_offer_accept,
                 R.string.glia_dialog_screen_sharing_offer_decline,
                 {
-                    onRequestScreenSharingPermissionCallback?.askPermission()
                     screenSharingController!!.onScreenSharingAccepted(context)
+                    // Visitor accepted request, need to ask for screen sharing permission now
+                    onRequestScreenSharingPermissionCallback?.askPermission()
                 }
             ) { screenSharingController!!.onScreenSharingDeclined() }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForDialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForDialogs.kt
@@ -48,6 +48,7 @@ class ActivityWatcherForDialogs(
 
     @VisibleForTesting
     var startMediaProjection: ActivityResultLauncher<Intent>? = null
+
     @VisibleForTesting
     var mediaProjectionManager: MediaProjectionManager? = null
 
@@ -62,8 +63,12 @@ class ActivityWatcherForDialogs(
     var resumedActivity: WeakReference<Activity?> = WeakReference(null)
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
-        // Call and Chat screens process screen sharing requests on their own
-        if (callVisualizerController.isCallOrChatScreenActiveUseCase(activity)) return
+        if (callVisualizerController.isCallOrChatScreenActiveUseCase(activity)) {
+            // Call and Chat screens process screen sharing requests on their own
+            startMediaProjection = null
+            mediaProjectionManager = null
+            return
+        }
         registerForMediaProjectionPermissionResult(activity)
         super.onActivityPreCreated(activity, savedInstanceState)
     }
@@ -110,7 +115,8 @@ class ActivityWatcherForDialogs(
             return
         }
 
-        mediaProjectionManager = componentActivity.getSystemService(MediaProjectionManager::class.java)
+        mediaProjectionManager =
+            componentActivity.getSystemService(MediaProjectionManager::class.java)
         startMediaProjection = componentActivity.registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
         ) { result ->
@@ -323,7 +329,8 @@ class ActivityWatcherForDialogs(
                 startMediaProjection?.let { startMediaProjection ->
                     mediaProjectionManager?.let { mediaProjectionManager ->
                         startMediaProjection.launch(mediaProjectionManager.createScreenCaptureIntent())
-                        Logger.d(TAG, "Acquire a media projection token: launching permission request"
+                        Logger.d(
+                            TAG, "Acquire a media projection token: launching permission request"
                         )
                     }
                 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForDialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForDialogs.kt
@@ -96,9 +96,13 @@ class ActivityWatcherForDialogs(
                 TAG, "Activity does not support ActivityResultRegistry APIs, " +
                         "legacy onActivityResult() will be used to acquire a media projection token"
             )
+            startMediaProjection = null
+            mediaProjectionManager = null
+            return
         }
+
         mediaProjectionManager = activity.getSystemService(MediaProjectionManager::class.java)
-        startMediaProjection = componentActivity?.registerForActivityResult(
+        startMediaProjection = componentActivity.registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
         ) { result ->
             Logger.d(TAG, "Acquire a media projection token: result received")

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -122,6 +122,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     private var onNavigateToCallListener: OnNavigateToCallListener? = null
     private var onNavigateToSurveyListener: OnNavigateToSurveyListener? = null
     private var onBackToCallListener: OnBackToCallListener? = null
+    private var onRequestScreenSharingPermissionCallback: OnRequestScreenSharingPermissionCallback? = null
     private val onOptionClickedListener = OnOptionClickedListener { id, indexInList, optionIndex ->
         Logger.d(TAG, "singleChoiceCardClicked")
         controller?.singleChoiceOptionClicked(id, indexInList, optionIndex)
@@ -275,6 +276,12 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
     fun setOnBackToCallListener(onBackToCallListener: OnBackToCallListener?) {
         this.onBackToCallListener = onBackToCallListener
+    }
+
+    fun setOnRequestScreenSharingPermissionCallback(
+        onRequestScreenSharingPermissionCallback: OnRequestScreenSharingPermissionCallback?
+    ) {
+        this.onRequestScreenSharingPermissionCallback = onRequestScreenSharingPermissionCallback
     }
 
     /**
@@ -571,7 +578,10 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                 resources.getText(R.string.glia_dialog_screen_sharing_offer_message).toString(),
                 R.string.glia_dialog_screen_sharing_offer_accept,
                 R.string.glia_dialog_screen_sharing_offer_decline,
-                { screenSharingController?.onScreenSharingAccepted(context) }
+                {
+                    onRequestScreenSharingPermissionCallback?.askPermission()
+                    screenSharingController?.onScreenSharingAccepted(context)
+                }
             ) { screenSharingController?.onScreenSharingDeclined() }
         }
     }
@@ -1125,6 +1135,10 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
     interface OnTitleUpdatedListener {
         fun onTitleUpdated(title: String?)
+    }
+
+    interface OnRequestScreenSharingPermissionCallback {
+        fun askPermission()
     }
 
     companion object {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -579,8 +579,9 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                 R.string.glia_dialog_screen_sharing_offer_accept,
                 R.string.glia_dialog_screen_sharing_offer_decline,
                 {
-                    onRequestScreenSharingPermissionCallback?.askPermission()
                     screenSharingController?.onScreenSharingAccepted(context)
+                    // Visitor accepted request, need to ask for screen sharing permission now
+                    onRequestScreenSharingPermissionCallback?.askPermission()
                 }
             ) { screenSharingController?.onScreenSharingDeclined() }
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/MediaProjectionService.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/MediaProjectionService.java
@@ -8,12 +8,27 @@ import android.os.IBinder;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
+import com.glia.androidsdk.Engagement;
+import com.glia.androidsdk.Glia;
+import com.glia.androidsdk.omnibrowse.Omnibrowse;
+import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement;
+import com.glia.androidsdk.omnicore.OmnicoreEngagement;
 import com.glia.widgets.core.notification.NotificationFactory;
 
+import java.util.function.Consumer;
+
+/**
+ * Apps targeting SDK version 29 or later require for screen-sharing a running foreground service.
+ * This service requires declaration in the Manifest file.
+ */
 @RequiresApi(api = Build.VERSION_CODES.O)
 public class MediaProjectionService extends Service {
     private static final String TAG = "MediaProjectionService";
     private static final int SERVICE_ID = 123;
+
+    public interface Actions {
+        String START = "EngagementMonitoringService:Start";
+    }
 
     @Nullable
     @Override
@@ -28,16 +43,38 @@ public class MediaProjectionService extends Service {
     }
 
     public void setupAsForegroundService() {
+        // Register this service as a foreground service.
         startForeground(SERVICE_ID, NotificationFactory.createScreenSharingNotification(this));
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        if (Actions.START.equals(intent.getAction())) {
+            setupListeners();
+        }
+
         return Service.START_STICKY;
+    }
+
+    private final Consumer<OmnicoreEngagement> omnicoreEngagementStartListener = (engagement) ->
+            engagement.on(Engagement.Events.END, (Runnable) this::stopSelf);
+
+    private final Consumer<OmnibrowseEngagement> omnibrowseEngagementStartListener = (engagement) ->
+            engagement.on(Engagement.Events.END, (Runnable) this::stopSelf);
+
+    public void setupListeners() {
+        Glia.on(Glia.Events.ENGAGEMENT, omnicoreEngagementStartListener);
+        Glia.omnibrowse.on(Omnibrowse.Events.ENGAGEMENT, omnibrowseEngagementStartListener);
+    }
+
+    public void removeListeners() {
+        Glia.off(Glia.Events.ENGAGEMENT, omnicoreEngagementStartListener);
+        Glia.omnibrowse.off(Omnibrowse.Events.ENGAGEMENT, omnibrowseEngagementStartListener);
     }
 
     @Override
     public void onDestroy() {
+        removeListeners();
         super.onDestroy();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepository.java
@@ -2,8 +2,12 @@ package com.glia.widgets.core.screensharing.data;
 
 import static com.glia.androidsdk.screensharing.ScreenSharing.Status.NOT_SHARING;
 import static com.glia.androidsdk.screensharing.ScreenSharing.Status.SHARING;
+import static com.glia.widgets.core.screensharing.MediaProjectionService.Actions.START;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
 
 import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.Glia;
@@ -16,6 +20,7 @@ import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.androidsdk.screensharing.ScreenSharingRequest;
 import com.glia.androidsdk.screensharing.VisitorScreenSharingState;
 import com.glia.widgets.core.screensharing.GliaScreenSharingCallback;
+import com.glia.widgets.core.screensharing.MediaProjectionService;
 import com.glia.widgets.di.GliaCore;
 import com.glia.widgets.helper.Logger;
 
@@ -54,13 +59,22 @@ public class GliaScreenSharingRepository {
             ScreenSharing.Mode screenSharingMode
     ) {
         Logger.d(TAG, "screen sharing accepted by the user");
-
+        startMediaProjectionService(activity);
         screenSharingRequest.accept(
                 screenSharingMode,
                 activity,
                 UNIQUE_RESULT_CODE,
                 exceptionConsumer
         );
+    }
+
+    @SuppressLint("ShouldUseStaticImport")
+    private void startMediaProjectionService(Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            Intent intent = new Intent(activity, MediaProjectionService.class);
+            intent.setAction(START);
+            activity.startForegroundService(intent);
+        }
     }
 
     public void onScreenSharingDeclined() {
@@ -95,8 +109,6 @@ public class GliaScreenSharingRepository {
             );
         });
 
-        gliaCore.off(Glia.Events.ENGAGEMENT, omnicoreEngagementConsumer);
-        gliaCore.getCallVisualizer().off(Omnibrowse.Events.ENGAGEMENT, omnibrowseEngagementConsumer);
     }
 
     private void onEngagement(Engagement engagement) {
@@ -156,5 +168,5 @@ public class GliaScreenSharingRepository {
     }
 
     private static final String TAG = GliaScreenSharingRepository.class.getSimpleName();
-    private static final int UNIQUE_RESULT_CODE = 0x1994;
+    public static final int UNIQUE_RESULT_CODE = 0x1994;
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -180,7 +180,6 @@ public class ControllerFactory {
 
     public void destroyControllers() {
         destroyCallController();
-        destroyScreenSharingController();
         destroyChatController();
         serviceChatHeadController.onDestroy();
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForDialogsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForDialogsTest.kt
@@ -1,8 +1,14 @@
 package com.glia.widgets.callvisualizer
 
 import android.app.Activity
+import android.media.projection.MediaProjectionManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.fragment.app.FragmentActivity
+import com.glia.widgets.call.CallActivity
 import com.glia.widgets.callvisualizer.controller.CallVisualizerController
 import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
+import com.glia.widgets.chat.ChatActivity
 import com.glia.widgets.core.dialog.Dialog
 import com.glia.widgets.core.dialog.DialogController
 import com.glia.widgets.core.dialog.model.DialogState
@@ -11,7 +17,8 @@ import junit.framework.TestCase.assertNull
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
+import org.mockito.Mockito.*
+import org.mockito.kotlin.verify
 import java.lang.ref.WeakReference
 
 internal class ActivityWatcherForDialogsTest {
@@ -92,5 +99,55 @@ internal class ActivityWatcherForDialogsTest {
         val state = DialogState(Dialog.MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING)
         activityWatcherForDialogs.dialogCallback?.emitDialogState(state)
         assertNotNull(activityWatcherForDialogs.alertDialog)
+    }
+
+    @Test
+    fun mediaProjectionObjects_null_whenChatActivity() {
+        val activity = mock(ChatActivity::class.java)
+        activityWatcherForDialogs.onActivityPreCreated(activity, null)
+
+        assertNull(activityWatcherForDialogs.mediaProjectionManager)
+        assertNull(activityWatcherForDialogs.startMediaProjection)
+    }
+
+    @Test
+    fun mediaProjectionObjects_null_whenCallActivity() {
+        val activity = mock(CallActivity::class.java)
+        activityWatcherForDialogs.onActivityPreCreated(activity, null)
+
+        assertNull(activityWatcherForDialogs.mediaProjectionManager)
+        assertNull(activityWatcherForDialogs.startMediaProjection)
+    }
+
+    @Test
+    fun mediaProjectionObjects_noCreation_whenNotComponentActivity() {
+        val activity = mock(Activity::class.java)
+        activityWatcherForDialogs.registerForMediaProjectionPermissionResult(activity)
+
+        verify(activity, never()).getSystemService(MediaProjectionManager::class.java)
+    }
+
+    @Test
+    fun mediaProjectionObjects_creation_whenComponentActivity() {
+        val activity = mock(ComponentActivity::class.java)
+        activityWatcherForDialogs.registerForMediaProjectionPermissionResult(activity)
+
+        verify(activity, times(1)).getSystemService(MediaProjectionManager::class.java)
+        verify(activity, times(1)).registerForActivityResult(
+            any(ActivityResultContract::class.java),
+            any()
+        )
+    }
+
+    @Test
+    fun mediaProjectionObjects_creation_whenComponentActivitySubclass() {
+        val activity = mock(FragmentActivity::class.java)
+        activityWatcherForDialogs.registerForMediaProjectionPermissionResult(activity)
+
+        verify(activity, times(1)).getSystemService(MediaProjectionManager::class.java)
+        verify(activity, times(1)).registerForActivityResult(
+            any(ActivityResultContract::class.java),
+            any()
+        )
     }
 }


### PR DESCRIPTION
[MOB-1859](https://glia.atlassian.net/browse/MOB-1859)

Not so many changes, but a long description for understanding them. 🙂 

**HOW SCREEN SHARING FLOW WORKS NOW**

1. Operator requests screen sharing
2. Widgets SDK asks the visitor to accept the request via `AlertDialog`
3. If visitor accepts the request, Widgets SDK calls Core SDK [accept()](https://github.com/salemove/android-sdk-widgets/blob/master/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepository.java#L58-L64) function
4. Core SDK inside it's `medra` module calls [startActivityForResult()](https://github.com/salemove/android-sdk/blob/master/medra/src/main/java/com/glia/medra/internal/webrtc/Permissions.java#L39) to [acquire a media projection token](https://developer.android.com/guide/topics/large-screens/media-projection#legacy_approach). Visitor has to accept system permission for exposing sensitive info during casting/recording
5. Widgets SDK overrides the `onActivityResult()` function in [CallActivity](https://github.com/salemove/android-sdk-widgets/blob/master/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java#L130) as well as in [ChatActivity](https://github.com/salemove/android-sdk-widgets/blob/master/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java#L102) and passes result to `GliaWidgets.onActivityResult()` function

**PROBLEM**
It was working well for regular engagements where screen sharing requests could happen only on `CallActivity` or `ChatActivity`. However, for Call Visualizer engagements, screen sharing request should be shown on top of any Activity of an integrator's app (not only `CallActivity` or `ChatActivity`). To make the current approach work, we would have had to ask the integrator to override `onActivityResult()` for each Activity that exists in integrator's app. I think that's not a good way to go.

**SOLUTION**
The idea is to use the [recommended approach](https://developer.android.com/guide/topics/large-screens/media-projection#recommended_approach) for acquiring a media projection token **for all cases, including `CallActivity` and `ChatActivity`**. This approach doesn't need to expect the result in `onActivityResult()` callback. Instead, it registers it's own callback on Activity creation. It's possible to register our own callback for each Activity using the [ActivityWatcher](https://github.com/salemove/android-sdk-widgets/blob/master/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForDialogs.kt) implemented earlier for CallVisualizer. However, we need to keep in mind that this approach works only for `Activity` that is extended from `ComponentActivity`. For other activities (I suppose it's rather rare case) we can offer our legacy approach - integrator will need to override the `onActivityResult()` function and pass result to `GliaWidgets.onActivityResult(requestCode, resultCode, data);` interface.

**NEW LOGIC**

- If permission is requested from `ComponentActivity`=> Core SDK should not call `startActivityForResult()`. It will be done by Widgets SDK. This way we will not show permissions dialog twice for a visitor.
- If permission is requested not from `ComponentActivity`=> `medra` will use Android legacy approach to ask for permission and integrator will need to add `GliaWidgets.onActivityResult(requestCode, resultCode, data);`  into each Activity's `onActivityResult()` function.

**NEW FLOW**

1. Operator requests screen sharing
2. Widgets SDK asks the visitor to accept the request via AlertDialog
3. If visitor accepts the request, Widgets SDK will use the [recommended approach](https://developer.android.com/guide/topics/large-screens/media-projection#recommended_approach) for acquiring a media projection token. So, Widgets SDK will register an Activity result callback and launch Media Projection intent.
4. Visitor has to accept system permission for exposing sensitive info during casting/recording
5. Core SDK checks if permission is asked from ComponentActivity. If so, then `medra` module will not call the legacy `startActivityForResult()`. It will just wait for result in the same place as before.

[MOB-1859]: https://glia.atlassian.net/browse/MOB-1859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ