### PR TITLE
Bugfix/mob 1980 call visualizer video call not opening

### DIFF
--- a/app/src/androidTest/java/com/glia/exampleapp/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/glia/exampleapp/ExampleInstrumentedTest.java
@@ -1,6 +1,6 @@
 package com.glia.exampleapp;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
     public void useAppContext() {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        assertEquals("com.glia.widgetssdk", appContext.getPackageName());
+        assertTrue(appContext.getPackageName().contains("com.glia.exampleapp"));
     }
 }

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -35,6 +35,7 @@ import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
 import com.glia.widgets.call.Configuration;
+import com.glia.widgets.callvisualizer.CallVisualizerSupportActivity;
 import com.glia.widgets.callvisualizer.EndScreenSharingActivity;
 import com.glia.widgets.chat.ChatActivity;
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer;

--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -38,6 +38,10 @@
             android:launchMode="singleTask"
             android:theme="@style/Application.Glia.Call.Activity"
             android:windowSoftInputMode="adjustResize"/>
+        <activity android:name=".callvisualizer.CallVisualizerSupportActivity"
+            android:launchMode="singleTask"
+            android:noHistory="true"
+            android:theme="@style/Application.Glia.Translucent.Activity"/>
 
         <service
             android:name=".core.chathead.ChatHeadService"

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherContract.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.view.View
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
+import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.widgets.core.dialog.model.DialogState
 
 class ActivityWatcherContract {
@@ -19,6 +20,9 @@ class ActivityWatcherContract {
         fun onPositiveDialogButtonClicked(activity: Activity? = null)
         fun onNegativeDialogButtonClicked()
         fun onDialogControllerCallback(state: DialogState)
+        fun onMediaUpgradeReceived(mediaUpgrade: MediaUpgradeOffer)
+        fun onInitialCameraPermissionResult(isGranted: Boolean, isComponentActivity: Boolean = true)
+        fun onRequestedCameraPermissionResult(isGranted: Boolean)
     }
 
     interface Watcher {
@@ -35,6 +39,9 @@ class ActivityWatcherContract {
         fun openOverlayPermissionView()
         fun setupDialogCallback()
         fun removeDialogCallback()
-        fun fetchGliaOrRootView(): View?
+        fun requestCameraPermission()
+        fun openComponentActivity()
+        fun destroySupportActivityIfExists()
+        fun checkCameraPermission()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
@@ -1,0 +1,5 @@
+package com.glia.widgets.callvisualizer
+
+import androidx.appcompat.app.AppCompatActivity
+
+class CallVisualizerSupportActivity : AppCompatActivity()

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/extensions/ViewExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/extensions/ViewExtensions.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.view.unifiedui.extensions
 
-import android.app.Activity
 import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.TypedArray


### PR DESCRIPTION
The issue came from ActivityWatcherForDialogs not having access to onActivityResult and could not get the camera permission result.

For AppCompatActivity this was resolved with an ActivityResultLauncher, but for Activity views, a transparent CallVisualizerSupportActivity is opened to handle everything with the same type of ActivityResultLauncher but in our transparent view that is closed upon completion.

Currently for testing purposes there is a button in MainFragment that opens a android.app.Activity type of view with what we can test this functionality. Before merger that button and view will be deleted. 
