### PR TITLE
Rename ActivityWatcherForDialogs to ActivityWatcherForCallVisualizer

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -42,7 +42,7 @@ import com.glia.widgets.view.head.controller.ServiceChatHeadController
 import com.google.android.material.theme.overlay.MaterialThemeOverlay
 import java.lang.ref.WeakReference
 
-class ActivityWatcherForDialogs(
+class ActivityWatcherForCallVisualizer(
     private val callVisualizerController: CallVisualizerController,
     private val screenSharingController: ScreenSharingController,
     private val dialogController: DialogController,
@@ -50,7 +50,7 @@ class ActivityWatcherForDialogs(
 ) : Application.ActivityLifecycleCallbacks {
 
     companion object {
-        private val TAG = ActivityWatcherForDialogs::class.java.simpleName
+        private val TAG = ActivityWatcherForCallVisualizer::class.java.simpleName
     }
 
     @VisibleForTesting

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -15,7 +15,7 @@ import com.glia.widgets.core.notification.device.INotificationManager;
 import com.glia.widgets.core.notification.device.NotificationManager;
 import com.glia.widgets.core.permissions.PermissionManager;
 import com.glia.widgets.filepreview.data.source.local.DownloadsFolderDataSource;
-import com.glia.widgets.callvisualizer.ActivityWatcherForDialogs;
+import com.glia.widgets.callvisualizer.ActivityWatcherForCallVisualizer;
 import com.glia.widgets.helper.ApplicationLifecycleManager;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.ResourceProvider;
@@ -63,12 +63,12 @@ public class Dependencies {
                 new ApplicationLifecycleManager(),
                 controllerFactory.getChatHeadController()
         );
-        ActivityWatcherForDialogs activityWatcherForDialogs = new ActivityWatcherForDialogs(
+        ActivityWatcherForCallVisualizer activityWatcherForCallVisualizer = new ActivityWatcherForCallVisualizer(
                 controllerFactory.getCallVisualizerController(),
                 controllerFactory.getScreenSharingController(),
                 controllerFactory.getDialogController(),
                 controllerFactory.getChatHeadController());
-        application.registerActivityLifecycleCallbacks(activityWatcherForDialogs);
+        application.registerActivityLifecycleCallbacks(activityWatcherForCallVisualizer);
         resourceProvider = new ResourceProvider(application.getBaseContext());
         callVisualizerManager = new CallVisualizerManager(
                 useCaseFactory.getVisitorCodeViewBuilderUseCase(),

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerTest.kt
@@ -25,9 +25,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.lang.ref.WeakReference
 
-internal class ActivityWatcherForDialogsTest {
+internal class ActivityWatcherForCallVisualizerTest {
 
-    private lateinit var activityWatcherForDialogs: ActivityWatcherForDialogs
+    private lateinit var activityWatcherForCallVisualizer: ActivityWatcherForCallVisualizer
 
     @Before
     fun setUp() {
@@ -40,14 +40,14 @@ internal class ActivityWatcherForDialogsTest {
         )
         val serviceChatHeadController = mock(ServiceChatHeadController::class.java)
         val screenSharingController = mock(ScreenSharingController::class.java)
-        activityWatcherForDialogs = ActivityWatcherForDialogs(
+        activityWatcherForCallVisualizer = ActivityWatcherForCallVisualizer(
             callVisualizerController,
             screenSharingController,
             dialogController,
             serviceChatHeadController
         )
-        activityWatcherForDialogs.alertDialog = mock(androidx.appcompat.app.AlertDialog::class.java)
-        activityWatcherForDialogs.setupDialogCallback(WeakReference(mock(Activity::class.java)))
+        activityWatcherForCallVisualizer.alertDialog = mock(androidx.appcompat.app.AlertDialog::class.java)
+        activityWatcherForCallVisualizer.setupDialogCallback(WeakReference(mock(Activity::class.java)))
     }
 
     @Test
@@ -56,11 +56,11 @@ internal class ActivityWatcherForDialogsTest {
         val window = mock(Window::class.java)
         whenever(activity.window).thenReturn(window)
         whenever(window.decorView).thenReturn(mock(View::class.java))
-        activityWatcherForDialogs.onActivityResumed(activity)
-        activityWatcherForDialogs.onActivityPaused(activity)
-        whenever(activityWatcherForDialogs.getGliaViewOrRootView(activity)).thenReturn(mock(View::class.java))
+        activityWatcherForCallVisualizer.onActivityResumed(activity)
+        activityWatcherForCallVisualizer.onActivityPaused(activity)
+        whenever(activityWatcherForCallVisualizer.getGliaViewOrRootView(activity)).thenReturn(mock(View::class.java))
 
-        assertNull(activityWatcherForDialogs.resumedActivity.get())
+        assertNull(activityWatcherForCallVisualizer.resumedActivity.get())
     }
 
     @Test
@@ -69,73 +69,73 @@ internal class ActivityWatcherForDialogsTest {
         val window = mock(Window::class.java)
         whenever(activity.window).thenReturn(window)
         whenever(window.decorView).thenReturn(mock(View::class.java))
-        activityWatcherForDialogs.onActivityResumed(activity)
+        activityWatcherForCallVisualizer.onActivityResumed(activity)
 
-        assertNotNull(activityWatcherForDialogs.resumedActivity.get())
+        assertNotNull(activityWatcherForCallVisualizer.resumedActivity.get())
     }
 
     @Test
     fun alertDialog_dismissed_whenEmitDialogStateModeNone() {
-        activityWatcherForDialogs.dialogCallback?.emitDialogState(DialogState(Dialog.MODE_NONE))
+        activityWatcherForCallVisualizer.dialogCallback?.emitDialogState(DialogState(Dialog.MODE_NONE))
 
-        assertNull(activityWatcherForDialogs.alertDialog)
+        assertNull(activityWatcherForCallVisualizer.alertDialog)
     }
 
     @Test
     fun alertDialog_created_whenEmitDialogStateModeMediaUpgrade() {
         val state = DialogState(Dialog.MODE_MEDIA_UPGRADE)
-        activityWatcherForDialogs.dialogCallback?.emitDialogState(state)
-        assertNotNull(activityWatcherForDialogs.alertDialog)
+        activityWatcherForCallVisualizer.dialogCallback?.emitDialogState(state)
+        assertNotNull(activityWatcherForCallVisualizer.alertDialog)
     }
 
     @Test
     fun alertDialog_created_whenEmitDialogStateModeOverlayPermission() {
         val state = DialogState(Dialog.MODE_OVERLAY_PERMISSION)
-        activityWatcherForDialogs.dialogCallback?.emitDialogState(state)
-        assertNotNull(activityWatcherForDialogs.alertDialog)
+        activityWatcherForCallVisualizer.dialogCallback?.emitDialogState(state)
+        assertNotNull(activityWatcherForCallVisualizer.alertDialog)
     }
 
     @Test
     fun alertDialog_created_whenEmitDialogStateModeStartScreenSharing() {
         val state = DialogState(Dialog.MODE_START_SCREEN_SHARING)
-        activityWatcherForDialogs.dialogCallback?.emitDialogState(state)
-        assertNotNull(activityWatcherForDialogs.alertDialog)
+        activityWatcherForCallVisualizer.dialogCallback?.emitDialogState(state)
+        assertNotNull(activityWatcherForCallVisualizer.alertDialog)
     }
 
     @Test
     fun alertDialog_created_whenEmitDialogStateModeEnableNotifications() {
         val state = DialogState(Dialog.MODE_ENABLE_NOTIFICATION_CHANNEL)
-        activityWatcherForDialogs.dialogCallback?.emitDialogState(state)
-        assertNotNull(activityWatcherForDialogs.alertDialog)
+        activityWatcherForCallVisualizer.dialogCallback?.emitDialogState(state)
+        assertNotNull(activityWatcherForCallVisualizer.alertDialog)
     }
 
     @Test
     fun alertDialog_created_whenEmitDialogStateModeNotificationsAndScreenSharing() {
         val state = DialogState(Dialog.MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING)
-        activityWatcherForDialogs.dialogCallback?.emitDialogState(state)
-        assertNotNull(activityWatcherForDialogs.alertDialog)
+        activityWatcherForCallVisualizer.dialogCallback?.emitDialogState(state)
+        assertNotNull(activityWatcherForCallVisualizer.alertDialog)
     }
 
     @Test
     fun mediaProjectionObjects_null_whenChatActivity() {
         val activity = mock(ChatActivity::class.java)
-        activityWatcherForDialogs.onActivityPreCreated(activity, null)
+        activityWatcherForCallVisualizer.onActivityPreCreated(activity, null)
 
-        assertTrue(activityWatcherForDialogs.startMediaProjectionLaunchers.isEmpty())
+        assertTrue(activityWatcherForCallVisualizer.startMediaProjectionLaunchers.isEmpty())
     }
 
     @Test
     fun mediaProjectionObjects_null_whenCallActivity() {
         val activity = mock(CallActivity::class.java)
-        activityWatcherForDialogs.onActivityPreCreated(activity, null)
+        activityWatcherForCallVisualizer.onActivityPreCreated(activity, null)
 
-        assertTrue(activityWatcherForDialogs.startMediaProjectionLaunchers.isEmpty())
+        assertTrue(activityWatcherForCallVisualizer.startMediaProjectionLaunchers.isEmpty())
     }
 
     @Test
     fun mediaProjectionObjects_creation_whenComponentActivity() {
         val activity = mock(ComponentActivity::class.java)
-        activityWatcherForDialogs.registerForMediaProjectionPermissionResult(activity)
+        activityWatcherForCallVisualizer.registerForMediaProjectionPermissionResult(activity)
 
         verify(activity, times(1)).registerForActivityResult(
             any(ActivityResultContract::class.java),
@@ -146,7 +146,7 @@ internal class ActivityWatcherForDialogsTest {
     @Test
     fun mediaProjectionObjects_creation_whenComponentActivitySubclass() {
         val activity = mock(FragmentActivity::class.java)
-        activityWatcherForDialogs.registerForMediaProjectionPermissionResult(activity)
+        activityWatcherForCallVisualizer.registerForMediaProjectionPermissionResult(activity)
 
         verify(activity, times(1)).registerForActivityResult(
             any(ActivityResultContract::class.java),


### PR DESCRIPTION
This is a small PR aimed to rename 
`ActivityWatcherForDialogs` to `ActivityWatcherForCallVisualizer`.

The main idea is that `ActivityWatcherForDialogs` is currently not only for dialogs but for bubble also. That's why I think the new name can reflect what's class purpuse better.