### PR TITLE
Set correct (match_parent) height for ChatHeadLayout in MainFragment

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -14,6 +14,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 
@@ -45,6 +46,9 @@ import com.glia.widgets.view.head.ChatHeadLayout;
 public class MainFragment extends Fragment {
 
     @Nullable
+    private FrameLayout rootView;
+
+    @Nullable
     private ConstraintLayout containerView;
 
     @Nullable
@@ -64,6 +68,7 @@ public class MainFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        this.rootView = view.findViewById(R.id.root_view);
         this.containerView = view.findViewById(R.id.constraint_layout);
         NavController navController = NavHostFragment.findNavController(this);
         setupAuthButtonsVisibility();
@@ -130,8 +135,8 @@ public class MainFragment extends Fragment {
                 }
         );
 
-        if (containerView != null) {
-            containerView.addView(chatHeadLayout);
+        if (rootView != null) {
+            rootView.addView(chatHeadLayout);
         }
     }
 

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -1,192 +1,201 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:clipToPadding="false"
-    android:clipChildren="false"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:orientation="vertical">
+    <!-- FrameLayout is needed to provide match_parent height for ChatHeadLayout.
+     ChatHeadLayout is added from MainFragment.
+     ScrollView can have only one child and it's child should have wrap_content height. -->
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/constraint_layout"
+    <ScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:animateLayoutChanges="true"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:orientation="vertical">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/tool_bar_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/top_app_bar"
-            style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/constraint_layout"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:title="@string/app_name" />
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true">
 
-    </com.google.android.material.appbar.AppBarLayout>
+            <com.google.android.material.appbar.AppBarLayout
+                android:id="@+id/tool_bar_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/start_guideline"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="16dp" />
+                <com.google.android.material.appbar.MaterialToolbar
+                    android:id="@+id/top_app_bar"
+                    style="@style/Widget.MaterialComponents.Toolbar.Primary"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    app:title="@string/app_name" />
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/end_guideline"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="16dp" />
+            </com.google.android.material.appbar.AppBarLayout>
 
-    <Button
-        android:id="@+id/settings_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/margin_m"
-        android:text="@string/main_open_settings"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/tool_bar_layout" />
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/start_guideline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="16dp" />
 
-    <!-- https://salemove.atlassian.net/browse/MUIC-362
-    Button
-        android:id="@+id/integrator_chat"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:text="@string/main_start_in_integrator_app"
-        app:icon="@drawable/ic_baseline_chat_bubble"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/settings_button" /-->
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/end_guideline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_end="16dp" />
 
-    <Button
-        android:id="@+id/chat_activity_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:paddingEnd="36dp"
-        android:text="@string/main_start_chat_flow"
-        app:icon="@drawable/ic_baseline_chat_bubble"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/settings_button" />
+            <Button
+                android:id="@+id/settings_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_m"
+                android:text="@string/main_open_settings"
+                app:layout_constraintEnd_toEndOf="@id/end_guideline"
+                app:layout_constraintStart_toStartOf="@id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@id/tool_bar_layout" />
 
-    <Button
-        android:id="@+id/audio_call_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:paddingEnd="36dp"
-        android:text="@string/main_start_audio_call"
-        app:icon="@drawable/ic_baseline_call"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/chat_activity_button" />
+            <!-- https://salemove.atlassian.net/browse/MUIC-362
+            Button
+                android:id="@+id/integrator_chat"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_start_in_integrator_app"
+                app:icon="@drawable/ic_baseline_chat_bubble"
+                app:layout_constraintEnd_toEndOf="@id/end_guideline"
+                app:layout_constraintStart_toStartOf="@id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@id/settings_button" /-->
 
-    <Button
-        android:id="@+id/video_call_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:paddingEnd="36dp"
-        android:text="@string/main_start_video_call"
-        app:icon="@drawable/ic_baseline_videocam"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/audio_call_button" />
+            <Button
+                android:id="@+id/chat_activity_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:paddingEnd="36dp"
+                android:text="@string/main_start_chat_flow"
+                app:icon="@drawable/ic_baseline_chat_bubble"
+                app:layout_constraintEnd_toEndOf="@id/end_guideline"
+                app:layout_constraintStart_toStartOf="@id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@id/settings_button" />
 
-    <Button
-        android:id="@+id/message_center_activity_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:paddingEnd="36dp"
-        android:text="@string/main_start_message_center_flow"
-        app:icon="@drawable/ic_secure_message"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/video_call_button" />
+            <Button
+                android:id="@+id/audio_call_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:paddingEnd="36dp"
+                android:text="@string/main_start_audio_call"
+                app:icon="@drawable/ic_baseline_call"
+                app:layout_constraintEnd_toEndOf="@id/end_guideline"
+                app:layout_constraintStart_toStartOf="@id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@id/chat_activity_button" />
 
-    <Button
-        android:id="@+id/end_engagement_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:text="@string/main_end_engagement"
-        app:layout_constraintEnd_toStartOf="@+id/end_guideline"
-        app:layout_constraintStart_toStartOf="@+id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@+id/message_center_activity_button" />
+            <Button
+                android:id="@+id/video_call_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:paddingEnd="36dp"
+                android:text="@string/main_start_video_call"
+                app:icon="@drawable/ic_baseline_videocam"
+                app:layout_constraintEnd_toEndOf="@id/end_guideline"
+                app:layout_constraintStart_toStartOf="@id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@id/audio_call_button" />
 
-    <Button
-        android:id="@+id/initGliaWidgetsButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:text="@string/main_init_glia"
-        android:visibility="visible"
-        app:layout_constraintEnd_toStartOf="@+id/end_guideline"
-        app:layout_constraintStart_toStartOf="@+id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@+id/end_engagement_button" />
+            <Button
+                android:id="@+id/message_center_activity_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:paddingEnd="36dp"
+                android:text="@string/main_start_message_center_flow"
+                app:icon="@drawable/ic_secure_message"
+                app:layout_constraintEnd_toEndOf="@id/end_guideline"
+                app:layout_constraintStart_toStartOf="@id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@id/video_call_button" />
 
-    <Button
-        android:id="@+id/authenticationButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:text="@string/main_authenticate"
-        android:visibility="gone"
-        app:layout_constraintEnd_toStartOf="@+id/end_guideline"
-        app:layout_constraintStart_toStartOf="@+id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@+id/initGliaWidgetsButton" />
+            <Button
+                android:id="@+id/end_engagement_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_end_engagement"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/message_center_activity_button" />
 
-    <Button
-        android:id="@+id/deauthenticationButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:text="@string/main_deauthenticate"
-        android:visibility="gone"
-        app:layout_constraintEnd_toStartOf="@+id/end_guideline"
-        app:layout_constraintStart_toStartOf="@+id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@+id/authenticationButton" />
+            <Button
+                android:id="@+id/initGliaWidgetsButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_init_glia"
+                android:visibility="visible"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/end_engagement_button" />
 
-    <Button
-        android:id="@+id/clear_session_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:text="@string/main_clear_visitor_session"
-        app:layout_constraintEnd_toStartOf="@+id/end_guideline"
-        app:layout_constraintStart_toStartOf="@+id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@+id/deauthenticationButton" />
+            <Button
+                android:id="@+id/authenticationButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_authenticate"
+                android:visibility="gone"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/initGliaWidgetsButton" />
 
-    <Button
-        android:id="@+id/visitor_code_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_m"
-        android:text="@string/main_show_visitor_code"
-        app:layout_constraintEnd_toStartOf="@+id/end_guideline"
-        app:layout_constraintStart_toStartOf="@+id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@+id/clear_session_button" />
+            <Button
+                android:id="@+id/deauthenticationButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_deauthenticate"
+                android:visibility="gone"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/authenticationButton" />
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/glia_medium"
-        android:visibility="gone"
-        tools:visibility="visible"
-        app:cardElevation="@dimen/glia_large"
-        app:cardCornerRadius="@dimen/glia_large"
-        app:layout_constraintTop_toBottomOf="@+id/visitor_code_button"/>
+            <Button
+                android:id="@+id/clear_session_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_clear_visitor_session"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/deauthenticationButton" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <Button
+                android:id="@+id/visitor_code_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_show_visitor_code"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/clear_session_button" />
 
-</ScrollView>
+            <androidx.cardview.widget.CardView
+                android:id="@+id/container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/glia_medium"
+                android:visibility="gone"
+                app:cardCornerRadius="@dimen/glia_large"
+                app:cardElevation="@dimen/glia_large"
+                app:layout_constraintTop_toBottomOf="@+id/visitor_code_button"
+                tools:visibility="visible" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+</FrameLayout>


### PR DESCRIPTION
[MOB-1972](https://glia.atlassian.net/browse/MOB-1972)

Fix for [this bug](https://github.com/salemove/android-sdk-widgets/pull/496#discussion_r1135100808). 

Bug was introduced in the [Create a public interface for the integrator to show Visitor Code](https://github.com/salemove/android-sdk-widgets/commit/615290e86553b4c0eed351220748ae5545505371) commit. Chat head layout is added to root container. And in this commit, container height was changed from `android:layout_height=match_parent` to `android:layout_height=wrap_content`. Hence, instead of occupying the whole screen, it became shrunk.

The idea of the fix is to add FrameLayout to provide `match_parent` height for `ChatHeadLayout`.


[MOB-1972]: https://glia.atlassian.net/browse/MOB-1972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ