### PR TITLE
Handle on hold state change for application bubble

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -87,6 +87,7 @@ internal class ApplicationChatHeadLayoutController(
 
     override fun onHoldChanged(isOnHold: Boolean) {
         this.isOnHold = isOnHold
+        updateChatHeadView()
     }
 
     fun updateChatHeadView() {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
@@ -101,6 +101,7 @@ public class ServiceChatHeadController
     @Override
     public void onDestroy() {
         toggleChatHeadServiceUseCase.invoke(null);
+        removeVisitorMediaStateListenerUseCase.execute(this);
     }
 
     @Override


### PR DESCRIPTION
[MOB-2057](https://glia.atlassian.net/browse/MOB-2057)

Changes overview:
- Handle on hold state change for application bubble
- Remove `VisitorMediaStateListener` for global bubble from `onDestroy()` (is not related to bug, I just noticed that it was missing)


[MOB-2057]: https://glia.atlassian.net/browse/MOB-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ