### PR TITLE
FIx new messages' divider didn’t place in the right place 

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/FindNewMessagesDividerIndexUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/FindNewMessagesDividerIndexUseCase.kt
@@ -1,0 +1,30 @@
+package com.glia.widgets.chat.domain
+
+import com.glia.androidsdk.chat.Chat
+import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
+
+class FindNewMessagesDividerIndexUseCase {
+
+    operator fun invoke(messages: List<ChatMessageInternal>, unreadMessagesCount: Int): Int {
+        if (messages.isEmpty() || unreadMessagesCount <= 0) return -1
+
+        var dividerIndex = -1
+        var remainingUnreadMessagesCount = unreadMessagesCount
+
+        val iterator = messages.run { listIterator(size) }
+
+        while (iterator.hasPrevious() && remainingUnreadMessagesCount > 0) {
+
+            val message = iterator.previous()
+
+            if (message.chatMessage.senderType != Chat.Participant.VISITOR) {
+                --remainingUnreadMessagesCount
+            }
+
+            dividerIndex = iterator.nextIndex()
+        }
+
+        return dividerIndex.coerceAtLeast(0)
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaLoadHistoryUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaLoadHistoryUseCase.kt
@@ -14,12 +14,13 @@ internal class GliaLoadHistoryUseCase(
     private val secureConversationsRepository: SecureConversationsRepository,
     private val isSecureEngagementUseCase: IsSecureEngagementUseCase,
     private val mapOperatorUseCase: MapOperatorUseCase,
-    private val getUnreadMessagesCountUseCase: GetUnreadMessagesCountWithTimeoutUseCase
+    private val getUnreadMessagesCountUseCase: GetUnreadMessagesCountWithTimeoutUseCase,
+    private val findNewMessagesDividerIndexUseCase: FindNewMessagesDividerIndexUseCase
 ) {
 
     private val isSecureEngagement get() = isSecureEngagementUseCase()
 
-    fun execute(): Single<ChatHistoryResponse> = if (isSecureEngagement) {
+    operator fun invoke(): Single<ChatHistoryResponse> = if (isSecureEngagement) {
         loadHistoryWithNewMessagesCount()
     } else {
         loadHistoryAndMapOperator().map { ChatHistoryResponse(it) }
@@ -27,7 +28,12 @@ internal class GliaLoadHistoryUseCase(
 
     private fun loadHistoryWithNewMessagesCount() = Single.zip(
         loadHistoryAndMapOperator(), getUnreadMessagesCountUseCase()
-    ) { messages, count -> ChatHistoryResponse(messages, count) }
+    ) { messages, count ->
+        ChatHistoryResponse(
+            messages,
+            findNewMessagesDividerIndexUseCase(messages, count)
+        )
+    }
 
     private fun loadHistoryAndMapOperator() = loadHistory()
         .flatMapPublisher { Flowable.fromArray(*it) }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/model/ChatHistoryResponse.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/model/ChatHistoryResponse.kt
@@ -2,5 +2,5 @@ package com.glia.widgets.core.engagement.domain.model
 
 internal data class ChatHistoryResponse(
     val items: List<ChatMessageInternal>,
-    val unreadMessagesCount: Int = 0
+    val newMessagesDividerIndex: Int = -1
 )

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -11,6 +11,7 @@ import com.glia.widgets.chat.domain.CustomCardAdapterTypeUseCase;
 import com.glia.widgets.chat.domain.CustomCardInteractableUseCase;
 import com.glia.widgets.chat.domain.CustomCardShouldShowUseCase;
 import com.glia.widgets.chat.domain.CustomCardTypeUseCase;
+import com.glia.widgets.chat.domain.FindNewMessagesDividerIndexUseCase;
 import com.glia.widgets.chat.domain.GliaLoadHistoryUseCase;
 import com.glia.widgets.chat.domain.GliaOnMessageUseCase;
 import com.glia.widgets.chat.domain.GliaOnOperatorTypingUseCase;
@@ -24,6 +25,8 @@ import com.glia.widgets.chat.domain.IsShowSendButtonUseCase;
 import com.glia.widgets.chat.domain.SiteInfoUseCase;
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase;
+import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeViewBuilderUseCase;
 import com.glia.widgets.core.chathead.ChatHeadManager;
 import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase;
@@ -39,28 +42,11 @@ import com.glia.widgets.core.engagement.domain.GetEngagementStateFlowableUseCase
 import com.glia.widgets.core.engagement.domain.GetOperatorFlowableUseCase;
 import com.glia.widgets.core.engagement.domain.GetOperatorUseCase;
 import com.glia.widgets.core.engagement.domain.GliaEndEngagementUseCase;
-import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase;
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
-import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.engagement.domain.IsOngoingEngagementUseCase;
 import com.glia.widgets.core.engagement.domain.IsQueueingEngagementUseCase;
 import com.glia.widgets.core.engagement.domain.MapOperatorUseCase;
-import com.glia.widgets.core.mediaupgradeoffer.domain.AddMediaUpgradeOfferCallbackUseCase;
-import com.glia.widgets.core.mediaupgradeoffer.domain.RemoveMediaUpgradeOfferCallbackUseCase;
-import com.glia.widgets.core.queue.domain.QueueTicketStateChangeToUnstaffedUseCase;
-import com.glia.widgets.core.secureconversations.domain.AddSecureFileAttachmentsObserverUseCase;
-import com.glia.widgets.core.secureconversations.domain.AddSecureFileToAttachmentAndUploadUseCase;
-import com.glia.widgets.core.secureconversations.domain.ResetMessageCenterUseCase;
-import com.glia.widgets.core.secureconversations.domain.SendMessageButtonStateUseCase;
-import com.glia.widgets.core.secureconversations.domain.GetSecureFileAttachmentsUseCase;
-import com.glia.widgets.core.secureconversations.domain.IsMessageCenterAvailableUseCase;
-import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase;
-import com.glia.widgets.core.secureconversations.domain.OnNextMessageUseCase;
-import com.glia.widgets.core.secureconversations.domain.RemoveSecureFileAttachmentUseCase;
-import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase;
-import com.glia.widgets.core.secureconversations.domain.ShowMessageLimitErrorUseCase;
-import com.glia.widgets.core.survey.domain.GliaSurveyUseCase;
 import com.glia.widgets.core.engagement.domain.SetEngagementConfigUseCase;
 import com.glia.widgets.core.engagement.domain.ShouldShowMediaEngagementViewUseCase;
 import com.glia.widgets.core.fileupload.domain.AddFileAttachmentsObserverUseCase;
@@ -69,6 +55,8 @@ import com.glia.widgets.core.fileupload.domain.GetFileAttachmentsUseCase;
 import com.glia.widgets.core.fileupload.domain.RemoveFileAttachmentObserverUseCase;
 import com.glia.widgets.core.fileupload.domain.RemoveFileAttachmentUseCase;
 import com.glia.widgets.core.fileupload.domain.SupportedFileCountCheckUseCase;
+import com.glia.widgets.core.mediaupgradeoffer.domain.AddMediaUpgradeOfferCallbackUseCase;
+import com.glia.widgets.core.mediaupgradeoffer.domain.RemoveMediaUpgradeOfferCallbackUseCase;
 import com.glia.widgets.core.notification.device.INotificationManager;
 import com.glia.widgets.core.notification.domain.RemoveCallNotificationUseCase;
 import com.glia.widgets.core.notification.domain.RemoveScreenSharingNotificationUseCase;
@@ -82,10 +70,23 @@ import com.glia.widgets.core.permissions.domain.HasScreenSharingNotificationChan
 import com.glia.widgets.core.queue.domain.GliaCancelQueueTicketUseCase;
 import com.glia.widgets.core.queue.domain.GliaQueueForChatEngagementUseCase;
 import com.glia.widgets.core.queue.domain.GliaQueueForMediaEngagementUseCase;
-import com.glia.widgets.core.secureconversations.domain.IsMessagingAvailableUseCase;
-import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase;
+import com.glia.widgets.core.queue.domain.QueueTicketStateChangeToUnstaffedUseCase;
+import com.glia.widgets.core.secureconversations.domain.AddSecureFileAttachmentsObserverUseCase;
+import com.glia.widgets.core.secureconversations.domain.AddSecureFileToAttachmentAndUploadUseCase;
+import com.glia.widgets.core.secureconversations.domain.GetSecureFileAttachmentsUseCase;
 import com.glia.widgets.core.secureconversations.domain.GetUnreadMessagesCountWithTimeoutUseCase;
+import com.glia.widgets.core.secureconversations.domain.IsMessageCenterAvailableUseCase;
+import com.glia.widgets.core.secureconversations.domain.IsMessagingAvailableUseCase;
+import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase;
+import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase;
+import com.glia.widgets.core.secureconversations.domain.OnNextMessageUseCase;
+import com.glia.widgets.core.secureconversations.domain.RemoveSecureFileAttachmentUseCase;
+import com.glia.widgets.core.secureconversations.domain.ResetMessageCenterUseCase;
+import com.glia.widgets.core.secureconversations.domain.SendMessageButtonStateUseCase;
+import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase;
+import com.glia.widgets.core.secureconversations.domain.ShowMessageLimitErrorUseCase;
 import com.glia.widgets.core.survey.domain.GliaSurveyAnswerUseCase;
+import com.glia.widgets.core.survey.domain.GliaSurveyUseCase;
 import com.glia.widgets.core.visitor.domain.AddVisitorMediaStateListenerUseCase;
 import com.glia.widgets.core.visitor.domain.RemoveVisitorMediaStateListenerUseCase;
 import com.glia.widgets.filepreview.domain.usecase.DownloadFileUseCase;
@@ -230,7 +231,8 @@ public class UseCaseFactory {
                 repositoryFactory.getSecureConversationsRepository(),
                 createIsSecureEngagementUseCase(),
                 getMapOperatorUseCase(),
-                createSubscribeToUnreadMessagesCountUseCase()
+                createSubscribeToUnreadMessagesCountUseCase(),
+                createFindNewMessagesDividerIndexUseCase()
         );
     }
 
@@ -696,6 +698,7 @@ public class UseCaseFactory {
         return new MarkMessagesReadWithDelayUseCase(repositoryFactory.getSecureConversationsRepository());
     }
 
+    @NonNull
     public GliaOnCallVisualizerUseCase createOnCallVisualizerUseCase() {
         return new GliaOnCallVisualizerUseCase(
                 repositoryFactory.getGliaEngagementRepository(),
@@ -706,6 +709,7 @@ public class UseCaseFactory {
         );
     }
 
+    @NonNull
     public GliaOnCallVisualizerEndUseCase createOnCallVisualizerEndUseCase() {
         return new GliaOnCallVisualizerEndUseCase(
                 repositoryFactory.getCallVisualizerRepository(),
@@ -716,5 +720,10 @@ public class UseCaseFactory {
                 repositoryFactory.getGliaSurveyRepository(),
                 repositoryFactory.getGliaVisitorMediaRepository()
         );
+    }
+
+    @NonNull
+    public FindNewMessagesDividerIndexUseCase createFindNewMessagesDividerIndexUseCase() {
+        return new FindNewMessagesDividerIndexUseCase();
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/FindNewMessagesDividerIndexUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/FindNewMessagesDividerIndexUseCaseTest.kt
@@ -1,0 +1,66 @@
+package com.glia.widgets.chat.domain
+
+import com.glia.androidsdk.chat.Chat
+import com.glia.androidsdk.chat.ChatMessage
+import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.properties.Delegates
+
+class FindNewMessagesDividerIndexUseCaseTest {
+    private val useCase: FindNewMessagesDividerIndexUseCase =
+        FindNewMessagesDividerIndexUseCase()
+
+    private var operatorChatMessage: ChatMessage by Delegates.notNull()
+    private var visitorChatMessage: ChatMessage by Delegates.notNull()
+
+    @Before
+    fun setUp() {
+        operatorChatMessage = mock()
+        whenever(operatorChatMessage.senderType) doReturn Chat.Participant.OPERATOR
+
+        visitorChatMessage = mock()
+        whenever(visitorChatMessage.senderType) doReturn Chat.Participant.VISITOR
+    }
+
+    @Test
+    fun `ComputeNewMessagesDividerIndexUseCase return -1 when empty list passed`() {
+        val index = useCase.invoke(emptyList(), 2)
+        assertEquals(-1, index)
+    }
+
+    @Test
+    fun `ComputeNewMessagesDividerIndexUseCase return -1 when unreadMessagesCount is 0`() {
+        val index = useCase.invoke(listOf(mock(), mock()), 0)
+        assertEquals(-1, index)
+    }
+
+    @Test
+    fun `ComputeNewMessagesDividerIndexUseCase return correct index when no visitor message at the end`() {
+        val index =
+            useCase.invoke((1..10).map { ChatMessageInternal(operatorChatMessage, null) }, 2)
+        assertEquals(8, index)
+    }
+
+    @Test
+    fun `ComputeNewMessagesDividerIndexUseCase return correct index when exists visitor message at the end`() {
+        val items = (1..10).map {
+            ChatMessageInternal(if (it > 8) visitorChatMessage else operatorChatMessage, null)
+        }
+        val index = useCase.invoke(items, 2)
+        assertEquals(6, index)
+    }
+
+    @Test
+    fun `ComputeNewMessagesDividerIndexUseCase return 0 when unreadMessagesCount bigger than message list size`() {
+        val items = (1..10).map {
+            ChatMessageInternal(if (it > 8) visitorChatMessage else operatorChatMessage, null)
+        }
+        val index = useCase.invoke(items, 20)
+        assertEquals(0, index)
+    }
+}


### PR DESCRIPTION
Initially, the unread messages divider was placed incorrectly when there were visitor messages in the mix. 

[MOB 2029](https://glia.atlassian.net/browse/MOB-2030)