### PR TITLE
Send Slack notification even if master build workflow fails

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -227,10 +227,16 @@ workflows:
         inputs:
         - notify_email_list: $BUILD_EMAILS
     - slack@3:
-        is_always_run: false
+        is_always_run: true
         inputs:
         - channel: '#tm-mobile-builds'
         - text: Android Build Succeeded!
+        - webhook_url_on_error: $SLACK_ANDROID_WEBHOOK
+        - channel_on_error: '#tm-mobile'
+        - text_on_error: "@mobile-caretaker Android Build Failed! (master-build)"
+        - emoji_on_error: "\U0001F4A5"
+        - color_on_error: '#d9482b'
+        - from_username_on_error: Bitrise
         - pretext: ''
         - webhook_url: $SLACK_ANDROID_WEBHOOK
     - cache-push@2: {}


### PR DESCRIPTION
[Devs want to add build failure notifications for master Bitrise job in Android SDK Widgets](https://glia.atlassian.net/browse/MOB-1974)

As part of the recent acceptance tests issue on iOS, it was discovered that something similar can happen in Android. A Slack notification for failed jobs in the master workflow needs to be added, in order to know about failures for uploading to Browserstack.