### PR TITLE
Show a new messages divider in secure conversations chat transcript

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -40,6 +40,8 @@
 
         <item name="gliaAlertDialogButtonUseVerticalAlignment">true</item>
         <item name="whiteLabel">false</item>
+        <item name="gliaNewMessagesDividerColor">@color/color_red</item>
+        <item name="gliaNewMessagesDividerTextColor">@color/color_pure_yellow</item>
     </style>
 
     <style name="Application.GliaAndroidSdkWidgetsExample.Button" parent="@style/Widget.MaterialComponents.Button.TextButton.Icon">

--- a/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
@@ -85,6 +85,18 @@ data class UiTheme(
     val operatorMessageTextColor: Int? = null,
 
     /**
+     * The color of "new messages" divider in the chat
+     */
+    @ColorRes
+    val newMessageDividerColor: Int? = null,
+
+    /**
+     * The color of "new messages" divider text in the chat
+     */
+    @ColorRes
+    val newMessageDividerTextColor: Int? = null,
+
+    /**
      * Color for bot action button background color
      */
     @ColorRes
@@ -326,6 +338,8 @@ data class UiTheme(
         visitorMessageBackgroundColor = builder.visitorMessageBackgroundColor,
         visitorMessageTextColor = builder.visitorMessageTextColor,
         operatorMessageBackgroundColor = builder.operatorMessageBackgroundColor,
+        newMessageDividerColor = builder.newMessageDividerColor,
+        newMessageDividerTextColor = builder.newMessageDividerTextColor,
         gliaChatBackgroundColor = builder.gliaChatBackgroundColor,
         operatorMessageTextColor = builder.operatorMessageTextColor,
         botActionButtonBackgroundColor = builder.botActionButtonBackgroundColor,
@@ -456,6 +470,20 @@ data class UiTheme(
         @ColorRes
         var operatorMessageTextColor: Int? = null
             private set
+
+        /**
+         * The color of "new messages" divider in the chat
+         */
+        @ColorRes
+        var newMessageDividerColor: Int? = null
+        private set
+
+        /**
+         * The color of "new messages" divider text in the chat
+         */
+        @ColorRes
+        var newMessageDividerTextColor: Int? = null
+        private set
 
         /**
          * Color for bot action button background color
@@ -765,6 +793,14 @@ data class UiTheme(
             operatorMessageTextColor = color
         }
 
+        fun setNewMessagesDividerColor(@ColorRes color: Int?) {
+            newMessageDividerColor = color
+        }
+
+        fun setNewMessagesDividerTextColor(@ColorRes color: Int?) {
+            newMessageDividerTextColor = color
+        }
+
         fun setBotActionButtonBackgroundColor(@ColorRes color: Int?) {
             botActionButtonBackgroundColor = color
         }
@@ -946,6 +982,8 @@ data class UiTheme(
             visitorMessageBackgroundColor = theme.visitorMessageBackgroundColor
             visitorMessageTextColor = theme.visitorMessageTextColor
             operatorMessageBackgroundColor = theme.operatorMessageBackgroundColor
+            newMessageDividerColor = theme.newMessageDividerColor
+            newMessageDividerTextColor = theme.newMessageDividerTextColor
             operatorMessageTextColor = theme.operatorMessageTextColor
             botActionButtonBackgroundColor = theme.botActionButtonBackgroundColor
             botActionButtonTextColor = theme.botActionButtonTextColor

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
@@ -89,6 +89,16 @@ class ChatAdapter(
                     ChatMediaUpgradeLayoutBinding.inflate(inflater, parent, false), uiTheme
                 )
             }
+            NEW_MESSAGES_DIVIDER_TYPE -> {
+                NewMessagesDividerViewHolder(
+                    ChatNewMessagesDividerLayoutBinding.inflate(
+                        inflater,
+                        parent,
+                        false
+                    ),
+                    uiTheme
+                )
+            }
             else -> {
                 var customCardViewHolder: CustomCardViewHolder? = null
                 if (customCardAdapter != null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/NewMessagesDividerViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/NewMessagesDividerViewHolder.kt
@@ -1,0 +1,40 @@
+package com.glia.widgets.chat.adapter.holder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.glia.widgets.UiTheme
+import com.glia.widgets.databinding.ChatNewMessagesDividerLayoutBinding
+import com.glia.widgets.view.unifiedui.extensions.getColorCompat
+import com.glia.widgets.view.unifiedui.extensions.getFontCompat
+
+class NewMessagesDividerViewHolder(binding: ChatNewMessagesDividerLayoutBinding, uiTheme: UiTheme) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    init {
+        setupUiTheme(uiTheme, binding)
+    }
+
+    private fun setupUiTheme(
+        uiTheme: UiTheme,
+        binding: ChatNewMessagesDividerLayoutBinding
+    ) {
+
+        uiTheme.newMessageDividerColor?.also {
+            binding.newMessagesDividerLeft.setBackgroundResource(it)
+            binding.newMessagesDividerRight.setBackgroundResource(it)
+        }
+        uiTheme.newMessageDividerTextColor?.also {
+            binding.newMessagesTv.setTextColor(itemView.getColorCompat(it))
+        }
+
+        if (uiTheme.fontRes != null) {
+            val fontFamily = itemView.getFontCompat(uiTheme.fontRes)
+            binding.newMessagesTv.typeface = fontFamily
+        }
+
+        uiTheme.fontRes?.let {
+            itemView.getFontCompat(it)
+        }?.also {
+            binding.newMessagesTv.typeface = it
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/GliaQueueRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/GliaQueueRepository.java
@@ -162,7 +162,13 @@ public class GliaQueueRepository {
      */
     public Single<Queue[]> getQueues() {
         return Single.create(emitter -> {
-            RequestCallback<Queue[]> requestCallback = (queues, e) -> emitter.onSuccess(queues);
+            RequestCallback<Queue[]> requestCallback = (queues, e) -> {
+                if (e == null) {
+                    emitter.onSuccess(queues);
+                } else {
+                    emitter.onError(e);
+                }
+            };
             gliaCore.getQueues(requestCallback);
         });
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
@@ -14,10 +14,6 @@ class SecureConversationsRepository(private val secureConversations: SecureConve
         secureConversations.fetchChatTranscript(listener::loaded)
     }
 
-    fun fetchChatTranscript(callback: RequestCallback<Array<ChatMessage>>?) {
-        secureConversations.fetchChatTranscript(callback)
-    }
-
     fun send(message: String, queueIds: Array<String>, attachment: MessageAttachment, callback: RequestCallback<VisitorMessage?>) {
         secureConversations.send(message, queueIds, attachment, callback)
     }
@@ -52,4 +48,7 @@ class SecureConversationsRepository(private val secureConversations: SecureConve
         else
             listener.messageSent(visitorMessage)
     }
+
+    fun getUnreadMessagesCount(callback: RequestCallback<Int>) =
+        secureConversations.getUnreadMessageCount(callback)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCase.kt
@@ -1,0 +1,42 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import androidx.annotation.VisibleForTesting
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.helper.Logger
+import io.reactivex.Single
+import java.util.concurrent.TimeUnit
+
+private const val TAG = "GetUnreadMessagesCountUseCase"
+
+/**
+ * Timeout for the [SecureConversationsRepository.getUnreadMessagesCount]
+ *
+ * This timeout is not related to the timeout for marking the messages read.
+ *
+ * @see [GetUnreadMessagesCountWithTimeoutUseCase.invoke]
+ */
+@VisibleForTesting
+const val TIMEOUT_SEC = 3L
+
+internal class GetUnreadMessagesCountWithTimeoutUseCase(private val repository: SecureConversationsRepository) {
+
+    /**
+     * @return 0 if the current socket doesn't signal a success value within the specified [TIMEOUT_SEC] window.
+     *
+     * This is combined with the chat transcript result to avoid "Jumping UI" when adding new messages'
+     * divider [SecureConversationsRepository.getUnreadMessagesCount] is a socket call and
+     * there is no warranty that it will return anything so timeout is added to make sure that it will return 0
+     * after the timeout if there is no answer from socket yet.
+     */
+    operator fun invoke(): Single<Int> = Single.create {
+        repository.getUnreadMessagesCount { count, exception ->
+            if (it.isDisposed) return@getUnreadMessagesCount
+            if (exception != null) {
+                it.tryOnError(exception)
+                Logger.e(TAG, "Failed to get unread messages count", exception)
+            } else {
+                it.onSuccess(count ?: 0)
+            }
+        }
+    }.timeout(TIMEOUT_SEC, TimeUnit.SECONDS).onErrorReturnItem(0)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -120,7 +120,8 @@ public class ControllerFactory {
                     useCaseFactory.createIsSecureEngagementUseCase(),
                     useCaseFactory.createSetEngagementConfigUseCase(),
                     useCaseFactory.createIsSecureConversationsChatAvailableUseCase(),
-                    useCaseFactory.createMarkMessagesReadUseCase()
+                    useCaseFactory.createMarkMessagesReadUseCase(),
+                    useCaseFactory.createSubscribeToUnreadMessagesCountUseCase()
             );
         } else {
             Logger.d(TAG, "retained chat controller");

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -73,6 +73,7 @@ import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDela
 import com.glia.widgets.core.secureconversations.domain.RemoveSecureFileAttachmentObserverUseCase;
 import com.glia.widgets.core.secureconversations.domain.RemoveSecureFileAttachmentUseCase;
 import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase;
+import com.glia.widgets.core.secureconversations.domain.GetUnreadMessagesCountWithTimeoutUseCase;
 import com.glia.widgets.core.survey.domain.GliaSurveyAnswerUseCase;
 import com.glia.widgets.core.survey.domain.GliaSurveyUseCase;
 import com.glia.widgets.core.visitor.domain.AddVisitorMediaStateListenerUseCase;
@@ -608,6 +609,11 @@ public class UseCaseFactory {
                 repositoryFactory.getEngagementConfigRepository(),
                 createIsMessagingAvailableUseCase()
         );
+    }
+
+    @NonNull
+    public GetUnreadMessagesCountWithTimeoutUseCase createSubscribeToUnreadMessagesCountUseCase() {
+        return new GetUnreadMessagesCountWithTimeoutUseCase(repositoryFactory.getSecureConversationsRepository());
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -174,6 +174,12 @@ public class Utils {
                         R.attr.operatorMessageTextColor
                 )
         );
+        defaultThemeBuilder.setNewMessagesDividerColor(
+                getTypedArrayIntegerValue(typedArray, context, R.styleable.GliaView_newMessagesDividerColor, R.attr.gliaNewMessagesDividerColor)
+        );
+        defaultThemeBuilder.setNewMessagesDividerTextColor(
+                getTypedArrayIntegerValue(typedArray, context, R.styleable.GliaView_newMessagesDividerTextColor, R.attr.gliaNewMessagesDividerTextColor)
+        );
         defaultThemeBuilder.setBotActionButtonBackgroundColor(
                 getTypedArrayIntegerValue(
                         typedArray,

--- a/widgetssdk/src/main/res/layout/chat_new_messages_divider_layout.xml
+++ b/widgetssdk/src/main/res/layout/chat_new_messages_divider_layout.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/glia_large"
+    android:gravity="center"
+    android:orientation="horizontal">
+
+    <FrameLayout
+        android:id="@+id/new_messages_divider_left"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/glia_px"
+        android:layout_weight="1"
+        android:background="?attr/gliaNewMessagesDividerColor"
+        android:importantForAccessibility="no" />
+
+    <TextView
+        android:id="@+id/new_messages_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/glia_medium"
+        android:text="@string/glia_chat_new_messages"
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:textColor="?attr/gliaNewMessagesDividerTextColor" />
+
+    <FrameLayout
+        android:id="@+id/new_messages_divider_right"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/glia_px"
+        android:layout_weight="1"
+        android:background="?attr/gliaNewMessagesDividerColor"
+        android:importantForAccessibility="no" />
+
+</LinearLayout>

--- a/widgetssdk/src/main/res/values/attrs.xml
+++ b/widgetssdk/src/main/res/values/attrs.xml
@@ -81,6 +81,10 @@
         <attr name="gliaChatBackgroundColor" format="reference" />
         <!-- The icon resID used when visitor is sharing the screen -->
         <attr name="endScreenShareTintColor" format="reference" />
+        <!--The color of "new messages" divider in the chat-->
+        <attr name="newMessagesDividerColor" format="reference"/>
+        <!--The color of "new messages" divider text in the chat-->
+        <attr name="newMessagesDividerTextColor" format="reference"/>
 
         <attr name="chatHeaderTitleTintColor" format="reference" />
         <attr name="chatHeaderHomeButtonTintColor" format="reference" />
@@ -167,6 +171,10 @@
     <attr name="gliaVisitorMessageBackgroundColor" format="reference" />
     <!-- Visitor message text color -->
     <attr name="gliaVisitorMessageTextColor" format="reference" />
+    <!--The color of "new messages" divider in the chat-->
+    <attr name="gliaNewMessagesDividerColor" format="reference"/>
+    <!--The color of "new messages" divider text in the chat-->
+    <attr name="gliaNewMessagesDividerTextColor" format="reference"/>
     <!-- Operator message background color -->
     <attr name="gliaOperatorMessageBackgroundColor" format="reference" />
     <!-- Operator message text color -->

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="glia_chat_attachment_item_content_description">Attachment %1$s, size %2$s. %3$s</string>
     <string name="glia_chat_attachment_remove_item_content_description">Remove attachment %1$s</string>
     <string name="glia_chat_visitor_status_transferring">Transferring</string>
+    <string name="glia_chat_new_messages">New Messages</string>
 
     <string name="glia_messaging_title">Messaging</string>
 

--- a/widgetssdk/src/main/res/values/themes.xml
+++ b/widgetssdk/src/main/res/values/themes.xml
@@ -48,6 +48,8 @@
         <item name="visitorMessageTextColor">?attr/gliaVisitorMessageTextColor</item>
         <item name="operatorMessageBackgroundColor">?attr/gliaOperatorMessageBackgroundColor</item>
         <item name="operatorMessageTextColor">?attr/gliaOperatorMessageTextColor</item>
+        <item name="newMessagesDividerColor">?attr/gliaNewMessagesDividerColor</item>
+        <item name="newMessagesDividerTextColor">?attr/gliaNewMessagesDividerTextColor</item>
         <item name="botActionButtonBackgroundColor">?attr/gliaBotActionButtonBackgroundColor</item>
         <item name="botActionButtonTextColor">?attr/gliaBotActionButtonTextColor</item>
         <item name="botActionButtonSelectedBackgroundColor">
@@ -134,6 +136,8 @@
         <item name="gliaVisitorMessageTextColor">?attr/gliaBaseLightColor</item>
         <item name="gliaOperatorMessageBackgroundColor">?attr/gliaSystemAgentBubbleColor</item>
         <item name="gliaOperatorMessageTextColor">?attr/gliaBaseDarkColor</item>
+        <item name="gliaNewMessagesDividerColor">?attr/gliaBrandPrimaryColor</item>
+        <item name="gliaNewMessagesDividerTextColor">?attr/gliaBrandPrimaryColor</item>
         <item name="gliaBotActionButtonBackgroundColor">?attr/gliaSystemAgentBubbleColor</item>
         <item name="gliaBotActionButtonTextColor">?attr/gliaBaseDarkColor</item>
         <item name="gliaBotActionButtonSelectedBackgroundColor">?attr/gliaBrandPrimaryColor</item>

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -20,6 +20,7 @@ import com.glia.widgets.core.queue.domain.GliaQueueForChatEngagementUseCase
 import com.glia.widgets.core.queue.domain.QueueTicketStateChangeToUnstaffedUseCase
 import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase
 import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase
+import com.glia.widgets.core.secureconversations.domain.GetUnreadMessagesCountWithTimeoutUseCase
 import com.glia.widgets.core.survey.domain.GliaSurveyUseCase
 import com.glia.widgets.filepreview.domain.usecase.DownloadFileUseCase
 import com.glia.widgets.helper.TimeCounter
@@ -77,6 +78,7 @@ class ChatControllerTest {
     private lateinit var engagementConfigUseCase: SetEngagementConfigUseCase
     private lateinit var isSecureConversationsChatAvailableUseCase: IsSecureConversationsChatAvailableUseCase
     private lateinit var markMessagesReadWithDelayUseCase: MarkMessagesReadWithDelayUseCase
+    private lateinit var getUnreadMessagesCountWithTimeoutUseCase: GetUnreadMessagesCountWithTimeoutUseCase
 
     private lateinit var chatController: ChatController
 
@@ -127,6 +129,7 @@ class ChatControllerTest {
         engagementConfigUseCase = mock()
         isSecureConversationsChatAvailableUseCase = mock()
         markMessagesReadWithDelayUseCase = mock()
+        getUnreadMessagesCountWithTimeoutUseCase = mock()
 
         chatController = ChatController(
             chatViewCallback = chatViewCallback,
@@ -174,6 +177,7 @@ class ChatControllerTest {
             engagementConfigUseCase = engagementConfigUseCase,
             isSecureEngagementAvailableUseCase = isSecureConversationsChatAvailableUseCase,
             markMessagesReadWithDelayUseCase = markMessagesReadWithDelayUseCase,
+            getUnreadMessagesCountWithTimeoutUseCase = getUnreadMessagesCountWithTimeoutUseCase
         )
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCaseTest.kt
@@ -1,0 +1,69 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import org.junit.Before
+import org.junit.Test
+import org.mockito.internal.stubbing.answers.AnswersWithDelay
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.stubbing.Answer
+import kotlin.properties.Delegates
+
+class GetUnreadMessagesCountWithTimeoutUseCaseTest {
+    private var repository: SecureConversationsRepository by Delegates.notNull()
+    private var useCase: GetUnreadMessagesCountWithTimeoutUseCase by Delegates.notNull()
+
+    @Before
+    fun setUp() {
+        repository = mock()
+        useCase = GetUnreadMessagesCountWithTimeoutUseCase(repository)
+    }
+
+    @Test
+    fun `invoke returns 0 when there is no answer during timeout`() {
+        val answer: Answer<*> = AnswersWithDelay(
+            TIMEOUT_SEC * 2_000L
+        ) {
+            val callback: RequestCallback<Int?> = it.getArgument(0)
+            callback.onResult(5, null)
+        }
+        whenever(repository.getUnreadMessagesCount(any())).doAnswer(answer)
+
+        useCase().test().assertComplete().assertValue(0)
+    }
+
+    @Test
+    fun `invoke completes with 0 when error is returned`() {
+        doAnswer {
+            val callback: RequestCallback<Int?> = it.getArgument(0)
+            callback.onResult(null, GliaException("", GliaException.Cause.INTERNAL_ERROR))
+        }.whenever(repository).getUnreadMessagesCount(any())
+
+        useCase().test().assertComplete().assertValue(0)
+    }
+
+    @Test
+    fun `invoke completes with 0 when count is null`() {
+        doAnswer {
+            val callback: RequestCallback<Int?> = it.getArgument(0)
+            callback.onResult(null, null)
+        }.whenever(repository).getUnreadMessagesCount(any())
+
+        useCase().test().assertComplete().assertValue(0)
+    }
+
+    @Test
+    fun `invoke completes with correct messages count when success is called`() {
+        doAnswer {
+            val callback: RequestCallback<Int?> = it.getArgument(0)
+            callback.onResult(10, null)
+        }.whenever(repository).getUnreadMessagesCount(any())
+
+        useCase().test().assertComplete().assertValue(10)
+    }
+
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-1735

**Additional info:**
When fetching chat transcript, there is a field called delivered_at which can have a date, or can be nil. If it’s nil, it means that the message hasn’t been read yet. Above the oldest unread message, there should be a new message divider that looks like the document in Figma. This component has to be fully translatable and accessible.

**Screenshots:**

https://user-images.githubusercontent.com/19994238/220933523-63988f41-a6b9-4eea-9af9-1c5b49be4f7b.mp4


