### PR TITLE
Fixed end screen sharing dialog anomalies

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/SurveyStateManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/SurveyStateManager.kt
@@ -1,0 +1,24 @@
+package com.glia.widgets.core.chathead
+
+class SurveyStateManager {
+    private var surveyStep: SurveyStep = SurveyStep.PRE_ENGAGEMENT
+
+    fun getEngagementStep() : SurveyStep {
+        return surveyStep
+    }
+
+    fun pendingSurvey() {
+        surveyStep = SurveyStep.SURVEY
+    }
+
+    fun engagementEnded() {
+        surveyStep = SurveyStep.ENDED
+    }
+
+}
+
+enum class SurveyStep {
+    PRE_ENGAGEMENT,
+    SURVEY,
+    ENDED
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/HasPendingSurveyUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/HasPendingSurveyUseCase.kt
@@ -1,0 +1,8 @@
+package com.glia.widgets.core.chathead.domain
+
+import com.glia.widgets.core.chathead.SurveyStateManager
+import com.glia.widgets.core.chathead.SurveyStep
+
+class HasPendingSurveyUseCase(private val surveyStateManager: SurveyStateManager) {
+    operator fun invoke() = surveyStateManager.getEngagementStep() == SurveyStep.SURVEY
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ResolveChatHeadNavigationUseCase.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ResolveChatHeadNavigationUseCase.java
@@ -1,6 +1,6 @@
 package com.glia.widgets.core.chathead.domain;
 
-import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase;
 import com.glia.widgets.core.engagement.GliaEngagementRepository;
 import com.glia.widgets.core.engagement.GliaEngagementTypeRepository;
 import com.glia.widgets.core.queue.GliaQueueRepository;
@@ -10,18 +10,18 @@ public class ResolveChatHeadNavigationUseCase {
     private final GliaEngagementRepository engagementRepository;
     private final GliaQueueRepository queueRepository;
     private final GliaEngagementTypeRepository gliaEngagementTypeRepository;
-    private final IsCallVisualizerUseCase isCallVisualizerUseCase;
+    private final IsCallVisualizerScreenSharingUseCase isCallVisualizerScreenSharingUseCase;
 
     public ResolveChatHeadNavigationUseCase(
             GliaEngagementRepository engagementRepository,
             GliaQueueRepository queueRepository,
             GliaEngagementTypeRepository gliaEngagementTypeRepository,
-            IsCallVisualizerUseCase isCallVisualizerUseCase
+            IsCallVisualizerScreenSharingUseCase isCallVisualizerScreenSharingUseCase
     ) {
         this.engagementRepository = engagementRepository;
         this.queueRepository = queueRepository;
         this.gliaEngagementTypeRepository = gliaEngagementTypeRepository;
-        this.isCallVisualizerUseCase = isCallVisualizerUseCase;
+        this.isCallVisualizerScreenSharingUseCase = isCallVisualizerScreenSharingUseCase;
     }
 
     public Destinations execute() {
@@ -49,6 +49,6 @@ public class ResolveChatHeadNavigationUseCase {
     }
 
     private boolean isSharingScreen() {
-        return isCallVisualizerUseCase.invoke();
+        return isCallVisualizerScreenSharingUseCase.invoke();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/SetPendingSurveyUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/SetPendingSurveyUseCase.kt
@@ -1,0 +1,7 @@
+package com.glia.widgets.core.chathead.domain
+
+import com.glia.widgets.core.chathead.SurveyStateManager
+
+class SetPendingSurveyUseCase(private val surveyStateManager: SurveyStateManager) {
+    operator fun invoke() = surveyStateManager.pendingSurvey()
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/SetPendingSurveyUsedUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/SetPendingSurveyUsedUseCase.kt
@@ -1,0 +1,7 @@
+package com.glia.widgets.core.chathead.domain
+
+import com.glia.widgets.core.chathead.SurveyStateManager
+
+class SetPendingSurveyUsedUseCase(private val surveyStateManager: SurveyStateManager) {
+    operator fun invoke() = surveyStateManager.engagementEnded()
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -132,7 +132,9 @@ public class ControllerFactory {
                     useCaseFactory.createIsOngoingEngagementUseCase(),
                     useCaseFactory.createSetEngagementConfigUseCase(),
                     useCaseFactory.createIsSecureConversationsChatAvailableUseCase(),
-                    useCaseFactory.createMarkMessagesReadUseCase()
+                    useCaseFactory.createMarkMessagesReadUseCase(),
+                    useCaseFactory.createHasPendingSurveyUseCase(),
+                    useCaseFactory.createSetPendingSurveyUsed()
             );
         } else {
             Logger.d(TAG, "retained chat controller");
@@ -176,7 +178,8 @@ public class ControllerFactory {
                     useCaseFactory.createGetGliaEngagementStateFlowableUseCase(),
                     useCaseFactory.createUpdateFromCallScreenUseCase(),
                     useCaseFactory.createQueueTicketStateChangeToUnstaffedUseCase(),
-                    useCaseFactory.createIsCallVisualizerUseCase());
+                    useCaseFactory.createIsCallVisualizerUseCase(),
+                    useCaseFactory.createIsOngoingEngagementUseCase());
         } else {
             Logger.d(TAG, "retained call controller");
             retainedCallController.setViewCallback(callViewCallback);
@@ -266,6 +269,7 @@ public class ControllerFactory {
                     useCaseFactory.createRemoveVisitorMediaStateListenerUseCase(),
                     chatHeadPosition,
                     useCaseFactory.createGetOperatorFlowableUseCase(),
+                    useCaseFactory.createSetPendingSurveyUseCase(),
                     useCaseFactory.createIsCallVisualizerScreenSharingUseCase()
             );
         }
@@ -285,6 +289,7 @@ public class ControllerFactory {
                     useCaseFactory.createAddVisitorMediaStateListenerUseCase(),
                     useCaseFactory.createRemoveVisitorMediaStateListenerUseCase(),
                     useCaseFactory.createGetOperatorFlowableUseCase(),
+                    useCaseFactory.createSetPendingSurveyUseCase(),
                     useCaseFactory.createIsCallVisualizerScreenSharingUseCase()
             );
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -30,8 +30,12 @@ import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharing
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase;
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeViewBuilderUseCase;
 import com.glia.widgets.core.chathead.ChatHeadManager;
+import com.glia.widgets.core.chathead.SurveyStateManager;
+import com.glia.widgets.core.chathead.domain.HasPendingSurveyUseCase;
 import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase;
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase;
+import com.glia.widgets.core.chathead.domain.SetPendingSurveyUseCase;
+import com.glia.widgets.core.chathead.domain.SetPendingSurveyUsedUseCase;
 import com.glia.widgets.core.chathead.domain.ToggleChatHeadServiceUseCase;
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager;
 import com.glia.widgets.core.dialog.PermissionDialogManager;
@@ -116,6 +120,7 @@ public class UseCaseFactory {
     private final PermissionManager permissionManager;
     private final PermissionDialogManager permissionDialogManager;
     private final GliaSdkConfigurationManager gliaSdkConfigurationManager;
+    private static final SurveyStateManager surveyStateManager = new SurveyStateManager();
     private final INotificationManager notificationManager;
     private final ChatHeadManager chatHeadManager;
     private final Schedulers schedulers;
@@ -177,7 +182,7 @@ public class UseCaseFactory {
                     repositoryFactory.getGliaEngagementRepository(),
                     repositoryFactory.getGliaQueueRepository(),
                     repositoryFactory.getGliaEngagementTypeRepository(),
-                    createIsCallVisualizerUseCase()
+                    createIsCallVisualizerScreenSharingUseCase()
             );
         }
         return resolveChatHeadNavigationUseCase;
@@ -304,6 +309,21 @@ public class UseCaseFactory {
                 repositoryFactory.getGliaVisitorMediaRepository(),
                 repositoryFactory.getEngagementConfigRepository()
         );
+    }
+
+    @NonNull
+    public SetPendingSurveyUseCase createSetPendingSurveyUseCase() {
+        return new SetPendingSurveyUseCase(surveyStateManager);
+    }
+
+    @NonNull
+    public HasPendingSurveyUseCase createHasPendingSurveyUseCase() {
+        return new HasPendingSurveyUseCase(surveyStateManager);
+    }
+
+    @NonNull
+    public SetPendingSurveyUsedUseCase createSetPendingSurveyUsed() {
+        return new SetPendingSurveyUsedUseCase(surveyStateManager);
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -10,6 +10,7 @@ import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharing
 import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
+import com.glia.widgets.core.chathead.domain.SetPendingSurveyUseCase
 import com.glia.widgets.core.engagement.domain.GetOperatorFlowableUseCase
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementEndUseCase
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase
@@ -33,6 +34,7 @@ internal class ApplicationChatHeadLayoutController(
     private val addVisitorMediaStateListenerUseCase: AddVisitorMediaStateListenerUseCase,
     private val removeVisitorMediaStateListenerUseCase: RemoveVisitorMediaStateListenerUseCase,
     private val getOperatorFlowableUseCase: GetOperatorFlowableUseCase,
+    private val setPendingSurveyUseCase: SetPendingSurveyUseCase,
     private val isCallVisualizerScreenSharingUseCase: IsCallVisualizerScreenSharingUseCase
 ) : ChatHeadLayoutContract.Controller,
     VisitorMediaUpdatesListener,
@@ -134,6 +136,7 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     override fun engagementEnded() {
+        setPendingSurveyUseCase.invoke()
         state = State.ENDED
         operatorProfileImgUrl = null
         unreadMessagesCount = 0

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
@@ -13,6 +13,7 @@ import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCas
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase;
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase;
+import com.glia.widgets.core.chathead.domain.SetPendingSurveyUseCase;
 import com.glia.widgets.core.chathead.domain.ToggleChatHeadServiceUseCase;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.core.engagement.domain.GetOperatorFlowableUseCase;
@@ -45,6 +46,7 @@ public class ServiceChatHeadController
     private final AddVisitorMediaStateListenerUseCase addVisitorMediaStateListenerUseCase;
     private final RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase;
     private final GetOperatorFlowableUseCase getOperatorFlowableUseCase;
+    private final SetPendingSurveyUseCase setPendingSurveyUseCase;
     private final IsCallVisualizerScreenSharingUseCase isCallVisualizerScreenSharingUseCase;
     private final ChatHeadPosition chatHeadPosition;
 
@@ -82,6 +84,7 @@ public class ServiceChatHeadController
             RemoveVisitorMediaStateListenerUseCase removeVisitorMediaStateListenerUseCase,
             ChatHeadPosition chatHeadPosition,
             GetOperatorFlowableUseCase getOperatorFlowableUseCase,
+            SetPendingSurveyUseCase setPendingSurveyUseCase,
             IsCallVisualizerScreenSharingUseCase isCallVisualizerScreenSharingUseCase
     ) {
         this.toggleChatHeadServiceUseCase = toggleChatHeadServiceUseCase;
@@ -95,6 +98,7 @@ public class ServiceChatHeadController
         this.addVisitorMediaStateListenerUseCase = addVisitorMediaStateListenerUseCase;
         this.removeVisitorMediaStateListenerUseCase = removeVisitorMediaStateListenerUseCase;
         this.getOperatorFlowableUseCase = getOperatorFlowableUseCase;
+        this.setPendingSurveyUseCase = setPendingSurveyUseCase;
         this.isCallVisualizerScreenSharingUseCase = isCallVisualizerScreenSharingUseCase;
     }
 
@@ -189,6 +193,7 @@ public class ServiceChatHeadController
     }
 
     private void engagementEnded() {
+        setPendingSurveyUseCase.invoke();
         state = State.ENDED;
         operatorProfileImgUrl = null;
         unreadMessagesCount = 0;

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -5,6 +5,8 @@ import com.glia.widgets.chat.ChatViewCallback
 import com.glia.widgets.chat.domain.*
 import com.glia.widgets.chat.model.history.ChatItem
 import com.glia.widgets.chat.model.history.LinkedChatItem
+import com.glia.widgets.core.chathead.domain.HasPendingSurveyUseCase
+import com.glia.widgets.core.chathead.domain.SetPendingSurveyUsedUseCase
 import com.glia.widgets.core.dialog.DialogController
 import com.glia.widgets.core.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
 import com.glia.widgets.core.engagement.domain.*
@@ -82,6 +84,8 @@ class ChatControllerTest {
     private lateinit var isSecureConversationsChatAvailableUseCase: IsSecureConversationsChatAvailableUseCase
     private lateinit var markMessagesReadWithDelayUseCase: MarkMessagesReadWithDelayUseCase
     private lateinit var isQueueingEngagementUseCase: IsQueueingEngagementUseCase
+    private lateinit var hasPendingSurveyUseCase: HasPendingSurveyUseCase
+    private lateinit var setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase
 
     private lateinit var chatController: ChatController
 
@@ -135,6 +139,8 @@ class ChatControllerTest {
         isSecureConversationsChatAvailableUseCase = mock()
         markMessagesReadWithDelayUseCase = mock()
         isQueueingEngagementUseCase = mock()
+        hasPendingSurveyUseCase = mock()
+        setPendingSurveyUsedUseCase = mock()
 
         chatController = ChatController(
             chatViewCallback = chatViewCallback,
@@ -184,7 +190,9 @@ class ChatControllerTest {
             removeMediaUpgradeCallbackUseCase = removeMediaUpgradeOfferCallbackUseCase,
             isSecureEngagementAvailableUseCase = isSecureConversationsChatAvailableUseCase,
             markMessagesReadWithDelayUseCase = markMessagesReadWithDelayUseCase,
-            isQueueingEngagementUseCase = isQueueingEngagementUseCase
+            isQueueingEngagementUseCase = isQueueingEngagementUseCase,
+            hasPendingSurveyUseCase = hasPendingSurveyUseCase,
+            setPendingSurveyUsedUseCase = setPendingSurveyUsedUseCase
         )
     }
 


### PR DESCRIPTION
MOB-2007

The problematic flow was the following:

- Set engagement to not have a survey
- Start chat engagement with operator connected
- minimize the chat screen
- disconnect the operator
- click on bubble

Expected result:
- engagement ended dialog is shown

Actual result:
- app would show unexpected dialog
- when starting a new chat engagement, the engegement ended dialog is shown

Same for Call as well.
