### PR TITLE
Fix chat view order

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -412,6 +412,8 @@ internal class ChatController(
             currentChatItems.add(unsentItem)
             emitViewState { chatState.changeUnsentMessages(unsentMessages) }
 
+            updateQueueing(currentChatItems)
+
             return@emitChatItems chatState.changeItems(currentChatItems)
         }
     }
@@ -695,6 +697,15 @@ internal class ChatController(
             emitViewState { chatState.queueingStarted(operatorStatusItem) }
 
             return@emitChatItems chatState.changeItems(items)
+        }
+    }
+
+    private fun updateQueueing(items: MutableList<ChatItem>) {
+        if (chatState.operatorStatusItem?.status == OperatorStatusItem.Status.IN_QUEUE) {
+            items.remove(chatState.operatorStatusItem)
+            items.add(
+                OperatorStatusItem.QueueingStatusItem(chatState.companyName)
+            )
         }
     }
 
@@ -1342,12 +1353,10 @@ internal class ChatController(
             appendHistoryChatItem(currentItems, message, index == newItems.lastIndex)
         }
 
-        val sortedItems = currentItems.sortedBy { (it as? LinkedChatItem)?.timestamp }
-
         if (isSecureEngagementUseCase() && !isQueueingOrOngoingEngagement) {
-            emitChatTranscriptItems(sortedItems, unreadMessagesCount)
+            emitChatTranscriptItems(currentItems, unreadMessagesCount)
         } else {
-            emitChatItems { chatState.historyLoaded(sortedItems) }
+            emitChatItems { chatState.historyLoaded(currentItems) }
         }
 
     }


### PR DESCRIPTION
Fix the chat items order.
There was a bug where after the engagement is started the company/operator view went to the top of the messages.
To fix the issue the sorting of messages after the history loaded was removed.

[MOB-1966](https://glia.atlassian.net/browse/MOB-1966)

https://user-images.githubusercontent.com/79906470/226434115-9e7528de-2df6-4319-948d-1077efa3eb1e.mp4

