### PR TITLE
Add media upgrade offer callback for a new call

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -249,6 +249,7 @@ public class CallController implements
                         )
         );
         onEngagementEndUseCase.execute(this);
+        mediaUpgradeOfferRepository.addCallback(mediaUpgradeOfferRepositoryCallback);
         inactivityTimeCounter.addRawValueListener(inactivityTimerStatusListener);
         connectingTimerCounter.addRawValueListener(connectingTimerStatusListener);
         minimizeHandler.addListener(this::minimizeView);
@@ -347,7 +348,9 @@ public class CallController implements
 
         surveyUseCase.registerListener(this);
         subscribeToEngagementStateChange();
-        addMediaUpgradeCallbackUseCase.invoke(mediaUpgradeOfferRepositoryCallback);
+        if (mediaUpgradeOfferRepositoryCallback != null) {
+            addMediaUpgradeCallbackUseCase.invoke(mediaUpgradeOfferRepositoryCallback);
+        }
     }
 
     public void chatButtonClicked() {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -178,6 +178,7 @@ class ChatController(
         loadChatHistory()
         addFileAttachmentsObserverUseCase.execute(fileAttachmentObserver)
         initMediaUpgradeCallback()
+        mediaUpgradeOfferRepository.addCallback(mediaUpgradeOfferRepositoryCallback)
         minimizeHandler.addListener { minimizeView() }
         createNewTimerCallback()
         callTimer.addFormattedValueListener(timerStatusListener)

--- a/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/MediaUpgradeOfferRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/mediaupgradeoffer/MediaUpgradeOfferRepository.java
@@ -8,13 +8,15 @@ import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class MediaUpgradeOfferRepository {
     private final static String TAG = "MediaUpgradeOfferRepository";
 
-    private final List<MediaUpgradeOfferRepositoryCallback> callbacks = new ArrayList<>();
+    private final Set<MediaUpgradeOfferRepositoryCallback> callbacks = new HashSet<>();
     private final Consumer<MediaUpgradeOffer> upgradeOfferConsumer = offer -> {
         Logger.d(TAG, "upgradeOfferConsumer, offer: " + offer.toString());
         for (MediaUpgradeOfferRepositoryCallback callback : callbacks) {


### PR DESCRIPTION
[MOB-1880](https://glia.atlassian.net/browse/MOB-1880) broke the "start new Audio/Video engagement" flow . That's why acceptance tests are failing now (example app crashes on 'Start new audio call' menu item tap).

What this pull request does:
1. Adds media upgrade offer callback for a new Audio/Video engagement flow  -  callback still need to be added from the `init()` function.
2. Changing collection type to `Set` to prevent callback duplication.

[MOB-1880]: https://glia.atlassian.net/browse/MOB-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ