### PR TITLE
Mark messages in chat transcript as read after six seconds

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/history/NewMessagesItem.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/history/NewMessagesItem.kt
@@ -1,0 +1,6 @@
+package com.glia.widgets.chat.model.history
+
+import com.glia.widgets.chat.adapter.ChatAdapter
+import java.util.*
+
+object NewMessagesItem : ChatItem(UUID.randomUUID().toString(), ChatAdapter.NEW_MESSAGES_DIVIDER_TYPE)

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadWithDelayUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadWithDelayUseCase.kt
@@ -1,0 +1,33 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import androidx.annotation.VisibleForTesting
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.helper.Logger
+import io.reactivex.Completable
+import java.util.concurrent.TimeUnit
+
+private const val TAG = "MarkMessagesReadUseCase"
+
+@VisibleForTesting
+const val DELAY_SEC = 6L
+
+internal class MarkMessagesReadWithDelayUseCase(private val repository: SecureConversationsRepository) {
+
+    operator fun invoke(): Completable = Completable.timer(DELAY_SEC, TimeUnit.SECONDS)
+        .andThen(markMessagesRead())
+        .doOnComplete { Logger.d(TAG, "Messages successfully marked as read") }
+
+    private fun markMessagesRead(): Completable = Completable.create {
+        if (it.isDisposed) return@create
+
+        repository.markMessagesRead call@{ _, exception ->
+            if (it.isDisposed) return@call
+            if (exception != null) {
+                it.onError(exception)
+            } else {
+                it.onComplete()
+            }
+        }
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -119,7 +119,8 @@ public class ControllerFactory {
                     useCaseFactory.createIsOngoingEngagementUseCase(),
                     useCaseFactory.createIsSecureEngagementUseCase(),
                     useCaseFactory.createSetEngagementConfigUseCase(),
-                    useCaseFactory.createIsSecureConversationsChatAvailableUseCase()
+                    useCaseFactory.createIsSecureConversationsChatAvailableUseCase(),
+                    useCaseFactory.createMarkMessagesReadUseCase()
             );
         } else {
             Logger.d(TAG, "retained chat controller");

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -1,5 +1,7 @@
 package com.glia.widgets.di;
 
+import androidx.annotation.NonNull;
+
 import com.glia.androidsdk.visitor.Authentication;
 import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.call.domain.ToggleVisitorAudioMediaMuteUseCase;
@@ -67,6 +69,7 @@ import com.glia.widgets.core.secureconversations.domain.GetSecureFileAttachments
 import com.glia.widgets.core.secureconversations.domain.IsMessageCenterAvailableUseCase;
 import com.glia.widgets.core.secureconversations.domain.IsMessagingAvailableUseCase;
 import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase;
+import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase;
 import com.glia.widgets.core.secureconversations.domain.RemoveSecureFileAttachmentObserverUseCase;
 import com.glia.widgets.core.secureconversations.domain.RemoveSecureFileAttachmentUseCase;
 import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase;
@@ -122,6 +125,7 @@ public class UseCaseFactory {
         this.gliaCore = gliaCore;
     }
 
+    @NonNull
     public ToggleChatHeadServiceUseCase getToggleChatHeadServiceUseCase() {
         if (toggleChatHeadServiceUseCase == null) {
             toggleChatHeadServiceUseCase = new ToggleChatHeadServiceUseCase(
@@ -136,6 +140,7 @@ public class UseCaseFactory {
         return toggleChatHeadServiceUseCase;
     }
 
+    @NonNull
     public IsDisplayApplicationChatHeadUseCase getIsDisplayApplicationChatHeadUseCase() {
         if (isDisplayApplicationChatHeadUseCase == null) {
             isDisplayApplicationChatHeadUseCase = new IsDisplayApplicationChatHeadUseCase(
@@ -149,6 +154,7 @@ public class UseCaseFactory {
         return isDisplayApplicationChatHeadUseCase;
     }
 
+    @NonNull
     public ResolveChatHeadNavigationUseCase getResolveChatHeadNavigationUseCase() {
         if (resolveChatHeadNavigationUseCase == null) {
             resolveChatHeadNavigationUseCase = new ResolveChatHeadNavigationUseCase(
@@ -160,36 +166,42 @@ public class UseCaseFactory {
         return resolveChatHeadNavigationUseCase;
     }
 
+    @NonNull
     public ShowAudioCallNotificationUseCase createShowAudioCallNotificationUseCase() {
         if (showAudioCallNotificationUseCase == null)
             showAudioCallNotificationUseCase = new ShowAudioCallNotificationUseCase(notificationManager);
         return showAudioCallNotificationUseCase;
     }
 
+    @NonNull
     public ShowVideoCallNotificationUseCase createShowVideoCallNotificationUseCase() {
         if (showVideoCallNotificationUseCase == null)
             showVideoCallNotificationUseCase = new ShowVideoCallNotificationUseCase(notificationManager);
         return showVideoCallNotificationUseCase;
     }
 
+    @NonNull
     public RemoveCallNotificationUseCase createRemoveCallNotificationUseCase() {
         if (removeCallNotificationUseCase == null)
             removeCallNotificationUseCase = new RemoveCallNotificationUseCase(notificationManager);
         return removeCallNotificationUseCase;
     }
 
+    @NonNull
     public ShowScreenSharingNotificationUseCase createShowScreenSharingNotificationUseCase() {
         if (showScreenSharingNotificationUseCase == null)
             showScreenSharingNotificationUseCase = new ShowScreenSharingNotificationUseCase(notificationManager);
         return showScreenSharingNotificationUseCase;
     }
 
+    @NonNull
     public RemoveScreenSharingNotificationUseCase createRemoveScreenSharingNotificationUseCase() {
         if (removeScreenSharingNotificationUseCase == null)
             removeScreenSharingNotificationUseCase = new RemoveScreenSharingNotificationUseCase(notificationManager);
         return removeScreenSharingNotificationUseCase;
     }
 
+    @NonNull
     public GliaLoadHistoryUseCase createGliaLoadHistoryUseCase() {
         return new GliaLoadHistoryUseCase(
                 repositoryFactory.getGliaMessageRepository(),
@@ -199,10 +211,12 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public MapOperatorUseCase getMapOperatorUseCase() {
         return new MapOperatorUseCase(getOperatorUseCase());
     }
 
+    @NonNull
     public GliaQueueForChatEngagementUseCase createQueueForChatEngagementUseCase() {
         if (gliaQueueForChatEngagementUseCase == null) {
             gliaQueueForChatEngagementUseCase = new GliaQueueForChatEngagementUseCase(
@@ -214,6 +228,7 @@ public class UseCaseFactory {
         return gliaQueueForChatEngagementUseCase;
     }
 
+    @NonNull
     public GliaQueueForMediaEngagementUseCase createQueueForMediaEngagementUseCase() {
         if (gliaQueueForMediaEngagementUseCase == null) {
             gliaQueueForMediaEngagementUseCase = new GliaQueueForMediaEngagementUseCase(
@@ -225,6 +240,7 @@ public class UseCaseFactory {
         return gliaQueueForMediaEngagementUseCase;
     }
 
+    @NonNull
     public GliaCancelQueueTicketUseCase createCancelQueueTicketUseCase() {
         return new GliaCancelQueueTicketUseCase(
                 schedulers,
@@ -232,10 +248,12 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public GliaEndEngagementUseCase createEndEngagementUseCase() {
         return new GliaEndEngagementUseCase(repositoryFactory.getGliaEngagementRepository());
     }
 
+    @NonNull
     public GliaOnEngagementUseCase createOnEngagementUseCase() {
         return new GliaOnEngagementUseCase(
                 repositoryFactory.getGliaEngagementRepository(),
@@ -246,6 +264,7 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public GliaOnEngagementEndUseCase createOnEngagementEndUseCase() {
         return new GliaOnEngagementEndUseCase(
                 repositoryFactory.getGliaEngagementRepository(),
@@ -260,6 +279,7 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public GliaOnMessageUseCase createGliaOnMessageUseCase() {
         return new GliaOnMessageUseCase(
                 repositoryFactory.getGliaMessageRepository(),
@@ -267,6 +287,7 @@ public class UseCaseFactory {
                 getMapOperatorUseCase());
     }
 
+    @NonNull
     public GliaOnOperatorTypingUseCase createGliaOnOperatorTypingUseCase() {
         return new GliaOnOperatorTypingUseCase(
                 repositoryFactory.getGliaMessageRepository(),
@@ -274,10 +295,12 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public GliaSendMessagePreviewUseCase createGliaSendMessagePreviewUseCase() {
         return new GliaSendMessagePreviewUseCase(repositoryFactory.getGliaMessageRepository());
     }
 
+    @NonNull
     public GliaSendMessageUseCase createGliaSendMessageUseCase() {
         return new GliaSendMessageUseCase(
                 repositoryFactory.getGliaMessageRepository(),
@@ -289,12 +312,14 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public AddOperatorMediaStateListenerUseCase createAddOperatorMediaStateListenerUseCase() {
         return new AddOperatorMediaStateListenerUseCase(
                 repositoryFactory.getGliaOperatorMediaRepository()
         );
     }
 
+    @NonNull
     public ShouldShowMediaEngagementViewUseCase createShouldShowMediaEngagementViewUseCase() {
         return new ShouldShowMediaEngagementViewUseCase(
                 repositoryFactory.getGliaEngagementRepository(),
@@ -303,10 +328,12 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public AddFileAttachmentsObserverUseCase createAddFileAttachmentsObserverUseCase() {
         return new AddFileAttachmentsObserverUseCase(repositoryFactory.getGliaFileAttachmentRepository());
     }
 
+    @NonNull
     public AddFileToAttachmentAndUploadUseCase createAddFileToAttachmentAndUploadUseCase() {
         return new AddFileToAttachmentAndUploadUseCase(
                 repositoryFactory.getGliaEngagementRepository(),
@@ -315,22 +342,27 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public GetFileAttachmentsUseCase createGetFileAttachmentsUseCase() {
         return new GetFileAttachmentsUseCase(repositoryFactory.getGliaFileAttachmentRepository());
     }
 
+    @NonNull
     public RemoveFileAttachmentObserverUseCase createRemoveFileAttachmentObserverUseCase() {
         return new RemoveFileAttachmentObserverUseCase(repositoryFactory.getGliaFileAttachmentRepository());
     }
 
+    @NonNull
     public RemoveFileAttachmentUseCase createRemoveFileAttachmentUseCase() {
         return new RemoveFileAttachmentUseCase(repositoryFactory.getGliaFileAttachmentRepository());
     }
 
+    @NonNull
     public SupportedFileCountCheckUseCase createSupportedFileCountCheckUseCase() {
         return new SupportedFileCountCheckUseCase(repositoryFactory.getGliaFileAttachmentRepository());
     }
 
+    @NonNull
     public IsShowSendButtonUseCase createIsShowSendButtonUseCase() {
         return new IsShowSendButtonUseCase(
                 repositoryFactory.getGliaEngagementRepository(),
@@ -338,74 +370,92 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public HasScreenSharingNotificationChannelEnabledUseCase createHasScreenSharingNotificationChannelEnabledUseCase() {
         return new HasScreenSharingNotificationChannelEnabledUseCase(permissionManager);
     }
 
+    @NonNull
     public IsShowOverlayPermissionRequestDialogUseCase createIsShowOverlayPermissionRequestDialogUseCase() {
         return new IsShowOverlayPermissionRequestDialogUseCase(permissionManager, permissionDialogManager, gliaSdkConfigurationManager);
     }
 
+    @NonNull
     public HasCallNotificationChannelEnabledUseCase createHasCallNotificationChannelEnabledUseCase() {
         return new HasCallNotificationChannelEnabledUseCase(permissionManager);
     }
 
+    @NonNull
     public IsShowEnableCallNotificationChannelDialogUseCase createIsShowEnableCallNotificationChannelDialogUseCase() {
         return new IsShowEnableCallNotificationChannelDialogUseCase(permissionManager, permissionDialogManager);
     }
 
+    @NonNull
     public SetOverlayPermissionRequestDialogShownUseCase createSetOverlayPermissionRequestDialogShownUseCase() {
         return new SetOverlayPermissionRequestDialogShownUseCase(permissionDialogManager);
     }
 
+    @NonNull
     public SetEnableCallNotificationChannelDialogShownUseCase createSetEnableCallNotificationChannelDialogShownUseCase() {
         return new SetEnableCallNotificationChannelDialogShownUseCase(permissionDialogManager);
     }
 
+    @NonNull
     public GetImageFileFromDownloadsUseCase createGetImageFileFromDownloadsUseCase() {
         return new GetImageFileFromDownloadsUseCase(repositoryFactory.getGliaFileRepository());
     }
 
+    @NonNull
     public GetImageFileFromCacheUseCase createGetImageFileFromCacheUseCase() {
         return new GetImageFileFromCacheUseCase(repositoryFactory.getGliaFileRepository());
     }
 
+    @NonNull
     public GetImageFileFromNetworkUseCase createGetImageFileFromNetworkUseCase() {
         return new GetImageFileFromNetworkUseCase(repositoryFactory.getGliaFileRepository());
     }
 
+    @NonNull
     public PutImageFileToDownloadsUseCase createPutImageFileToDownloadsUseCase() {
         return new PutImageFileToDownloadsUseCase(repositoryFactory.getGliaFileRepository());
     }
 
+    @NonNull
     public DownloadFileUseCase createDownloadFileUseCase() {
         return new DownloadFileUseCase(repositoryFactory.getGliaFileRepository());
     }
 
+    @NonNull
     public IsEnableChatEditTextUseCase createIsEnableChatEditTextUseCase() {
         return new IsEnableChatEditTextUseCase();
     }
 
+    @NonNull
     public SiteInfoUseCase createSiteInfoUseCase() {
         return new SiteInfoUseCase(repositoryFactory.getGliaEngagementRepository());
     }
 
+    @NonNull
     public GliaSurveyUseCase getGliaSurveyUseCase() {
         return new GliaSurveyUseCase(repositoryFactory.getGliaSurveyRepository());
     }
 
+    @NonNull
     public GliaSurveyAnswerUseCase getSurveyAnswerUseCase() {
         return new GliaSurveyAnswerUseCase(repositoryFactory.getGliaSurveyRepository());
     }
 
+    @NonNull
     public AddVisitorMediaStateListenerUseCase createAddVisitorMediaStateListenerUseCase() {
         return new AddVisitorMediaStateListenerUseCase(repositoryFactory.getGliaVisitorMediaRepository());
     }
 
+    @NonNull
     public RemoveVisitorMediaStateListenerUseCase createRemoveVisitorMediaStateListenerUseCase() {
         return new RemoveVisitorMediaStateListenerUseCase(repositoryFactory.getGliaVisitorMediaRepository());
     }
 
+    @NonNull
     public ToggleVisitorAudioMediaMuteUseCase createToggleVisitorAudioMediaMuteUseCase() {
         return new ToggleVisitorAudioMediaMuteUseCase(
                 schedulers,
@@ -413,6 +463,7 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public ToggleVisitorVideoUseCase createToggleVisitorVideoUseCase() {
         return new ToggleVisitorVideoUseCase(
                 schedulers,
@@ -420,58 +471,72 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public IsShowVideoUseCase createIsShowVideoUseCase() {
         return new IsShowVideoUseCase(schedulers);
     }
 
+    @NonNull
     public IsShowOnHoldUseCase createIsShowOnHoldUseCase() {
         return new IsShowOnHoldUseCase(schedulers);
     }
 
+    @NonNull
     public GetEngagementStateFlowableUseCase createGetGliaEngagementStateFlowableUseCase() {
         return new GetEngagementStateFlowableUseCase(repositoryFactory.getGliaEngagementStateRepository());
     }
 
+    @NonNull
     public GetOperatorFlowableUseCase createGetOperatorFlowableUseCase() {
         return new GetOperatorFlowableUseCase(repositoryFactory.getGliaEngagementStateRepository());
     }
 
+    @NonNull
     public IsFromCallScreenUseCase createIsFromCallScreenUseCase() {
         return new IsFromCallScreenUseCase(repositoryFactory.getChatScreenRepository());
     }
 
+    @NonNull
     public UpdateFromCallScreenUseCase createUpdateFromCallScreenUseCase() {
         return new UpdateFromCallScreenUseCase(repositoryFactory.getChatScreenRepository());
     }
 
+    @NonNull
     public GetOperatorUseCase getOperatorUseCase() {
         return new GetOperatorUseCase(repositoryFactory.getOperatorRepository());
     }
 
+    @NonNull
     public CustomCardTypeUseCase createCustomCardTypeUseCase() {
         return new CustomCardTypeUseCase(GliaWidgets.getCustomCardAdapter());
     }
 
+    @NonNull
     public CustomCardAdapterTypeUseCase createCustomCardAdapterTypeUseCase() {
         return new CustomCardAdapterTypeUseCase(GliaWidgets.getCustomCardAdapter());
     }
 
+    @NonNull
     public CustomCardInteractableUseCase createCustomCardInteractableUseCase() {
         return new CustomCardInteractableUseCase(GliaWidgets.getCustomCardAdapter());
     }
 
+    @NonNull
     public CustomCardShouldShowUseCase createCustomCardShouldShowUseCase() {
         return new CustomCardShouldShowUseCase(GliaWidgets.getCustomCardAdapter());
     }
 
+    @NonNull
     public QueueTicketStateChangeToUnstaffedUseCase createQueueTicketStateChangeToUnstaffedUseCase() {
         return new QueueTicketStateChangeToUnstaffedUseCase(repositoryFactory.getGliaQueueRepository());
     }
 
+    @NonNull
     public IsGliaActivityUseCase createIsCallOrChatScreenActiveUseCase() {
         return new IsGliaActivityUseCase();
     }
 
+    @NonNull
     public SendSecureMessageUseCase createSendSecureMessageUseCase(String queueId) {
         return new SendSecureMessageUseCase(
                 queueId,
@@ -479,30 +544,37 @@ public class UseCaseFactory {
                 repositoryFactory.getSecureFileAttachmentRepository());
     }
 
+    @NonNull
     public IsMessageCenterAvailableUseCase createIsMessageCenterAvailableUseCase(String queueId) {
         return new IsMessageCenterAvailableUseCase(queueId, createIsMessagingAvailableUseCase());
     }
 
+    @NonNull
     public AddSecureFileToAttachmentAndUploadUseCase createAddSecureFileToAttachmentAndUploadUseCase() {
         return new AddSecureFileToAttachmentAndUploadUseCase(repositoryFactory.getSecureFileAttachmentRepository());
     }
 
+    @NonNull
     public AddSecureFileAttachmentsObserverUseCase createAddSecureFileAttachmentsObserverUseCase() {
         return new AddSecureFileAttachmentsObserverUseCase(repositoryFactory.getSecureFileAttachmentRepository());
     }
 
+    @NonNull
     public GetSecureFileAttachmentsUseCase createGetSecureFileAttachmentsUseCase() {
         return new GetSecureFileAttachmentsUseCase(repositoryFactory.getSecureFileAttachmentRepository());
     }
 
+    @NonNull
     public RemoveSecureFileAttachmentObserverUseCase createRemoveSecureFileAttachmentObserverUseCase() {
         return new RemoveSecureFileAttachmentObserverUseCase(repositoryFactory.getSecureFileAttachmentRepository());
     }
 
+    @NonNull
     public RemoveSecureFileAttachmentUseCase createRemoveSecureFileAttachmentUseCase() {
         return new RemoveSecureFileAttachmentUseCase(repositoryFactory.getSecureFileAttachmentRepository());
     }
 
+    @NonNull
     public IsSecureEngagementUseCase createIsSecureEngagementUseCase() {
         return new IsSecureEngagementUseCase(
                 repositoryFactory.getEngagementConfigRepository(),
@@ -510,26 +582,36 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public IsAuthenticatedUseCase createIsAuthenticatedUseCase() {
         return new IsAuthenticatedUseCase(gliaCore.getAuthentication(Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT));
     }
 
+    @NonNull
     public SetEngagementConfigUseCase createSetEngagementConfigUseCase() {
         return new SetEngagementConfigUseCase(repositoryFactory.getEngagementConfigRepository());
     }
 
+    @NonNull
     public IsOngoingEngagementUseCase createIsOngoingEngagementUseCase() {
         return new IsOngoingEngagementUseCase(repositoryFactory.getGliaEngagementRepository());
     }
 
+    @NonNull
     public IsMessagingAvailableUseCase createIsMessagingAvailableUseCase() {
         return new IsMessagingAvailableUseCase(repositoryFactory.getGliaQueueRepository(), schedulers);
     }
 
+    @NonNull
     public IsSecureConversationsChatAvailableUseCase createIsSecureConversationsChatAvailableUseCase() {
         return new IsSecureConversationsChatAvailableUseCase(
                 repositoryFactory.getEngagementConfigRepository(),
                 createIsMessagingAvailableUseCase()
         );
+    }
+
+    @NonNull
+    public MarkMessagesReadWithDelayUseCase createMarkMessagesReadUseCase() {
+        return new MarkMessagesReadWithDelayUseCase(repositoryFactory.getSecureConversationsRepository());
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -19,6 +19,7 @@ import com.glia.widgets.core.queue.domain.GliaCancelQueueTicketUseCase
 import com.glia.widgets.core.queue.domain.GliaQueueForChatEngagementUseCase
 import com.glia.widgets.core.queue.domain.QueueTicketStateChangeToUnstaffedUseCase
 import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase
+import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase
 import com.glia.widgets.core.survey.domain.GliaSurveyUseCase
 import com.glia.widgets.filepreview.domain.usecase.DownloadFileUseCase
 import com.glia.widgets.helper.TimeCounter
@@ -75,6 +76,7 @@ class ChatControllerTest {
     private lateinit var isSecureEngagementUseCase: IsSecureEngagementUseCase
     private lateinit var engagementConfigUseCase: SetEngagementConfigUseCase
     private lateinit var isSecureConversationsChatAvailableUseCase: IsSecureConversationsChatAvailableUseCase
+    private lateinit var markMessagesReadWithDelayUseCase: MarkMessagesReadWithDelayUseCase
 
     private lateinit var chatController: ChatController
 
@@ -124,6 +126,7 @@ class ChatControllerTest {
         isSecureEngagementUseCase = mock()
         engagementConfigUseCase = mock()
         isSecureConversationsChatAvailableUseCase = mock()
+        markMessagesReadWithDelayUseCase = mock()
 
         chatController = ChatController(
             chatViewCallback = chatViewCallback,
@@ -169,7 +172,8 @@ class ChatControllerTest {
             isOngoingEngagementUseCase = isOngoingEngagementUseCase,
             isSecureEngagementUseCase = isSecureEngagementUseCase,
             engagementConfigUseCase = engagementConfigUseCase,
-            isSecureEngagementAvailableUseCase = isSecureConversationsChatAvailableUseCase
+            isSecureEngagementAvailableUseCase = isSecureConversationsChatAvailableUseCase,
+            markMessagesReadWithDelayUseCase = markMessagesReadWithDelayUseCase,
         )
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadWithDelayUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadWithDelayUseCaseTest.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.TestScheduler
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+import java.util.concurrent.TimeUnit
+import kotlin.properties.Delegates
+
+class MarkMessagesReadWithDelayUseCaseTest {
+    private var repository: SecureConversationsRepository by Delegates.notNull()
+    private var useCase: MarkMessagesReadWithDelayUseCase by Delegates.notNull()
+
+    @Before
+    fun setUp() {
+        repository = mock()
+        useCase = MarkMessagesReadWithDelayUseCase(repository)
+        RxJavaPlugins.reset()
+    }
+
+    @After
+    fun tearDown() = RxJavaPlugins.reset()
+
+    @Test
+    fun `invoke calls mark messages read after expected delay`() {
+        val testScheduler = TestScheduler()
+        RxJavaPlugins.setComputationSchedulerHandler { testScheduler }
+
+        doAnswer {
+            val callback: RequestCallback<Void> = it.getArgument(0)
+            callback.onResult(null, null)
+        }.whenever(repository).markMessagesRead(any())
+
+        val testObservable = useCase().test()
+        verify(repository, never()).markMessagesRead(any())
+        testScheduler.advanceTimeBy(DELAY_SEC, TimeUnit.SECONDS)
+        verify(repository).markMessagesRead(any())
+
+        testObservable.assertComplete()
+    }
+}


### PR DESCRIPTION
Retrieving chat transcripts doesn’t mark messages as read for some reason. This has to be done manually, using the Core SDK method created in the related task linked below. From the moment you fetch a chat transcript, after six seconds, the method should be called. Calling this should clear the “new messages” indicator created in the task linked below.

**Jira issue:**
https://glia.atlassian.net/browse/MOB-1737
