### PR TITLE
Extract Glia Queue ID from project source code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,7 @@ android {
     initEnvProperty('GLIA_API_KEY_SECRET')
     initEnvProperty('GLIA_API_KEY_ID')
     initEnvProperty('GLIA_SITE_ID')
+    initEnvProperty('GLIA_QUEUE_ID')
     initEnvProperty('FIREBASE_PROJECT_ID')
     initEnvProperty('FIREBASE_API_KEY')
     initEnvProperty('FIREBASE_APP_ID')
@@ -51,6 +52,7 @@ android {
             resValue("string", "site_id", GLIA_SITE_ID)
             resValue("string", "glia_api_key_id", GLIA_API_KEY_ID)
             resValue("string", "glia_api_key_secret", GLIA_API_KEY_SECRET)
+            resValue("string", "glia_queue_id", GLIA_QUEUE_ID)
             resValue("string", "firebase_proj_id", FIREBASE_PROJECT_ID)
             resValue("string", "firebase_api_key", FIREBASE_API_KEY)
         }
@@ -60,6 +62,7 @@ android {
             resValue("string", "firebase_app_id", FIREBASE_APP_ID_DEBUG ?: "")
         }
         master {
+            // TODO: look into this build variant, is it really needed?
             initWith debug
             applicationIdSuffix '.master'
             matchingFallbacks = ['debug']

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,6 @@ android {
     initEnvProperty('FIREBASE_API_KEY')
     initEnvProperty('FIREBASE_APP_ID')
     initEnvProperty('FIREBASE_APP_ID_DEBUG')
-    initEnvProperty('FIREBASE_APP_ID_MASTER')
 
     buildTypes {
         all {
@@ -60,13 +59,6 @@ android {
             signingConfig signingConfigs.debug
             applicationIdSuffix '.debug'
             resValue("string", "firebase_app_id", FIREBASE_APP_ID_DEBUG ?: "")
-        }
-        master {
-            // TODO: look into this build variant, is it really needed?
-            initWith debug
-            applicationIdSuffix '.master'
-            matchingFallbacks = ['debug']
-            resValue("string", "firebase_app_id", FIREBASE_APP_ID_MASTER ?: "")
         }
         release {
             initWith debug

--- a/app/src/main/java/com/glia/exampleapp/ChatFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/ChatFragment.java
@@ -55,7 +55,7 @@ public class ChatFragment extends Fragment {
         chatView.setOnBackClickedListener(onBackClickedListener);
         chatView.startChat(
                 Utils.getStringFromPrefs(R.string.pref_company_name, getString(R.string.settings_value_default_company_name), sharedPreferences, getResources()),
-                Utils.getStringFromPrefs(R.string.pref_queue_id, getString(R.string.default_queue_id), sharedPreferences, getResources()),
+                Utils.getStringFromPrefs(R.string.pref_queue_id, getString(R.string.glia_queue_id), sharedPreferences, getResources()),
                 Utils.getStringFromPrefs(R.string.pref_context_asset_id, null, sharedPreferences, getResources()));
     }
 

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -280,7 +280,7 @@ public class MainFragment extends Fragment {
     private String getQueueIdFromPrefs(SharedPreferences sharedPreferences) {
         return Utils.getStringFromPrefs(
                 R.string.pref_queue_id,
-                getString(R.string.default_queue_id),
+                getString(R.string.glia_queue_id),
                 sharedPreferences,
                 getResources()
         );

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="ExtraTranslation,TypographyDashes,Typos">
-    <string name="default_queue_id">a0b87175-4ed1-44a7-9e78-e798f45d233f</string>
-</resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -21,7 +21,7 @@
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
-            app:defaultValue="@string/default_queue_id"
+            app:defaultValue="@string/glia_queue_id"
             app:key="@string/pref_queue_id"
             app:title="@string/settings_queue_id"
             app:useSimpleSummaryProvider="true" />

--- a/app/src/master/res/values/setup.xml
+++ b/app/src/master/res/values/setup.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="default_queue_id" tools:ignore="ExtraTranslation">55e5ca69-04a9-453a-88c1-73b13e83a227</string>
-</resources>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -83,9 +83,6 @@ workflows:
     envs:
     - opts:
         is_expand: false
-      INTEGRATOR_VARIANT: debug
-    - opts:
-        is_expand: false
       VERSION_INCREMENT_TYPE: patch
   authenticated_increment_project_version:
     description: Task builds an SDK and uploads it to Nexus.
@@ -120,10 +117,6 @@ workflows:
         inputs:
         - notify_email_list: $BUILD_EMAILS
     - cache-push@2: {}
-    envs:
-    - opts:
-        is_expand: false
-      INTEGRATOR_VARIANT: debug
   develop:
     steps:
     - activate-ssh-key@4:
@@ -178,10 +171,6 @@ workflows:
         inputs:
         - notify_email_list: $BUILD_EMAILS
     - cache-push@2: {}
-    envs:
-    - opts:
-        is_expand: false
-      INTEGRATOR_VARIANT: master
   master:
     steps:
     - activate-ssh-key@4:
@@ -234,10 +223,6 @@ workflows:
         - pretext: ''
         - webhook_url: $SLACK_ANDROID_WEBHOOK
     - cache-push@2: {}
-    envs:
-    - opts:
-        is_expand: false
-      INTEGRATOR_VARIANT: master
   post_release:
     steps:
     - trigger-bitrise-workflow@0:
@@ -375,10 +360,6 @@ workflows:
         - test_type: instrumentation
         - use_verbose_log: true
     - cache-push@2: {}
-    envs:
-    - opts:
-        is_expand: false
-      INTEGRATOR_VARIANT: debug
   upgrade_dependencies:
     steps:
     - activate-ssh-key@4: {}
@@ -462,6 +443,9 @@ app:
   - opts:
       is_expand: false
     ANDROID_CORTEX_BANKING_APP_SLUG: 0376f45568cb22dd
+  - opts:
+      is_expand: false
+    INTEGRATOR_VARIANT: debug
 trigger_map:
 - push_branch: master
   workflow: master


### PR DESCRIPTION
After this change, the Queue ID can be provided using the argument GLIA_QUEUE_ID in the local.properties project file or as an environment variable.

Also added this variable in CI
Also, update the [guide for the CE](https://glia.atlassian.net/wiki/pages/diffpagesbyversion.action?pageId=3121020935&selectedPageVersions=12&selectedPageVersions=13)
Also removed 'master' build variant as it does not provide any benefits