### PR TITLE
Improved ADA compatibility

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/CharCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/CharCodeView.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.ShapeDrawable
 import android.graphics.drawable.shapes.RoundRectShape
 import android.util.AttributeSet
+import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import com.glia.widgets.R
@@ -80,8 +81,10 @@ class CharCodeView @JvmOverloads constructor(
     private fun createCharSlotView(character: Char, runtimeTheme: UiTheme?, remoteTheme: VisitorCodeTheme?): TextView {
 
         val charView = TextView(context, null, R.attr.visitorCodeStyle, R.style.Application_Glia_VisitorCode) // TODO: confirm this
+        charView.isFocusable = false
         charView.text = character.toString()
         charView.gravity = TEXT_ALIGNMENT_CENTER
+        charView.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
 
         runtimeTheme?.let {
             applyRuntimeTheme(it, charView)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
@@ -5,6 +5,7 @@ import android.content.res.ColorStateList
 import android.content.res.TypedArray
 import android.os.CountDownTimer
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
 import android.widget.FrameLayout
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -22,11 +23,12 @@ import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.Utils
 import com.glia.widgets.view.button.GliaPositiveButton
+import com.google.android.material.theme.overlay.MaterialThemeOverlay
+import com.glia.widgets.view.unifiedui.exstensions.*
 import com.glia.widgets.view.unifiedui.exstensions.applyButtonTheme
 import com.glia.widgets.view.unifiedui.exstensions.applyLayerTheme
 import com.glia.widgets.view.unifiedui.exstensions.applyTextTheme
 import com.glia.widgets.view.unifiedui.exstensions.layoutInflater
-import com.google.android.material.theme.overlay.MaterialThemeOverlay
 import com.glia.widgets.view.unifiedui.exstensions.applyImageColorTheme
 
 /**
@@ -57,7 +59,7 @@ class VisitorCodeView internal constructor(
         layoutInflater.inflate(R.layout.visitor_code_view, this, true)
         successContainer = findViewById(R.id.success_container)
         failureContainer = findViewById(R.id.failure_container)
-        successTitle = findViewById(R.id.title_view)
+        successTitle = findViewById(R.id.success_title_view)
         failureTitle = findViewById(R.id.failure_title)
         charCodeView = findViewById(R.id.codeView)
         progressBar = findViewById(R.id.progress_bar)
@@ -119,6 +121,9 @@ class VisitorCodeView internal constructor(
         runOnUi {
             showProgressBar(true)
             showSuccess()
+            successTitle.contentDescription = context.getString(R.string.glia_visitor_code_loading)
+            successTitle.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
+            closeButton.contentDescription = context.getString(R.string.glia_chat_alert_dialog_close_content_description)
         }
     }
 
@@ -143,6 +148,8 @@ class VisitorCodeView internal constructor(
     override fun showVisitorCode(visitorCode: VisitorCode) {
         runOnUi {
             showProgressBar(false)
+            successTitle.contentDescription = context.getString(R.string.glia_visitor_code_content_description, visitorCode.code.separateStringWithSymbol("-"))
+            successTitle.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
             charCodeView.setText(visitorCode.code)
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ResourceExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ResourceExtensions.kt
@@ -16,3 +16,7 @@ fun Context.getDimenRes(@DimenRes dimenId: Int): Float {
 fun Context.getDimenResPx(@DimenRes dimenId: Int): Int {
     return this.resources.getDimensionPixelSize(dimenId)
 }
+
+fun String.separateStringWithSymbol(symbol: String): String {
+    return this.split("").joinToString(symbol)
+}

--- a/widgetssdk/src/main/res/layout/visitor_code_view.xml
+++ b/widgetssdk/src/main/res/layout/visitor_code_view.xml
@@ -19,7 +19,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-            android:id="@+id/title_view"
+            android:id="@+id/success_title_view"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:gravity="center"
@@ -35,10 +35,11 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center"
+            android:importantForAccessibility="yes"
             android:layout_marginTop="@dimen/glia_pre_x_large"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/title_view" />
+            app:layout_constraintTop_toBottomOf="@id/success_title_view" />
 
         <ProgressBar
             android:id="@+id/progress_bar"
@@ -47,10 +48,11 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/glia_pre_x_large"
             android:progressTint="?attr/gliaBrandPrimaryColor"
+            android:importantForAccessibility="no"
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/title_view" />
+            app:layout_constraintTop_toBottomOf="@id/success_title_view" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -58,7 +60,7 @@
         android:id="@+id/failure_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="visible"
+        android:visibility="gone"
         android:paddingTop="@dimen/glia_large_x_large"
         android:paddingStart="@dimen/glia_large_x_large"
         android:paddingEnd="@dimen/glia_large_x_large"
@@ -77,8 +79,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toTopOf="@id/failure_refresh_button"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:maxLines="2"/>
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <com.glia.widgets.view.button.GliaPositiveButton
             android:id="@+id/failure_refresh_button"
@@ -98,7 +99,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:padding="@dimen/glia_pre_x_large"
-        android:contentDescription="@string/glia_chat_glia_logo_content_description"
+        android:importantForAccessibility="no"
         android:src="@drawable/ic_powered_by_glia"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -116,7 +117,6 @@
         android:id="@+id/close_button"
         android:layout_width="@dimen/glia_chat_new_messages_image_size"
         android:layout_height="@dimen/glia_chat_new_messages_image_size"
-        android:contentDescription="@string/glia_chat_alert_dialog_close_content_description"
         android:padding="@dimen/glia_pre_x_large"
         android:layout_marginEnd="18dp"
         android:layout_marginBottom="14dp"

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -235,6 +235,8 @@
 
     <!-- Visitor Code View -->
     <string name="glia_visitor_code_view_title">Your Visitor Code</string>
+    <string name="glia_visitor_code_content_description">Your visitor code is %1$s</string>
+    <string name="glia_visitor_code_loading">Loading your visitor code</string>
     <string name="glia_visitor_code_error_title">Could not load the visitor code. Please try refreshing.</string>
     <string name="glia_visitor_code_refresh_button">Refresh</string>
 


### PR DESCRIPTION
MOB-1819

This was the best I was able to do, minor imperfections keep happening, but I think the current version is good enough.

TalkBack will talk to finish the sentence and depending on the loading time might skip some elements. For this reason I disabled contentDescription for close and glia image because those kept coming up in undesired ways. Close button description is added back in a way that won't be read out automatically
