### PR TITLE
Added hide audio buttons when callvisualizer session is active

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -22,6 +22,7 @@ import com.glia.widgets.core.engagement.domain.GetEngagementStateFlowableUseCase
 import com.glia.widgets.core.engagement.domain.GliaEndEngagementUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
+import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.ShouldShowMediaEngagementViewUseCase;
 import com.glia.widgets.core.engagement.domain.model.EngagementStateEvent;
 import com.glia.widgets.core.engagement.domain.model.EngagementStateEventVisitor;
@@ -101,6 +102,7 @@ public class CallController implements
     private final GetEngagementStateFlowableUseCase getGliaEngagementStateFlowableUseCase;
     private final UpdateFromCallScreenUseCase updateFromCallScreenUseCase;
     private final QueueTicketStateChangeToUnstaffedUseCase ticketStateChangeToUnstaffedUseCase;
+    private final IsCallVisualizerUseCase isCallVisualizerUseCase;
 
     private final GliaOperatorMediaRepository.OperatorMediaStateListener operatorMediaStateListener = this::onNewOperatorMediaState;
 
@@ -141,7 +143,8 @@ public class CallController implements
             ToggleVisitorVideoUseCase toggleVisitorVideoUseCase,
             GetEngagementStateFlowableUseCase getGliaEngagementStateFlowableUseCase,
             UpdateFromCallScreenUseCase updateFromCallScreenUseCase,
-            QueueTicketStateChangeToUnstaffedUseCase ticketStateChangeToUnstaffedUseCase) {
+            QueueTicketStateChangeToUnstaffedUseCase ticketStateChangeToUnstaffedUseCase,
+            IsCallVisualizerUseCase isCallVisualizerUseCase) {
         Logger.d(TAG, "constructor");
         this.viewCallback = callViewCallback;
         this.callState = new CallState.Builder()
@@ -153,6 +156,7 @@ public class CallController implements
                 .setIsSpeakerOn(false)
                 .setIsMuted(false)
                 .setHasVideo(false)
+                .setIsCallVisualizer(isCallVisualizerUseCase.execute())
                 .createCallState();
         this.dialogController = dialogController;
         this.callTimer = sharedTimer;
@@ -185,6 +189,7 @@ public class CallController implements
         this.getGliaEngagementStateFlowableUseCase = getGliaEngagementStateFlowableUseCase;
         this.updateFromCallScreenUseCase = updateFromCallScreenUseCase;
         this.ticketStateChangeToUnstaffedUseCase = ticketStateChangeToUnstaffedUseCase;
+        this.isCallVisualizerUseCase = isCallVisualizerUseCase;
     }
 
     @Override
@@ -505,6 +510,7 @@ public class CallController implements
             Logger.d(TAG, "Emit state:\n" + state.toString());
             viewCallback.emitState(callState);
         }
+
     }
 
     private synchronized boolean setState(CallState state) {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
@@ -24,6 +24,7 @@ class CallState {
     public final boolean isOnHold;
     //    Need this to not update all views when only time is changed.
     public final boolean isOnlyTimeChanged;
+    public final boolean isCallVisualizer;
 
     @NonNull
     @Override
@@ -40,6 +41,7 @@ class CallState {
                 ", requestedMediaType: " + requestedMediaType +
                 ", isSpeakerOn: " + isSpeakerOn +
                 ", isOnHold: " + isOnHold +
+                ", isCallVisualizer: " + isCallVisualizer +
                 '}';
     }
 
@@ -59,14 +61,15 @@ class CallState {
                 Objects.equals(requestedMediaType, callState.requestedMediaType) &&
                 isSpeakerOn == callState.isSpeakerOn &&
                 isOnHold == callState.isOnHold &&
-                isOnlyTimeChanged == callState.isOnlyTimeChanged;
+                isOnlyTimeChanged == callState.isOnlyTimeChanged &&
+                isCallVisualizer == callState.isCallVisualizer;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(integratorCallStarted, isVisible, messagesNotSeen,
                 callStatus, landscapeLayoutControlsVisible, isMuted, hasVideo,
-                companyName, requestedMediaType, isSpeakerOn, isOnHold, isOnlyTimeChanged);
+                companyName, requestedMediaType, isSpeakerOn, isOnHold, isOnlyTimeChanged, isCallVisualizer);
     }
 
     public boolean showOperatorStatusView() {
@@ -328,16 +331,36 @@ class CallState {
                 .createCallState();
     }
 
-    public boolean isMuteButtonEnabled() {
-        return (isAudioCall() || isVideoCall()) && !showOnHold();
+    public ViewState getMuteButtonViewState() {
+        if (isCallVisualizer) {
+            return ViewState.HIDE;
+        } else if ((isAudioCall() || isVideoCall()) && !showOnHold()) {
+            return ViewState.SHOW;
+        } else {
+            return ViewState.DISABLE;
+        }
     }
 
     public boolean isVideoButtonEnabled() {
         return is2WayVideoCall() && !showOnHold();
     }
 
-    public boolean isSpeakerButtonEnabled() {
-        return isAudioCall() || isVideoCall();
+    public ViewState getSpeakerButtonViewState() {
+        if (isCallVisualizer) {
+            return ViewState.HIDE;
+        } else if (isAudioCall() || isVideoCall()) {
+            return ViewState.SHOW;
+        } else {
+            return ViewState.DISABLE;
+        }
+    }
+
+    public ViewState getChatButtonViewState() {
+        if (isCallVisualizer) {
+            return ViewState.HIDE;
+        } else {
+            return ViewState.SHOW;
+        }
     }
 
     public boolean showCallTimerView() {
@@ -404,6 +427,7 @@ class CallState {
         private boolean isOnHold;
         //May be helpful when converting to Kotlin, as android studio makes fields nullable.
         private boolean isOnlyTimeChanged = false;
+        private boolean isCallVisualizer;
 
         public Builder setIntegratorCallStarted(boolean integratorCallStarted) {
             this.integratorCallStarted = integratorCallStarted;
@@ -465,6 +489,11 @@ class CallState {
             return this;
         }
 
+        public Builder setIsCallVisualizer(boolean isCallVisualizer) {
+            this.isCallVisualizer = isCallVisualizer;
+            return this;
+        }
+
         public Builder copyFrom(CallState callState) {
             integratorCallStarted = callState.integratorCallStarted;
             isVisible = callState.isVisible;
@@ -479,6 +508,7 @@ class CallState {
             isOnHold = callState.isOnHold;
             //as we are updating this field only when only time is changed, so needs to make it false every time.
             isOnlyTimeChanged = false;
+            isCallVisualizer = callState.isCallVisualizer;
             return this;
         }
 
@@ -500,5 +530,10 @@ class CallState {
         this.isSpeakerOn = builder.isSpeakerOn;
         this.isOnHold = builder.isOnHold;
         this.isOnlyTimeChanged = builder.isOnlyTimeChanged;
+        this.isCallVisualizer = builder.isCallVisualizer;
+    }
+
+    public enum ViewState {
+        SHOW, DISABLE, HIDE
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -35,6 +35,7 @@ import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.glia.widgets.UiTheme.UiThemeBuilder
+import com.glia.widgets.call.CallState.ViewState
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.core.dialog.Dialog
 import com.glia.widgets.core.dialog.DialogController
@@ -928,15 +929,6 @@ internal class CallView(
                 appBar.backgroundTintList = getColorStateListCompat(android.R.color.transparent)
             }
 
-            callState.isMuteButtonEnabled.also {
-                muteButtonLabel.isEnabled = it
-                muteButton.isEnabled = it
-            }
-
-            callState.isSpeakerButtonEnabled.also {
-                speakerButton.isEnabled = it
-                speakerButtonLabel.isEnabled = it
-            }
 
             callState.isVideoButtonEnabled.also {
                 videoButton.isEnabled = it
@@ -966,7 +958,16 @@ internal class CallView(
                 if (callState.isMuted) R.string.glia_call_mute_button_unmute else R.string.glia_call_mute_button_mute
             )
 
-            chatButtonBadgeView.isVisible = callState.messagesNotSeen > 0
+            callState.chatButtonViewState.apply {
+                if (this == ViewState.SHOW) {
+                    chatButtonBadgeView.isVisible = callState.messagesNotSeen > 0
+                }
+                applyViewState(this, chatButton, chatButtonLabel)
+
+            }
+            applyViewState(callState.muteButtonViewState, muteButton, muteButtonLabel)
+            applyViewState(callState.speakerButtonViewState, speakerButton, speakerButtonLabel)
+
             videoButton.isVisible = callState.is2WayVideoCall
             videoButtonLabel.isVisible = callState.is2WayVideoCall
             operatorNameView.isVisible = callState.showOperatorNameView()
@@ -999,6 +1000,14 @@ internal class CallView(
         }
     }
 
+    private fun applyViewState(state: ViewState, vararg views: View) {
+        val isVisible = state != ViewState.HIDE
+        val isEnabled = state == ViewState.SHOW
+        views.forEach {
+            it.isVisible = isVisible
+            it.isEnabled = isEnabled
+        }
+    }
     override fun navigateToChat() {
         onNavigateToChatListener?.call()
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -163,7 +163,8 @@ public class ControllerFactory {
                     useCaseFactory.createToggleVisitorVideoUseCase(),
                     useCaseFactory.createGetGliaEngagementStateFlowableUseCase(),
                     useCaseFactory.createUpdateFromCallScreenUseCase(),
-                    useCaseFactory.createQueueTicketStateChangeToUnstaffedUseCase());
+                    useCaseFactory.createQueueTicketStateChangeToUnstaffedUseCase(),
+                    useCaseFactory.createIsCallVisualizerUseCase());
         } else {
             Logger.d(TAG, "retained call controller");
             retainedCallController.setViewCallback(callViewCallback);

--- a/widgetssdk/src/main/res/layout/call_buttons_layout.xml
+++ b/widgetssdk/src/main/res/layout/call_buttons_layout.xml
@@ -58,7 +58,7 @@
         android:layout_marginBottom="@dimen/glia_small"
         android:src="?attr/gliaIconCallVideoOn"
         app:backgroundTint="@color/call_fab_bg_color_states"
-        app:layout_constraintBottom_toTopOf="@id/mute_button_label"
+        app:layout_constraintBottom_toTopOf="@id/video_button_label"
         app:layout_constraintEnd_toStartOf="@id/mute_button"
         app:layout_constraintStart_toEndOf="@id/chat_button"
         app:rippleColor="@color/call_fab_ripple_color_states"


### PR DESCRIPTION
MOB-1817

Implemented Call visualizer engagement disables CallView audio controls

https://salemove.slack.com/archives/C04BTHLDL9Y/p1677679060595919 decision to not show disabled buttons.

![no controls](https://user-images.githubusercontent.com/9782505/222426893-2e95696c-1d5a-4f81-9647-ff79703a6210.png)
