### PR TITLE
Add/remove MediaUpgradeOfferRepositoryCallback in onResume()/onPauseof ChatView and CallView

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -27,6 +27,8 @@ import com.glia.widgets.core.engagement.domain.model.EngagementStateEvent;
 import com.glia.widgets.core.engagement.domain.model.EngagementStateEventVisitor;
 import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepository;
 import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepositoryCallback;
+import com.glia.widgets.core.mediaupgradeoffer.domain.AddMediaUpgradeOfferCallbackUseCase;
+import com.glia.widgets.core.mediaupgradeoffer.domain.RemoveMediaUpgradeOfferCallbackUseCase;
 import com.glia.widgets.core.notification.domain.RemoveCallNotificationUseCase;
 import com.glia.widgets.core.notification.domain.ShowAudioCallNotificationUseCase;
 import com.glia.widgets.core.notification.domain.ShowVideoCallNotificationUseCase;
@@ -90,6 +92,8 @@ public class CallController implements
     private final IsShowEnableCallNotificationChannelDialogUseCase isShowEnableCallNotificationChannelDialogUseCase;
     private final AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase;
     private final RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase;
+    private final AddMediaUpgradeOfferCallbackUseCase addMediaUpgradeCallbackUseCase;
+    private final RemoveMediaUpgradeOfferCallbackUseCase removeMediaUpgradeCallbackUseCase;
     private final DialogController dialogController;
     private final GliaSurveyUseCase surveyUseCase;
     private final ToggleVisitorAudioMediaMuteUseCase toggleVisitorAudioMediaMuteUseCase;
@@ -131,6 +135,8 @@ public class CallController implements
             GliaSurveyUseCase surveyUseCase,
             AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase,
             RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase,
+            AddMediaUpgradeOfferCallbackUseCase addMediaUpgradeCallbackUseCase,
+            RemoveMediaUpgradeOfferCallbackUseCase removeMediaUpgradeCallbackUseCase,
             ToggleVisitorAudioMediaMuteUseCase toggleVisitorAudioMediaMuteUseCase,
             ToggleVisitorVideoUseCase toggleVisitorVideoUseCase,
             GetEngagementStateFlowableUseCase getGliaEngagementStateFlowableUseCase,
@@ -172,6 +178,8 @@ public class CallController implements
         this.surveyUseCase = surveyUseCase;
         this.addVisitorMediaStateListenerUseCase = addVisitorMediaStateListenerUseCase;
         this.removeVisitorMediaStateListenerUseCase = removeVisitorMediaStateListenerUseCase;
+        this.addMediaUpgradeCallbackUseCase = addMediaUpgradeCallbackUseCase;
+        this.removeMediaUpgradeCallbackUseCase = removeMediaUpgradeCallbackUseCase;
         this.toggleVisitorAudioMediaMuteUseCase = toggleVisitorAudioMediaMuteUseCase;
         this.toggleVisitorVideoUseCase = toggleVisitorVideoUseCase;
         this.getGliaEngagementStateFlowableUseCase = getGliaEngagementStateFlowableUseCase;
@@ -241,7 +249,6 @@ public class CallController implements
                         )
         );
         onEngagementEndUseCase.execute(this);
-        mediaUpgradeOfferRepository.addCallback(mediaUpgradeOfferRepositoryCallback);
         inactivityTimeCounter.addRawValueListener(inactivityTimerStatusListener);
         connectingTimerCounter.addRawValueListener(connectingTimerStatusListener);
         minimizeHandler.addListener(this::minimizeView);
@@ -280,6 +287,9 @@ public class CallController implements
     public void onPause() {
         surveyUseCase.unregisterListener(this);
         removeVisitorMediaStateListenerUseCase.execute(this);
+        if(mediaUpgradeOfferRepositoryCallback != null) {
+            removeMediaUpgradeCallbackUseCase.invoke(mediaUpgradeOfferRepositoryCallback);
+        }
     }
 
     public void leaveChatClicked() {
@@ -337,6 +347,7 @@ public class CallController implements
 
         surveyUseCase.registerListener(this);
         subscribeToEngagementStateChange();
+        addMediaUpgradeCallbackUseCase.invoke(mediaUpgradeOfferRepositoryCallback);
     }
 
     public void chatButtonClicked() {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/MediaUpgradeOfferRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/MediaUpgradeOfferRepository.java
@@ -33,6 +33,11 @@ public class MediaUpgradeOfferRepository {
         callbacks.add(callback);
     }
 
+    public void removeCallback(MediaUpgradeOfferRepositoryCallback callback) {
+        Logger.d(TAG, "removeCallback");
+        callbacks.remove(callback);
+    }
+
     public void acceptOffer(MediaUpgradeOffer offer, Submitter submitter) {
         offer.accept(exception -> {
             if (exception == null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/domain/AddMediaUpgradeOfferCallbackUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/domain/AddMediaUpgradeOfferCallbackUseCase.kt
@@ -1,0 +1,12 @@
+package com.glia.widgets.core.mediaupgradeoffer.domain
+
+import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepository
+import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepositoryCallback
+
+class AddMediaUpgradeOfferCallbackUseCase(
+    private val mediaUpgradeOfferRepository: MediaUpgradeOfferRepository
+) {
+    operator fun invoke(callback: MediaUpgradeOfferRepositoryCallback) {
+        mediaUpgradeOfferRepository.addCallback(callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/domain/RemoveMediaUpgradeOfferCallbackUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/domain/RemoveMediaUpgradeOfferCallbackUseCase.kt
@@ -1,0 +1,12 @@
+package com.glia.widgets.core.mediaupgradeoffer.domain
+
+import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepository
+import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepositoryCallback
+
+class RemoveMediaUpgradeOfferCallbackUseCase(
+    private val mediaUpgradeOfferRepository: MediaUpgradeOfferRepository
+) {
+    operator fun invoke(callback: MediaUpgradeOfferRepositoryCallback) {
+        mediaUpgradeOfferRepository.removeCallback(callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -117,7 +117,9 @@ public class ControllerFactory {
                     useCaseFactory.createCustomCardTypeUseCase(),
                     useCaseFactory.createCustomCardInteractableUseCase(),
                     useCaseFactory.createCustomCardShouldShowUseCase(),
-                    useCaseFactory.createQueueTicketStateChangeToUnstaffedUseCase());
+                    useCaseFactory.createQueueTicketStateChangeToUnstaffedUseCase(),
+                    useCaseFactory.createAddMediaUpgradeOfferCallbackUseCase(),
+                    useCaseFactory.createRemoveMediaUpgradeOfferCallbackUseCase());
         } else {
             Logger.d(TAG, "retained chat controller");
             retainedChatController.setViewCallback(chatViewCallback);
@@ -153,6 +155,8 @@ public class ControllerFactory {
                     useCaseFactory.getGliaSurveyUseCase(),
                     useCaseFactory.createAddVisitorMediaStateListenerUseCase(),
                     useCaseFactory.createRemoveVisitorMediaStateListenerUseCase(),
+                    useCaseFactory.createAddMediaUpgradeOfferCallbackUseCase(),
+                    useCaseFactory.createRemoveMediaUpgradeOfferCallbackUseCase(),
                     useCaseFactory.createToggleVisitorAudioMediaMuteUseCase(),
                     useCaseFactory.createToggleVisitorVideoUseCase(),
                     useCaseFactory.createGetGliaEngagementStateFlowableUseCase(),

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -36,6 +36,8 @@ import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
 import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.MapOperatorUseCase;
+import com.glia.widgets.core.mediaupgradeoffer.domain.AddMediaUpgradeOfferCallbackUseCase;
+import com.glia.widgets.core.mediaupgradeoffer.domain.RemoveMediaUpgradeOfferCallbackUseCase;
 import com.glia.widgets.core.queue.domain.QueueTicketStateChangeToUnstaffedUseCase;
 import com.glia.widgets.core.survey.domain.GliaSurveyUseCase;
 import com.glia.widgets.core.engagement.domain.ShouldShowMediaEngagementViewUseCase;
@@ -450,5 +452,13 @@ public class UseCaseFactory {
 
     public IsCallVisualizerUseCase createIsCallVisualizerUseCase() {
         return new IsCallVisualizerUseCase();
+    }
+
+    public AddMediaUpgradeOfferCallbackUseCase createAddMediaUpgradeOfferCallbackUseCase() {
+        return new AddMediaUpgradeOfferCallbackUseCase(repositoryFactory.getMediaUpgradeOfferRepository());
+    }
+
+    public RemoveMediaUpgradeOfferCallbackUseCase createRemoveMediaUpgradeOfferCallbackUseCase() {
+        return new RemoveMediaUpgradeOfferCallbackUseCase(repositoryFactory.getMediaUpgradeOfferRepository());
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -14,6 +14,8 @@ import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase
 import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
 import com.glia.widgets.core.fileupload.domain.*
 import com.glia.widgets.core.mediaupgradeoffer.MediaUpgradeOfferRepository
+import com.glia.widgets.core.mediaupgradeoffer.domain.AddMediaUpgradeOfferCallbackUseCase
+import com.glia.widgets.core.mediaupgradeoffer.domain.RemoveMediaUpgradeOfferCallbackUseCase
 import com.glia.widgets.core.notification.domain.RemoveCallNotificationUseCase
 import com.glia.widgets.core.notification.domain.ShowAudioCallNotificationUseCase
 import com.glia.widgets.core.notification.domain.ShowVideoCallNotificationUseCase
@@ -73,6 +75,8 @@ class ChatControllerTest {
     private lateinit var customCardInteractableUseCase: CustomCardInteractableUseCase
     private lateinit var customCardShouldShowUseCase: CustomCardShouldShowUseCase
     private lateinit var ticketStateChangeToUnstaffedUseCase: QueueTicketStateChangeToUnstaffedUseCase
+    private lateinit var addMediaUpgradeOfferCallbackUseCase: AddMediaUpgradeOfferCallbackUseCase
+    private lateinit var removeMediaUpgradeOfferCallbackUseCase: RemoveMediaUpgradeOfferCallbackUseCase
 
     private lateinit var chatController: ChatController
 
@@ -118,6 +122,8 @@ class ChatControllerTest {
         customCardInteractableUseCase = mock()
         customCardShouldShowUseCase = mock()
         ticketStateChangeToUnstaffedUseCase = mock()
+        addMediaUpgradeOfferCallbackUseCase = mock()
+        removeMediaUpgradeOfferCallbackUseCase = mock()
 
         chatController = ChatController(chatViewCallback, mediaUpgradeOfferRepository, callTimer,
             minimizeHandler, dialogController, messagesNotSeenHandler, showAudioCallNotificationUseCase,
@@ -131,7 +137,8 @@ class ChatControllerTest {
             isShowOverlayPermissionRequestDialogUseCase, downloadFileUseCase, isEnableChatEditTextUseCase,
             siteInfoUseCase, surveyUseCase, getGliaEngagementStateFlowableUseCase, isFromCallScreenUseCase,
             updateFromCallScreenUseCase, customCardAdapterTypeUseCase, customCardTypeUseCase,
-            customCardInteractableUseCase, customCardShouldShowUseCase, ticketStateChangeToUnstaffedUseCase)
+            customCardInteractableUseCase, customCardShouldShowUseCase, ticketStateChangeToUnstaffedUseCase,
+            addMediaUpgradeOfferCallbackUseCase, removeMediaUpgradeOfferCallbackUseCase)
     }
 
     @Test


### PR DESCRIPTION
This will avoid AlertDialog extra creation when switching between Chat and Call and avoid memory leak on Call/Chat screen closing

[MOB-1880](https://glia.atlassian.net/browse/MOB-1880)

**Steps to reproduce the issue:**

- visitor starts a chat engagement
- operator upgrades to One-Way video
- visitor accepts
- visitor goes back to Chat screen
- operator upgrades to Two-Way video
- visitor accepts
- visitor goes back to Chat screen

**Expected result:** AlertDialog is closed
**Actual result:** Two-Way video upgrade dialog is still displayed and cannot be dismissed

Video recording of the bug can be found in [SSD-33295](https://glia.atlassian.net/browse/SSD-33295)

**Reason:** ChatView and CallView stay alive and MediaUpgradeOfferRepositoryCallback is registered for both screens' controllers.

**Solution:** add/remove MediaUpgradeOfferRepositoryCallback in onResume()/onPauseof ChatView and CallView


[MOB-1880]: https://glia.atlassian.net/browse/MOB-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SSD-33295]: https://glia.atlassian.net/browse/SSD-33295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ