### PR TITLE
Media upgrade bugfixing

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherController.kt
@@ -180,7 +180,8 @@ internal class ActivityWatcherController(
     }
 
     override fun onInitialCameraPermissionResult(isGranted: Boolean, isComponentActivity: Boolean) {
-        if (!isGranted) {
+        if (mediaUpgradeOffer.video == MediaDirection.TWO_WAY && !isGranted) {
+            // No need for visitor camera permission if it is not TWO_WAY video
             if (isComponentActivity) {
                 watcher.requestCameraPermission()
             } else {

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -5,7 +5,6 @@ import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.widget.Toast
@@ -13,7 +12,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import com.glia.androidsdk.Glia
@@ -57,21 +55,12 @@ internal class ActivityWatcherForCallVisualizer(
      */
     var resumedActivity: WeakReference<Activity?> = WeakReference(null)
 
-    @RequiresApi(Build.VERSION_CODES.Q)
-    override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
-        // Media projection is mandatory only for Android API 29+
-        // Source: https://developer.android.com/reference/android/media/projection/MediaProjectionManager#getMediaProjection(int,%20android.content.Intent)
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (controller.isCallOrChatActive(activity)) {
             // Call and Chat screens process screen sharing requests on their own
             controller.removeMediaProjectionLaunchers(activity::class.simpleName)
-            return
-        }
-        registerForMediaProjectionPermissionResult(activity)
-        super.onActivityPreCreated(activity, savedInstanceState)
-    }
-
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        if (!controller.isCallOrChatActive(activity)) {
+        } else {
+            registerForMediaProjectionPermissionResult(activity)
             registerForCameraPermissionResult(activity)
         }
         super.onActivityCreated(activity, savedInstanceState)

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -43,12 +43,12 @@ internal class CallVisualizerController(
 
     override fun onOneWayMediaUpgradeRequest(mediaUpgradeOffer: MediaUpgradeOffer, operatorName: String) {
         val formattedOperatorName = Utils.formatOperatorName(operatorName)
-        dialogController.showUpgradeVideoDialog2Way(mediaUpgradeOffer, formattedOperatorName)
+        dialogController.showUpgradeVideoDialog1Way(mediaUpgradeOffer, formattedOperatorName)
     }
 
     override fun onTwoWayMediaUpgradeRequest(mediaUpgradeOffer: MediaUpgradeOffer, operatorName: String) {
         val formattedOperatorName = Utils.formatOperatorName(operatorName)
-        dialogController.showUpgradeVideoDialog1Way(mediaUpgradeOffer, formattedOperatorName)
+        dialogController.showUpgradeVideoDialog2Way(mediaUpgradeOffer, formattedOperatorName)
     }
 
     override fun onSurveyLoaded(survey: Survey?) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-1978

**Additional info:**
- Fixed wrong media upgrade messages in Call Visualizer
- Added check for Call Visualizer not to request camera permission for a one-way video stream
- Fixed system mic/camera/screen-sharing permissions not being requested on API 28 and lower
