### PR TITLE
Add runtime theme support for CV media upgrade dialogs

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -361,7 +361,22 @@ public class MainFragment extends Fragment {
         GliaWidgets.init(GliaWidgetsConfigManager.createDefaultConfig(requireContext().getApplicationContext(), rawConfigs));
          */
 
-        GliaWidgets.init(GliaWidgetsConfigManager.createDefaultConfig(requireActivity().getApplicationContext()));
+        Context context = requireActivity().getApplicationContext();
+        UiTheme.UiThemeBuilder theme = new UiTheme.UiThemeBuilder();
+        theme.setBrandPrimaryColor(android.R.color.holo_orange_dark);
+        theme.setSystemNegativeColor(android.R.color.holo_purple);
+        theme.setBaseDarkColor(android.R.color.background_light);
+        theme.setBaseLightColor(android.R.color.background_dark);
+        theme.setBaseShadeColor(android.R.color.holo_green_light);
+        theme.setBaseNormalColor(android.R.color.holo_green_dark);
+        theme.setWhiteLabel(true);
+
+        GliaWidgets.init(GliaWidgetsConfigManager.createDefaultConfig(
+                context,
+                PreferenceManager.getDefaultSharedPreferences(context),
+                null,
+                theme.build()
+        ));
         prepareAuthentication();
         listenForCallVisualizerEngagements();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -175,8 +175,8 @@ internal class CallView(
         screenSharingMode: ScreenSharing.Mode?,
         mediaType: Engagement.MediaType?
     ) {
-        Dependencies.getSdkConfigurationManager().isUseOverlay = useOverlays
-        Dependencies.getSdkConfigurationManager().screenSharingMode = screenSharingMode
+        Dependencies.getSdkConfigurationManager()?.isUseOverlay = useOverlays
+        Dependencies.getSdkConfigurationManager()?.screenSharingMode = screenSharingMode
         callController?.initCall(companyName, queueId, visitorContextAssetId, mediaType)
         serviceChatHeadController?.init()
     }
@@ -561,6 +561,7 @@ internal class CallView(
 
     private fun setDefaultTheme(typedArray: TypedArray) {
         theme = Utils.getThemeFromTypedArray(typedArray, this.context)
+        theme = Utils.getFullHybridTheme(Dependencies.getSdkConfigurationManager()?.uiTheme, theme)
     }
 
     fun setUiTheme(uiTheme: UiTheme?) {

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -30,6 +30,7 @@ import com.glia.widgets.filepreview.ui.FilePreviewView
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.Utils
 import com.glia.widgets.view.Dialogs
+import com.glia.widgets.view.unifiedui.exstensions.deepMerge
 import com.glia.widgets.view.unifiedui.exstensions.wrapWithMaterialThemeOverlay
 import java.lang.ref.WeakReference
 
@@ -137,7 +138,7 @@ class ActivityWatcherForCallVisualizer(
     }
 
     private fun getConfigurationBuilder(): Configuration.Builder {
-        return Configuration.Builder().setWidgetsConfiguration(Dependencies.getSdkConfigurationManager().createWidgetsConfiguration())
+        return Configuration.Builder().setWidgetsConfiguration(Dependencies.getSdkConfigurationManager()?.createWidgetsConfiguration())
     }
 
     override fun showToast(message: String, duration: Int) {
@@ -190,8 +191,7 @@ class ActivityWatcherForCallVisualizer(
             return
         }
         Logger.d(TAG, "Show screen sharing and notifications dialog")
-        val builder = UiTheme.UiThemeBuilder()
-        val theme = builder.build()
+        val theme = UiTheme.UiThemeBuilder().build()
         val contextWithStyle = activity.wrapWithMaterialThemeOverlay()
         alertDialog = Dialogs.showOptionsDialog(
             context = contextWithStyle,
@@ -244,8 +244,7 @@ class ActivityWatcherForCallVisualizer(
         }
         activity.runOnUiThread {
             Logger.d(TAG, "Show screen sharing dialog")
-            val builder = UiTheme.UiThemeBuilder()
-            val theme = builder.build()
+            val theme = getRuntimeTheme(activity)
             val contextWithStyle = activity.wrapWithMaterialThemeOverlay()
 
             alertDialog = Dialogs.showScreenSharingDialog(
@@ -279,8 +278,7 @@ class ActivityWatcherForCallVisualizer(
         }
         activity.runOnUiThread {
             Logger.d(TAG, "Show upgrade dialog")
-            val builder = UiTheme.UiThemeBuilder()
-            val theme = builder.build()
+            val theme = getRuntimeTheme(activity)
             val contextWithStyle = activity.wrapWithMaterialThemeOverlay()
 
             alertDialog = Dialogs.showUpgradeDialog(contextWithStyle, theme, mediaUpgrade, {
@@ -320,8 +318,7 @@ class ActivityWatcherForCallVisualizer(
             return
         }
         Logger.d(TAG, "Show visitor code dialog")
-        val builder = UiTheme.UiThemeBuilder()
-        val theme = builder.build()
+        val theme = UiTheme.UiThemeBuilder().build()
         val contextWithStyle = activity.wrapWithMaterialThemeOverlay()
 
         alertDialog = Dialogs.showVisitorCodeDialog(contextWithStyle, theme)
@@ -336,5 +333,11 @@ class ActivityWatcherForCallVisualizer(
                 ?: it.findViewById(android.R.id.content)
                 ?: it.window.decorView.findViewById(android.R.id.content)
         }
+    }
+
+    private fun getRuntimeTheme(activity: Activity) : UiTheme {
+        val themeFromIntent: UiTheme? = activity.intent?.getParcelableExtra(GliaWidgets.UI_THEME)
+        val themeFromGlobalSetting = Dependencies.getSdkConfigurationManager()?.uiTheme
+        return Utils.getFullHybridTheme(themeFromIntent, themeFromGlobalSetting)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -207,8 +207,8 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
         useOverlays: Boolean = false,
         screenSharingMode: ScreenSharing.Mode? = null
     ) {
-        Dependencies.getSdkConfigurationManager().isUseOverlay = useOverlays
-        Dependencies.getSdkConfigurationManager().screenSharingMode = screenSharingMode
+        Dependencies.getSdkConfigurationManager()?.isUseOverlay = useOverlays
+        Dependencies.getSdkConfigurationManager()?.screenSharingMode = screenSharingMode
         controller?.initChat(companyName, queueId, visitorContextAssetId)
         serviceChatHeadController?.init()
     }
@@ -612,6 +612,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
     private fun setDefaultTheme(typedArray: TypedArray) {
         theme = Utils.getThemeFromTypedArray(typedArray, this.context)
+        theme = Utils.getFullHybridTheme(Dependencies.getSdkConfigurationManager()?.uiTheme, theme)
         theme.brandPrimaryColor?.let(::getColorCompat)?.also { statusBarColor = it }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.java
@@ -1,6 +1,9 @@
 package com.glia.widgets.core.configuration;
 
+import android.app.Activity;
 import android.content.Intent;
+
+import androidx.annotation.NonNull;
 
 import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.widgets.GliaWidgets;

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -3,6 +3,7 @@ package com.glia.widgets.di;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.Lifecycle;
 
@@ -85,6 +86,7 @@ public class Dependencies {
         return notificationManager;
     }
 
+    @Nullable
     public static GliaSdkConfigurationManager getSdkConfigurationManager() {
         return sdkConfigurationManager;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -83,6 +83,7 @@ public class Utils {
         }
     }
 
+    @NotNull
     public static UiTheme getThemeFromTypedArray(TypedArray typedArray, Context context) {
         UiTheme.UiThemeBuilder defaultThemeBuilder = new UiTheme.UiThemeBuilder();
         defaultThemeBuilder.setAppBarTitle(getAppBarTitleValue(typedArray));
@@ -460,6 +461,7 @@ public class Utils {
     }
 
     public static Boolean getGliaAlertDialogButtonUseVerticalAlignment(UiTheme theme) {
+        if (theme == null) return false;
         return theme.getGliaAlertDialogButtonUseVerticalAlignment() != null ?
                 theme.getGliaAlertDialogButtonUseVerticalAlignment() :
                 false;
@@ -532,8 +534,10 @@ public class Utils {
         imm.hideSoftInputFromWindow(windowToken, 0);
     }
 
-    public static UiTheme getFullHybridTheme(@NotNull UiTheme newTheme, @NotNull UiTheme oldTheme) {
-        return MergeKt.deepMerge(oldTheme, newTheme);
+    @NotNull
+    public static UiTheme getFullHybridTheme(@Nullable UiTheme newTheme, @Nullable UiTheme oldTheme) {
+        UiTheme mergedTheme = MergeKt.deepMerge(oldTheme, newTheme);
+        return mergedTheme != null ? mergedTheme : new UiTheme.UiThemeBuilder().build();
     }
 
     public static File createTempPhotoFile(Context context) throws IOException {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -123,38 +123,45 @@ object Dialogs {
             setOnCancelListener(cancelListener)
 
             val baseDarkColor = theme.baseDarkColor?.let { ContextCompat.getColor(context, it) }
+            val baseLightColor = theme.baseLightColor?.let { ContextCompat.getColor(context, it) }
+            val brandPrimaryColor = theme.brandPrimaryColor?.let { ContextCompat.getColor(context, it) }
+            val baseShadeColor = theme.baseShadeColor?.let { ContextCompat.getColor(context, it) }
+            val systemNegativeColor = theme.systemNegativeColor?.let { ContextCompat.getColor(context, it) }
             val fontFamily = theme.fontRes?.let { ResourcesCompat.getFont(context, it) }
 
             findViewById<TextView>(R.id.dialog_title_view).apply {
                 text = title
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.title.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.title)
             }
             findViewById<TextView>(R.id.dialog_message_view).apply {
                 text = message
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.message.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.message)
             }
             findViewById<BaseConfigurableButton>(R.id.decline_button).apply {
-                setTheme(theme)
                 text = negativeButtonText
-                fontFamily?.also(::setTypeface)
                 setOnClickListener(negativeButtonClickListener)
+                applyButtonTheme(
+                    backgroundColor = systemNegativeColor,
+                    textColor = baseLightColor,
+                    textFont = fontFamily
+                )
                 applyAlertTheme(alertTheme)
             }
             findViewById<BaseConfigurableButton>(R.id.accept_button).apply {
-                setTheme(theme)
                 text = positiveButtonText
-                fontFamily?.also(::setTypeface)
                 setOnClickListener(positiveButtonClickListener)
+                applyButtonTheme(
+                    backgroundColor = brandPrimaryColor,
+                    textColor = baseLightColor,
+                    textFont = fontFamily
+                )
                 applyAlertTheme(alertTheme)
             }
             findViewById<ImageView>(R.id.logo_view).apply {
                 isVisible = theme.whiteLabel ?: false
-                theme.baseShadeColor?.let { ContextCompat.getColorStateList(context, it) }
-                    ?.also(::setImageTintList)
+                applyImageColorTheme(baseShadeColor)
             }
         }
     }
@@ -167,28 +174,25 @@ object Dialogs {
         buttonClickListener: View.OnClickListener
     ): AlertDialog {
         val baseDarkColor = theme.baseDarkColor?.let { ContextCompat.getColor(context, it) }
-        val baseNormalColorStateList =
-            theme.baseNormalColor?.let { ContextCompat.getColorStateList(context, it) }
+        val baseNormalColor = theme.baseNormalColor?.let { ContextCompat.getColor(context, it) }
 
         val fontFamily = theme.fontRes?.let { ResourcesCompat.getFont(context, it) }
 
         return showDialog(context, R.layout.alert_dialog, theme.baseLightColor) {
             findViewById<TextView>(R.id.dialog_title_view).apply {
                 setText(title)
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.title.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.title)
             }
             findViewById<TextView>(R.id.dialog_message_view).apply {
                 setText(message)
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.message.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.message)
             }
             findViewById<ImageButton>(R.id.close_dialog_button).apply {
-                baseNormalColorStateList?.also(::setImageTintList)
                 setOnClickListener(buttonClickListener)
-                alertTheme?.closeButtonColor.also(::applyImageColorTheme)
+                applyImageColorTheme(baseNormalColor)
+                applyImageColorTheme(alertTheme?.closeButtonColor)
             }
         }
     }
@@ -199,6 +203,8 @@ object Dialogs {
         buttonClickListener: View.OnClickListener
     ): AlertDialog {
         val baseDarkColor = theme.baseDarkColor?.let { ContextCompat.getColor(context, it) }
+        val baseLightColor = theme.baseLightColor?.let { ContextCompat.getColor(context, it) }
+        val brandPrimaryColor = theme.brandPrimaryColor?.let { ContextCompat.getColor(context, it) }
         val fontFamily = theme.fontRes?.let { ResourcesCompat.getFont(context, it) }
 
         return showDialog(
@@ -207,19 +213,21 @@ object Dialogs {
             theme.baseLightColor
         ) {
             findViewById<TextView>(R.id.dialog_title_view).apply {
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.title.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.title)
             }
             findViewById<TextView>(R.id.dialog_message_view).apply {
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.message.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.message)
+
             }
             findViewById<BaseConfigurableButton>(R.id.ok_button).apply {
-                setTheme(theme)
                 setOnClickListener(buttonClickListener)
-                fontFamily?.also(::setTypeface)
+                applyButtonTheme(
+                    backgroundColor = brandPrimaryColor,
+                    textColor = baseLightColor,
+                    textFont = fontFamily
+                )
                 applyAlertTheme(alertTheme)
             }
         }
@@ -232,38 +240,43 @@ object Dialogs {
         onAcceptOfferClickListener: View.OnClickListener,
         onCloseClickListener: View.OnClickListener
     ): AlertDialog {
+        val baseLightColor = theme.baseLightColor?.let { ContextCompat.getColor(context, it) }
         val baseDarkColor = theme.baseDarkColor?.let { ContextCompat.getColor(context, it) }
-        val primaryBrandColorStateList =
-            theme.brandPrimaryColor?.let { ContextCompat.getColorStateList(context, it) }
-
+        val systemNegativeColor = theme.systemNegativeColor?.let { ContextCompat.getColor(context, it) }
+        val primaryBrandColor = theme.brandPrimaryColor?.let { ContextCompat.getColor(context, it) }
+        val baseShadeColor = theme.baseShadeColor?.let { ContextCompat.getColor(context, it) }
         val fontFamily = theme.fontRes?.let { ResourcesCompat.getFont(context, it) }
 
         return showDialog(context, getUpgradeDialogLayout(theme), theme.baseLightColor) {
             val titleIconView = findViewById<ImageView>(R.id.chat_title_icon).apply {
-                primaryBrandColorStateList?.also(::setImageTintList)
-                alertTheme?.titleImageColor.also(::applyImageColorTheme)
+                applyImageColorTheme(primaryBrandColor)
+                applyImageColorTheme(alertTheme?.titleImageColor)
             }
             val titleView = findViewById<TextView>(R.id.dialog_title_view).apply {
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.title.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.title)
             }
             findViewById<BaseConfigurableButton>(R.id.decline_button).apply {
-                setTheme(theme)
-                fontFamily?.also(::setTypeface)
                 setOnClickListener(onCloseClickListener)
+                applyButtonTheme(
+                    backgroundColor = systemNegativeColor,
+                    textColor = baseLightColor,
+                    textFont = fontFamily
+                )
                 applyAlertTheme(alertTheme)
             }
             findViewById<BaseConfigurableButton>(R.id.accept_button).apply {
-                setTheme(theme)
-                fontFamily?.also(::setTypeface)
                 setOnClickListener(onAcceptOfferClickListener)
+                applyButtonTheme(
+                    backgroundColor = primaryBrandColor,
+                    textColor = baseLightColor,
+                    textFont = fontFamily
+                )
                 applyAlertTheme(alertTheme)
             }
             findViewById<ImageView>(R.id.logo_view).apply {
                 isVisible = theme.whiteLabel ?: false
-                theme.baseShadeColor?.let { ContextCompat.getColorStateList(context, it) }
-                    ?.also(::setImageTintList)
+                applyImageColorTheme(baseShadeColor)
             }
 
             when (mediaUpgrade.mediaUpgradeMode) {
@@ -272,7 +285,7 @@ object Dialogs {
                         R.string.glia_dialog_upgrade_audio_title,
                         mediaUpgrade.operatorName
                     )
-                    titleIconView.setImageResource(theme.iconUpgradeAudioDialog!!)
+                    titleIconView.setImageResource(theme.iconUpgradeAudioDialog ?: R.drawable.ic_baseline_mic)
                     titleIconView.contentDescription =
                         context.getString(R.string.glia_chat_audio_icon_content_description)
                 }
@@ -311,11 +324,8 @@ object Dialogs {
             theme = theme,
             cancelable = true
         ).apply {
-            findViewById<TextView>(R.id.title_view).apply {
-                baseDarkColor?.also {
-                    this?.setTextColor(it)
-                    this?.typeface = fontFamily
-                }
+            findViewById<TextView>(R.id.title_view)?.apply {
+                applyTextTheme(baseDarkColor, fontFamily)
             }
         }
     }
@@ -330,53 +340,57 @@ object Dialogs {
         positiveButtonClickListener: View.OnClickListener,
         negativeButtonClickListener: View.OnClickListener
     ): AlertDialog {
+        val baseLightColor = theme.baseLightColor?.let { ContextCompat.getColor(context, it) }
         val baseDarkColor = theme.baseDarkColor?.let { ContextCompat.getColor(context, it) }
-        val primaryBrandColorStateList =
-            theme.brandPrimaryColor?.let { ContextCompat.getColorStateList(context, it) }
-
+        val systemNegativeColor = theme.systemNegativeColor?.let { ContextCompat.getColor(context, it) }
+        val primaryBrandColor = theme.brandPrimaryColor?.let { ContextCompat.getColor(context, it) }
+        val baseShadeColor = theme.baseShadeColor?.let { ContextCompat.getColor(context, it) }
         val fontFamily = theme.fontRes?.let { ResourcesCompat.getFont(context, it) }
 
         return showDialog(context, getScreenSharingLayout(theme), theme.baseLightColor) {
             findViewById<ImageView>(R.id.title_icon).apply {
-                primaryBrandColorStateList?.also(::setImageTintList)
-                alertTheme?.titleImageColor.also(::applyImageColorTheme)
+                applyImageColorTheme(primaryBrandColor)
+                applyImageColorTheme(alertTheme?.titleImageColor)
             }
             findViewById<TextView>(R.id.dialog_title_view).apply {
                 text = title
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.title.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.title)
             }
             findViewById<TextView>(R.id.dialog_message_view).apply {
                 text = message
-                baseDarkColor?.also(::setTextColor)
-                fontFamily?.also(::setTypeface)
-                alertTheme?.message.also(::applyTextTheme)
+                applyTextTheme(baseDarkColor, fontFamily)
+                applyTextTheme(alertTheme?.message)
             }
             findViewById<BaseConfigurableButton>(R.id.decline_button).apply {
-                setTheme(theme)
                 setText(negativeButtonText)
-                fontFamily?.also(::setTypeface)
                 setOnClickListener {
                     dismiss()
                     negativeButtonClickListener.onClick(it)
                 }
+                applyButtonTheme(
+                    backgroundColor = systemNegativeColor,
+                    textColor = baseLightColor,
+                    textFont = fontFamily
+                )
                 applyAlertTheme(alertTheme)
             }
             findViewById<BaseConfigurableButton>(R.id.accept_button).apply {
-                setTheme(theme)
                 setText(positiveButtonText)
-                fontFamily?.also(::setTypeface)
                 setOnClickListener {
                     dismiss()
                     positiveButtonClickListener.onClick(it)
                 }
+                applyButtonTheme(
+                    backgroundColor = primaryBrandColor,
+                    textColor = baseLightColor,
+                    textFont = fontFamily
+                )
                 applyAlertTheme(alertTheme)
             }
             findViewById<ImageView>(R.id.logo_view).apply {
                 isVisible = theme.whiteLabel ?: false
-                theme.baseShadeColor?.let { ContextCompat.getColorStateList(context, it) }
-                    ?.also(::setImageTintList)
+                applyImageColorTheme(baseShadeColor)
             }
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/button/BaseConfigurableButton.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/button/BaseConfigurableButton.java
@@ -76,6 +76,7 @@ public abstract class BaseConfigurableButton extends MaterialButton {
                 .build();
     }
 
+    @Deprecated
     public void setTheme(UiTheme theme) {
         if (theme == null) return;
         ButtonConfiguration runTimeConfiguration = getButtonConfigurationFromTheme(theme);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
@@ -84,25 +84,28 @@ class AppBarView @JvmOverloads constructor(
         }
 
         // colors
-        uiTheme.brandPrimaryColor?.let(::getColorStateListCompat)?.also {
-            binding.toolbar.backgroundTintList = it
-        }
-        (uiTheme.gliaChatHeaderExitQueueButtonTintColor ?: uiTheme.baseLightColor)?.also {
-            leaveQueueIcon.icon?.setTintCompat(it)
-        }
-        uiTheme.endScreenShareTintColor?.also {
-            endScreenShareButton.setColorFilter(ContextCompat.getColor(context, it))
-        }
+        val brandPrimaryColor = uiTheme.brandPrimaryColor?.let(::getColorCompat)
+        val baseLightColor = uiTheme.baseLightColor?.let(::getColorCompat)
+        val systemNegativeColor = uiTheme.systemNegativeColor?.let(::getColorCompat)
+        val exitQueueButtonColor = uiTheme.gliaChatHeaderExitQueueButtonTintColor?.let(::getColorCompat)
+            ?: baseLightColor
+        val endScreenShareButtonColor = uiTheme.endScreenShareTintColor?.let(::getColorCompat)
+        val chatHeaderTitleColor = uiTheme.gliaChatHeaderTitleTintColor?.let(::getColorCompat)
+        val chatHeaderHomeButtonColor = uiTheme.gliaChatHeaderHomeButtonTintColor?.let(::getColorCompat)
+        val textFont = uiTheme.fontRes?.let(::getFontCompat)
 
-        uiTheme.gliaChatHeaderTitleTintColor?.let(::getColorStateListCompat)
-            ?.also(binding.title::setTextColor)
-
-        uiTheme.gliaChatHeaderHomeButtonTintColor?.let(::getColorCompat)?.also {
-            binding.toolbar.navigationIcon?.setTint(it)
-        }
-        binding.endButton.setTheme(uiTheme)
-
-        uiTheme.fontRes?.let { binding.title.typeface = getFontCompat(it) }
+        binding.toolbar.applyToolbarTheme(
+            backgroundColor = brandPrimaryColor,
+            navigationIconColor = chatHeaderHomeButtonColor
+        )
+        leaveQueueIcon.applyIconColorTheme(exitQueueButtonColor)
+        endScreenShareButton.applyImageColorTheme(endScreenShareButtonColor)
+        binding.title.applyTextTheme(chatHeaderTitleColor, textFont)
+        binding.endButton.applyButtonTheme(
+            backgroundColor = systemNegativeColor,
+            textColor = baseLightColor,
+            textFont = textFont
+        )
     }
 
     fun setTitle(title: String?) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ViewExstensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/exstensions/ViewExstensions.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.widget.ImageView
 import android.widget.ProgressBar
@@ -33,6 +34,7 @@ import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.glia.widgets.view.unifiedui.theme.call.BarButtonStatesTheme
 import com.glia.widgets.view.unifiedui.theme.survey.OptionButtonTheme
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -145,6 +147,15 @@ internal fun View.applyLayerTheme(layer: LayerTheme?, padding: Rect? = null) {
 
 internal fun View.applyLayerTheme(@ColorInt backgroundColor: Int?) {
     backgroundColor?.apply(::setBackgroundColor)
+}
+
+internal fun MaterialToolbar.applyToolbarTheme(@ColorInt backgroundColor: Int?, @ColorInt navigationIconColor: Int?) {
+    backgroundColor?.let {
+        backgroundTintList = ColorStateList.valueOf(it)
+    }
+    navigationIconColor?.let {
+        navigationIcon?.setTint(navigationIconColor)
+    }
 }
 
 internal fun MaterialCardView.applyCardLayerTheme(layer: LayerTheme?) {
@@ -267,6 +278,12 @@ internal fun ImageView.applyImageColorTheme(colorTheme: ColorTheme?) {
 internal fun ImageView.applyImageColorTheme(@ColorInt imageColor: Int?) {
     imageColor?.let {
         imageTintList = ColorStateList.valueOf(it)
+    }
+}
+
+internal fun MenuItem.applyIconColorTheme(@ColorInt iconColor: Int?) {
+    iconColor?.let {
+        icon?.setTintCompat(it)
     }
 }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-1991

**Additional info:**
Also updated a bit of code for all other dialogs as some of them missed font family in buttons and to overall make the code more consistent

Additionally, it seems that `BaseConfigurableButton.setTheme(UiTheme)` does not apply themes correctly. I marked it as deprecated and replaced it in `Dialogs.kt`.

**Screenshots:**
![image](https://user-images.githubusercontent.com/10000880/227134845-f42212f5-d885-45f9-bd8b-ed73f40e3e86.png)
![image](https://user-images.githubusercontent.com/10000880/227134978-b91a52c0-472c-4bff-a3c2-92a10489882b.png)
![image](https://user-images.githubusercontent.com/10000880/227135010-8553de0c-5e71-4920-9389-dbd68920255a.png)
![image](https://user-images.githubusercontent.com/10000880/227135051-713b38b2-e5a1-49da-9632-f2675ddc1bd0.png)
![image](https://user-images.githubusercontent.com/10000880/227135078-163fee11-c109-406c-b8e5-d1048bdf5bb8.png)
![image](https://user-images.githubusercontent.com/10000880/227135119-eecd3f66-9852-4ab7-9f7a-2ee1fd4817de.png)

