### PR TITLE
Fix the Screen Overlay permission request

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -184,8 +184,6 @@ internal class ChatController(
         val queueIds = if (queueId != null) arrayOf(queueId) else emptyArray()
         engagementConfigUseCase(chatType, queueIds)
 
-        if (isShowOverlayPermissionRequestDialogUseCase.execute()) dialogController.showOverlayPermissionsDialog()
-
         ensureSecureMessagingAvailable()
 
         if (chatState.integratorChatStarted || dialogController.isShowingChatEnderDialog) {
@@ -515,6 +513,10 @@ internal class ChatController(
         surveyUseCase.registerListener(this)
         subscribeToEngagementStateChange()
         mediaUpgradeOfferRepositoryCallback?.let { addMediaUpgradeCallbackUseCase(it) }
+
+        if (isShowOverlayPermissionRequestDialogUseCase.execute()) {
+            dialogController.showOverlayPermissionsDialog()
+        }
     }
 
     private fun subscribeToEngagementStateChange() {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
@@ -78,6 +78,18 @@ class MessageCenterActivity : AppCompatActivity(),
         })
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        messageCenterView.onResume()
+    }
+
+    override fun onPause() {
+        messageCenterView.onPause()
+
+        super.onPause()
+    }
+
     override fun selectAttachmentFile(type: String) {
         getContent.launch(type)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
@@ -238,19 +238,23 @@ class MessageCenterView(
         }
     }
 
+    fun onResume() {
+        attachDialogController()
+    }
+
+    fun onPause() {
+        detachDialogController()
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
         window?.statusBarColor = statusBarColor
         defaultStatusBarColor = window?.statusBarColor
-
-        attachDialogController()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-
-        detachDialogController()
 
         window?.statusBarColor = defaultStatusBarColor ?: return
     }


### PR DESCRIPTION
Prevent to show the Screen Overlay permission on the Welcome to Message Center screen.

The crash cause: In case when the Welcome screen opens then the Chat screen opens:
- Chat controller during initialization asks to display the Screen Overlay dialog;
- Chat view is not ready for the handling of the dialogs;
- But the Welcome view is still ready to handle dialogues. However, it can't handle the Screen Overlay dialog. 

[MOB-1965](https://glia.atlassian.net/browse/MOB-1965)

[MOB-1965]: https://glia.atlassian.net/browse/MOB-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ