### PR TITLE
Do not set bubble a screen sharing icon if Call Visualizer is in vide…

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/IsCallVisualizerScreenSharingUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/IsCallVisualizerScreenSharingUseCase.kt
@@ -1,0 +1,7 @@
+package com.glia.widgets.core.callvisualizer.domain
+
+import com.glia.widgets.core.engagement.GliaEngagementTypeRepository
+
+class IsCallVisualizerScreenSharingUseCase(private val engagementTypeRepository: GliaEngagementTypeRepository) {
+    operator fun invoke(): Boolean = engagementTypeRepository.isCallVisualizerScreenSharing
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ResolveChatHeadNavigationUseCase.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ResolveChatHeadNavigationUseCase.java
@@ -5,7 +5,6 @@ import com.glia.widgets.core.engagement.GliaEngagementRepository;
 import com.glia.widgets.core.engagement.GliaEngagementTypeRepository;
 import com.glia.widgets.core.queue.GliaQueueRepository;
 import com.glia.widgets.core.queue.model.GliaQueueingState;
-import com.glia.widgets.di.Dependencies;
 
 public class ResolveChatHeadNavigationUseCase {
     private final GliaEngagementRepository engagementRepository;
@@ -50,6 +49,6 @@ public class ResolveChatHeadNavigationUseCase {
     }
 
     private boolean isSharingScreen() {
-        return Dependencies.getUseCaseFactory().createIsCallVisualizerUseCase().invoke();
+        return isCallVisualizerUseCase.invoke();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementTypeRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementTypeRepository.java
@@ -43,4 +43,8 @@ public class GliaEngagementTypeRepository {
         return visitorMediaRepository.hasVisitorVideoMedia().blockingGet() ||
                 visitorMediaRepository.hasVisitorAudioMedia().blockingGet();
     }
+
+    public boolean isCallVisualizerScreenSharing() {
+        return engagementRepository.isCallVisualizerEngagement() && !hasAnyMedia();
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -269,7 +269,7 @@ public class ControllerFactory {
                     useCaseFactory.createRemoveVisitorMediaStateListenerUseCase(),
                     chatHeadPosition,
                     useCaseFactory.createGetOperatorFlowableUseCase(),
-                    useCaseFactory.createIsCallVisualizerUseCase()
+                    useCaseFactory.createIsCallVisualizerScreenSharingUseCase()
             );
         }
         return serviceChatHeadController;
@@ -288,7 +288,7 @@ public class ControllerFactory {
                     useCaseFactory.createAddVisitorMediaStateListenerUseCase(),
                     useCaseFactory.createRemoveVisitorMediaStateListenerUseCase(),
                     useCaseFactory.createGetOperatorFlowableUseCase(),
-                    useCaseFactory.createIsCallVisualizerUseCase()
+                    useCaseFactory.createIsCallVisualizerScreenSharingUseCase()
             );
         }
         return applicationChatHeadController;

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -26,6 +26,7 @@ import com.glia.widgets.chat.domain.SiteInfoUseCase;
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase;
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeViewBuilderUseCase;
 import com.glia.widgets.core.chathead.ChatHeadManager;
@@ -598,6 +599,11 @@ public class UseCaseFactory {
     @NonNull
     public IsCallVisualizerUseCase createIsCallVisualizerUseCase() {
         return new IsCallVisualizerUseCase(repositoryFactory.getGliaEngagementRepository());
+    }
+
+    @NonNull
+    public IsCallVisualizerScreenSharingUseCase createIsCallVisualizerScreenSharingUseCase() {
+        return new IsCallVisualizerScreenSharingUseCase(repositoryFactory.getGliaEngagementTypeRepository());
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
@@ -20,7 +20,7 @@ import com.glia.widgets.call.CallActivity
 import com.glia.widgets.call.Configuration
 import com.glia.widgets.callvisualizer.EndScreenSharingActivity
 import com.glia.widgets.chat.ChatActivity
-import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.databinding.ChatHeadViewBinding
 import com.glia.widgets.di.Dependencies
@@ -55,13 +55,14 @@ class ChatHeadView @JvmOverloads constructor(
         get() = Dependencies.getGliaThemeManager().theme?.run {
             if (isService) bubbleTheme else chatTheme?.bubble
         }
+    @Suppress("JoinDeclarationAndAssignment")
     private var serviceChatHeadController: ServiceChatHeadController
-    private var isCallVisualizerUseCase: IsCallVisualizerUseCase
+    private var isCallVisualizerScreenSharingUseCase: IsCallVisualizerScreenSharingUseCase
     private var theme: UiTheme? = null
 
     init {
         serviceChatHeadController = Dependencies.getControllerFactory().chatHeadController
-        isCallVisualizerUseCase = Dependencies.getUseCaseFactory().createIsCallVisualizerUseCase()
+        isCallVisualizerScreenSharingUseCase = Dependencies.getUseCaseFactory().createIsCallVisualizerScreenSharingUseCase()
         setAccessibilityLabels()
         readTypedArray()
     }
@@ -243,7 +244,7 @@ class ChatHeadView @JvmOverloads constructor(
     }
 
     private fun updatePlaceholderImageView() {
-        val placeholderIcon = if (isCallVisualizerUseCase()) {
+        val placeholderIcon = if (isCallVisualizerScreenSharingUseCase()) {
             R.drawable.ic_screensharing // TODO: 14.03.2023 MOB-1942 add this icon to UiTheme the same way as operatorPlaceholderIcon
         } else {
             configuration.operatorPlaceholderIcon

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -6,7 +6,7 @@ import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement
 import com.glia.androidsdk.omnicore.OmnicoreEngagement
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase
-import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
 import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
@@ -33,7 +33,7 @@ internal class ApplicationChatHeadLayoutController(
     private val addVisitorMediaStateListenerUseCase: AddVisitorMediaStateListenerUseCase,
     private val removeVisitorMediaStateListenerUseCase: RemoveVisitorMediaStateListenerUseCase,
     private val getOperatorFlowableUseCase: GetOperatorFlowableUseCase,
-    private val isCallVisualizerUseCase: IsCallVisualizerUseCase
+    private val isCallVisualizerScreenSharingUseCase: IsCallVisualizerScreenSharingUseCase
 ) : ChatHeadLayoutContract.Controller,
     VisitorMediaUpdatesListener,
     GliaOnEngagementUseCase.Listener,
@@ -159,7 +159,7 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     private fun decideOnEngagementBubbleDesign(view: ChatHeadLayoutContract.View?) {
-        if (isCallVisualizerUseCase()) {
+        if (isCallVisualizerScreenSharingUseCase()) {
             view?.showScreenSharing()
         } else if (operatorProfileImgUrl != null) {
             view?.showOperatorImage(operatorProfileImgUrl)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
@@ -11,7 +11,7 @@ import com.glia.androidsdk.omnicore.OmnicoreEngagement;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
-import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase;
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase;
 import com.glia.widgets.core.chathead.domain.ToggleChatHeadServiceUseCase;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
@@ -45,7 +45,7 @@ public class ServiceChatHeadController
     private final AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase;
     private final RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase;
     private final GetOperatorFlowableUseCase getOperatorFlowableUseCase;
-    private final IsCallVisualizerUseCase isCallVisualizerUseCase;
+    private final IsCallVisualizerScreenSharingUseCase isCallVisualizerScreenSharingUseCase;
     private final ChatHeadPosition chatHeadPosition;
 
 
@@ -82,7 +82,7 @@ public class ServiceChatHeadController
             RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase,
             ChatHeadPosition chatHeadPosition,
             GetOperatorFlowableUseCase getOperatorFlowableUseCase,
-            IsCallVisualizerUseCase isCallVisualizerUseCase
+            IsCallVisualizerScreenSharingUseCase isCallVisualizerScreenSharingUseCase
     ) {
         this.toggleChatHeadServiceUseCase = toggleChatHeadServiceUseCase;
         this.resolveChatHeadNavigationUseCase = resolveChatHeadNavigationUseCase;
@@ -95,7 +95,7 @@ public class ServiceChatHeadController
         this.addVisitorMediaStateListenerUseCase = addVisitorMediaStateListenerUseCase;
         this.removeVisitorMediaStateListenerUseCase = removeVisitorMediaStateListenerUseCase;
         this.getOperatorFlowableUseCase = getOperatorFlowableUseCase;
-        this.isCallVisualizerUseCase = isCallVisualizerUseCase;
+        this.isCallVisualizerScreenSharingUseCase = isCallVisualizerScreenSharingUseCase;
     }
 
     @Override
@@ -248,7 +248,7 @@ public class ServiceChatHeadController
     }
 
     private void decideOnBubbleDesign() {
-        if (isCallVisualizerUseCase.invoke()) {
+        if (isCallVisualizerScreenSharingUseCase.invoke()) {
             chatHeadView.showScreenSharing();
         } else if (operatorProfileImgUrl != null) {
             chatHeadView.showOperatorImage(operatorProfileImgUrl);


### PR DESCRIPTION
[MOB-1979](https://glia.atlassian.net/browse/MOB-1979)

Changes overview:
- Distinguish two cases: is Call Visualizer engagement and Call Visualiser with screen sharing
- Set screen sharing icon for bubble only if it's Call Visualiser with screen sharing, so for Call Visualizer video call bubble should display avatar



[MOB-1979]: https://glia.atlassian.net/browse/MOB-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ