### PR TITLE
Hide screen sharing bubble on call visualizer end

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -25,7 +25,7 @@ import com.glia.widgets.core.engagement.domain.GetEngagementStateFlowableUseCase
 import com.glia.widgets.core.engagement.domain.GliaEndEngagementUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
-import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.ShouldShowMediaEngagementViewUseCase;
 import com.glia.widgets.core.engagement.domain.model.EngagementStateEvent;
 import com.glia.widgets.core.engagement.domain.model.EngagementStateEventVisitor;

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerRepository.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.callvisualizer
 
+import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.IncomingEngagementRequest
 import com.glia.androidsdk.comms.Media
@@ -25,6 +26,10 @@ class CallVisualizerRepository(private val gliaCore: GliaCore) {
         autoAcceptEngagementRequest()
         showDialogOnMediaUpgradeRequest()
         Logger.d(TAG, "CallVisualizerRepository initialized")
+    }
+
+    fun listenForEngagementEnd(engagement: OmnibrowseEngagement, engagementEnded: Runnable) {
+        engagement.on(Engagement.Events.END, engagementEnded)
     }
 
     fun addVisitorContext(visitorContext: String) {
@@ -67,6 +72,15 @@ class CallVisualizerRepository(private val gliaCore: GliaCore) {
             } else if (offer.video == MediaDirection.ONE_WAY) {
                 callback.onOneWayMediaUpgradeRequest(offer, operatorName)
             }
+        }
+    }
+
+    fun unregisterEngagementEndListener(engagementEnded: Runnable) {
+        gliaCore.currentEngagement.ifPresent { engagement: Engagement ->
+            engagement.off(
+                Engagement.Events.END,
+                engagementEnded
+            )
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerEndUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerEndUseCase.kt
@@ -1,0 +1,67 @@
+package com.glia.widgets.core.callvisualizer.domain
+
+import com.glia.androidsdk.Engagement
+import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement
+import com.glia.widgets.callvisualizer.CallVisualizerRepository
+import com.glia.widgets.core.notification.domain.RemoveCallNotificationUseCase
+import com.glia.widgets.core.notification.domain.RemoveScreenSharingNotificationUseCase
+import com.glia.widgets.core.operator.GliaOperatorMediaRepository
+import com.glia.widgets.core.survey.GliaSurveyRepository
+import com.glia.widgets.core.visitor.GliaVisitorMediaRepository
+
+class GliaOnCallVisualizerEndUseCase(
+    private val repository: CallVisualizerRepository,
+    private val operatorMediaRepository: GliaOperatorMediaRepository,
+    private val callVisualizerUseCase: GliaOnCallVisualizerUseCase,
+    private val removeCallNotificationUseCase: RemoveCallNotificationUseCase,
+    private val removeScreenSharingNotificationUseCase: RemoveScreenSharingNotificationUseCase,
+    private val surveyRepository: GliaSurveyRepository,
+    private val gliaVisitorMediaRepository: GliaVisitorMediaRepository
+) : GliaOnCallVisualizerUseCase.Listener {
+
+    interface Listener {
+        fun engagementEnded()
+    }
+
+    inner class EndCallVisualizerRunnable(private val engagement: Engagement) : Runnable {
+        override fun run() {
+            surveyRepository.onEngagementEnded(engagement)
+            listener?.engagementEnded()
+            operatorMediaRepository.stopListening(engagement)
+            removeScreenSharingNotificationUseCase.execute()
+            removeCallNotificationUseCase.execute()
+            gliaVisitorMediaRepository.onEngagementEnded(engagement)
+        }
+    }
+
+    private var listener: Listener? = null
+
+    private var endCallVisualizerRunnable: Runnable? = null
+
+    fun execute(listener: Listener) {
+        if (this.listener === listener) {
+            // Already listening
+            return
+        }
+        this.listener = listener
+        callVisualizerUseCase.execute(this)
+    }
+
+    fun unregisterListener(listener: Listener) {
+        if (this.listener == listener) {
+            endCallVisualizerRunnable?.let { repository.unregisterEngagementEndListener(it) }
+            callVisualizerUseCase.unregisterListener(this)
+            endCallVisualizerRunnable = null
+            this.listener = null
+        }
+    }
+
+    override fun newEngagementLoaded(engagement: OmnibrowseEngagement) {
+        EndCallVisualizerRunnable(engagement).let {
+            repository.listenForEngagementEnd(
+                engagement,
+                it
+            )
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerUseCase.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.core.engagement.domain
+package com.glia.widgets.core.callvisualizer.domain
 
 import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement
 import com.glia.widgets.core.engagement.GliaEngagementRepository
@@ -21,7 +21,7 @@ class GliaOnCallVisualizerUseCase(
 
     private var listener: Listener? = null
     fun execute(listener: Listener) {
-        if (this.listener === listener) {
+        if (this.listener == listener) {
             // Already listening
             return
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/IsCallVisualizerUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/IsCallVisualizerUseCase.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.core.engagement.domain
+package com.glia.widgets.core.callvisualizer.domain
 
 import com.glia.widgets.core.engagement.GliaEngagementRepository
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ResolveChatHeadNavigationUseCase.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ResolveChatHeadNavigationUseCase.java
@@ -2,7 +2,7 @@ package com.glia.widgets.core.chathead.domain;
 
 import com.glia.widgets.core.engagement.GliaEngagementRepository;
 import com.glia.widgets.core.engagement.GliaEngagementTypeRepository;
-import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.queue.GliaQueueRepository;
 import com.glia.widgets.core.queue.model.GliaQueueingState;
 import com.glia.widgets.di.Dependencies;

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/ShowVideoCallNotificationUseCase.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/ShowVideoCallNotificationUseCase.java
@@ -1,6 +1,6 @@
 package com.glia.widgets.core.notification.domain;
 
-import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.notification.device.INotificationManager;
 
 public class ShowVideoCallNotificationUseCase {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -239,6 +239,7 @@ public class ControllerFactory {
                     useCaseFactory.createOnEngagementUseCase(),
                     useCaseFactory.createOnCallVisualizerUseCase(),
                     useCaseFactory.createOnEngagementEndUseCase(),
+                    useCaseFactory.createOnCallVisualizerEndUseCase(),
                     messagesNotSeenHandler,
                     useCaseFactory.createAddVisitorMediaStateListenerUseCase(),
                     useCaseFactory.createRemoveVisitorMediaStateListenerUseCase(),
@@ -278,7 +279,10 @@ public class ControllerFactory {
             callVisualizerController = new CallVisualizerController(
                     repositoryFactory.getCallVisualizerRepository(),
                     dialogController,
-                    useCaseFactory.createIsCallOrChatScreenActiveUseCase()
+                    useCaseFactory.createIsCallOrChatScreenActiveUseCase(),
+                    useCaseFactory.getGliaSurveyUseCase(),
+                    useCaseFactory.createOnCallVisualizerUseCase(),
+                    useCaseFactory.createOnCallVisualizerEndUseCase()
             );
         }
         return callVisualizerController;

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -18,6 +18,7 @@ import com.glia.widgets.chat.domain.IsShowSendButtonUseCase;
 import com.glia.widgets.chat.domain.CustomCardShouldShowUseCase;
 import com.glia.widgets.chat.domain.SiteInfoUseCase;
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase;
+import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase;
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeViewBuilderUseCase;
 import com.glia.widgets.core.chathead.ChatHeadManager;
 import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase;
@@ -33,10 +34,10 @@ import com.glia.widgets.core.engagement.domain.GetEngagementStateFlowableUseCase
 import com.glia.widgets.core.engagement.domain.GetOperatorFlowableUseCase;
 import com.glia.widgets.core.engagement.domain.GetOperatorUseCase;
 import com.glia.widgets.core.engagement.domain.GliaEndEngagementUseCase;
-import com.glia.widgets.core.engagement.domain.GliaOnCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
-import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.MapOperatorUseCase;
 import com.glia.widgets.core.mediaupgradeoffer.domain.AddMediaUpgradeOfferCallbackUseCase;
 import com.glia.widgets.core.mediaupgradeoffer.domain.RemoveMediaUpgradeOfferCallbackUseCase;
@@ -480,6 +481,18 @@ public class UseCaseFactory {
                 repositoryFactory.getGliaQueueRepository(),
                 repositoryFactory.getGliaVisitorMediaRepository(),
                 repositoryFactory.getGliaEngagementStateRepository()
+        );
+    }
+
+    public GliaOnCallVisualizerEndUseCase createOnCallVisualizerEndUseCase() {
+        return new GliaOnCallVisualizerEndUseCase(
+                repositoryFactory.getCallVisualizerRepository(),
+                repositoryFactory.getGliaOperatorMediaRepository(),
+                createOnCallVisualizerUseCase(),
+                removeCallNotificationUseCase,
+                removeScreenSharingNotificationUseCase,
+                repositoryFactory.getGliaSurveyRepository(),
+                repositoryFactory.getGliaVisitorMediaRepository()
         );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
@@ -19,7 +19,7 @@ import com.glia.widgets.call.Configuration
 import com.glia.widgets.callvisualizer.EndScreenSharingActivity
 import com.glia.widgets.chat.ChatActivity
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
-import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase
 import com.glia.widgets.databinding.ChatHeadViewBinding
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.view.configuration.ChatHeadConfiguration
@@ -151,9 +151,11 @@ class ChatHeadView @JvmOverloads constructor(
         userImageTheme?.placeholderColor.also(binding.placeholderView::applyImageColorTheme)
     }
 
-    override fun navigateToChat() = context.startActivity(
-        getNavigationIntent(context, ChatActivity::class.java, sdkConfiguration!!)
-    )
+    override fun navigateToChat() {
+        sdkConfiguration?.let {
+            context.startActivity(getNavigationIntent(context, ChatActivity::class.java, it))
+        }
+    }
 
     override fun navigateToCall() {
         val activityConfig =

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.java
@@ -8,7 +8,7 @@ import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase;
 import com.glia.widgets.core.engagement.domain.GetOperatorFlowableUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
-import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.visitor.VisitorMediaUpdatesListener;
 import com.glia.widgets.core.visitor.domain.AddVisitorMediaStateListenerUseCase;
 import com.glia.widgets.core.visitor.domain.RemoveVisitorMediaStateListenerUseCase;

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
@@ -9,18 +9,18 @@ import com.glia.androidsdk.comms.VisitorMediaState;
 import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement;
 import com.glia.androidsdk.omnicore.OmnicoreEngagement;
 import com.glia.widgets.UiTheme;
+import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase;
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase;
 import com.glia.widgets.core.chathead.domain.ToggleChatHeadServiceUseCase;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.core.engagement.domain.GetOperatorFlowableUseCase;
-import com.glia.widgets.core.engagement.domain.GliaOnCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
-import com.glia.widgets.core.engagement.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.visitor.VisitorMediaUpdatesListener;
 import com.glia.widgets.core.visitor.domain.AddVisitorMediaStateListenerUseCase;
 import com.glia.widgets.core.visitor.domain.RemoveVisitorMediaStateListenerUseCase;
-import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.Utils;
 import com.glia.widgets.view.MessagesNotSeenHandler;
@@ -40,6 +40,7 @@ public class ServiceChatHeadController
     private final GliaOnEngagementUseCase gliaOnEngagementUseCase;
     private final GliaOnCallVisualizerUseCase gliaOnCallVisualizerUseCase;
     private final GliaOnEngagementEndUseCase gliaOnEngagementEndUseCase;
+    private final GliaOnCallVisualizerEndUseCase gliaOnCallVisualizerEndUseCase;
     private final MessagesNotSeenHandler messagesNotSeenHandler;
     private final AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase;
     private final RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase;
@@ -75,6 +76,7 @@ public class ServiceChatHeadController
             GliaOnEngagementUseCase gliaOnEngagementUseCase,
             GliaOnCallVisualizerUseCase gliaOnCallVisualizerUseCase,
             GliaOnEngagementEndUseCase onEngagementEndUseCase,
+            GliaOnCallVisualizerEndUseCase onCallVisualizerEndUseCase,
             MessagesNotSeenHandler messagesNotSeenHandler,
             AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase,
             RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase,
@@ -87,6 +89,7 @@ public class ServiceChatHeadController
         this.gliaOnEngagementUseCase = gliaOnEngagementUseCase;
         this.gliaOnCallVisualizerUseCase = gliaOnCallVisualizerUseCase;
         this.gliaOnEngagementEndUseCase = onEngagementEndUseCase;
+        this.gliaOnCallVisualizerEndUseCase = onCallVisualizerEndUseCase;
         this.messagesNotSeenHandler = messagesNotSeenHandler;
         this.chatHeadPosition = chatHeadPosition;
         this.addVisitorMediaStateListenerUseCase = addVisitorMediaStateListenerUseCase;
@@ -213,7 +216,8 @@ public class ServiceChatHeadController
                         throwable -> Logger.e(TAG, "getOperatorFlowableUseCase error: " + throwable.getMessage())
                 );
         engagementDisposables.add(operatorDisposable);
-        gliaOnEngagementEndUseCase.execute(this::engagementEnded);
+        // To recieve callback to engagementEnded() after Call Visualizer engagement ends
+        gliaOnCallVisualizerEndUseCase.execute(this::engagementEnded);
         updateChatHeadView();
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerTest.kt
@@ -10,10 +10,13 @@ import com.glia.widgets.call.CallActivity
 import com.glia.widgets.callvisualizer.controller.CallVisualizerController
 import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
 import com.glia.widgets.chat.ChatActivity
+import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase
+import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase
 import com.glia.widgets.core.dialog.Dialog
 import com.glia.widgets.core.dialog.DialogController
 import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.core.screensharing.ScreenSharingController
+import com.glia.widgets.core.survey.domain.GliaSurveyUseCase
 import com.glia.widgets.view.head.controller.ServiceChatHeadController
 import junit.framework.TestCase.assertNull
 import org.junit.Assert.assertNotNull
@@ -33,10 +36,16 @@ internal class ActivityWatcherForCallVisualizerTest {
     fun setUp() {
         val callVisualizerRepository = mock(CallVisualizerRepository::class.java)
         val dialogController = mock(DialogController::class.java)
+        val surveyUseCase = mock(GliaSurveyUseCase::class.java)
+        val onCallVisualizerUseCase = mock(GliaOnCallVisualizerUseCase::class.java)
+        val onCallVisualizerEndUseCase = mock(GliaOnCallVisualizerEndUseCase::class.java)
         val callVisualizerController = CallVisualizerController(
             callVisualizerRepository,
             dialogController,
-            IsCallOrChatScreenActiveUseCase()
+            IsCallOrChatScreenActiveUseCase(),
+            surveyUseCase,
+            onCallVisualizerUseCase,
+            onCallVisualizerEndUseCase
         )
         val serviceChatHeadController = mock(ServiceChatHeadController::class.java)
         val screenSharingController = mock(ScreenSharingController::class.java)


### PR DESCRIPTION
[Hide bubble on call visualizer end](https://glia.atlassian.net/browse/MOB-1957)

[Skip survey on Call Visualizer engagement end](https://glia.atlassian.net/browse/MOB-1959)

Besides, moved several classes from `engagement` to `callvisualizer` package.