### PR TITLE
Rename ActivityWatcherController for Call Visualiser

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -35,8 +35,8 @@ import java.lang.ref.WeakReference
 
 internal class ActivityWatcherForCallVisualizer(
     private val dialogController: DialogController,
-    val controller: ActivityWatcherContract.Controller
-) : BaseActivityWatcher(), ActivityWatcherContract.Watcher {
+    val controller: ActivityWatcherForCallVisualizerContract.Controller
+) : BaseActivityWatcher(), ActivityWatcherForCallVisualizerContract.Watcher {
 
     companion object {
         private val TAG = ActivityWatcherForCallVisualizer::class.java.simpleName

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
@@ -1,16 +1,14 @@
 package com.glia.widgets.callvisualizer
 
-import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.widgets.core.dialog.model.DialogState
 
-class ActivityWatcherContract {
+class ActivityWatcherForCallVisualizerContract {
 
     interface Controller {
         fun onActivityPaused()

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
@@ -19,14 +19,14 @@ import com.glia.widgets.core.screensharing.ScreenSharingController
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.view.unifiedui.extensions.wrapWithMaterialThemeOverlay
 
-internal class ActivityWatcherController(
+internal class ActivityWatcherForCallVisualizerController(
     private val callVisualizerController: CallVisualizerController,
     private val screenSharingController: ScreenSharingController,
     private val isShowOverlayPermissionRequestDialogUseCase: IsShowOverlayPermissionRequestDialogUseCase
-) : ActivityWatcherContract.Controller {
+) : ActivityWatcherForCallVisualizerContract.Controller {
 
     companion object {
-        private val TAG = ActivityWatcherController::class.java.simpleName
+        private val TAG = ActivityWatcherForCallVisualizerController::class.java.simpleName
     }
 
     @VisibleForTesting
@@ -35,9 +35,9 @@ internal class ActivityWatcherController(
     @Mode
     private var currentDialogMode: Int = MODE_NONE
 
-    private lateinit var watcher: ActivityWatcherContract.Watcher
+    private lateinit var watcher: ActivityWatcherForCallVisualizerContract.Watcher
 
-    override fun setWatcher(watcher: ActivityWatcherContract.Watcher) {
+    override fun setWatcher(watcher: ActivityWatcherForCallVisualizerContract.Watcher) {
         this.watcher = watcher
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -2,8 +2,8 @@ package com.glia.widgets.di;
 
 import com.glia.widgets.call.CallController;
 import com.glia.widgets.call.CallViewCallback;
-import com.glia.widgets.callvisualizer.ActivityWatcherContract;
-import com.glia.widgets.callvisualizer.ActivityWatcherController;
+import com.glia.widgets.callvisualizer.ActivityWatcherForCallVisualizerContract;
+import com.glia.widgets.callvisualizer.ActivityWatcherForCallVisualizerController;
 import com.glia.widgets.callvisualizer.EndScreenSharingContract;
 import com.glia.widgets.callvisualizer.EndScreenSharingController;
 import com.glia.widgets.callvisualizer.VisitorCodeContract;
@@ -13,7 +13,6 @@ import com.glia.widgets.chat.ChatViewCallback;
 import com.glia.widgets.chat.controller.ChatController;
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager;
 import com.glia.widgets.core.dialog.DialogController;
-import com.glia.widgets.core.dialog.PermissionDialogManager;
 import com.glia.widgets.core.screensharing.ScreenSharingController;
 import com.glia.widgets.filepreview.ui.FilePreviewController;
 import com.glia.widgets.helper.Logger;
@@ -26,8 +25,6 @@ import com.glia.widgets.view.MessagesNotSeenHandler;
 import com.glia.widgets.view.MinimizeHandler;
 import com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoContract;
 import com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoController;
-import com.glia.widgets.view.head.ActivityWatcherForChatHead;
-import com.glia.widgets.view.head.ChatHeadLayoutContract;
 import com.glia.widgets.view.head.ChatHeadPosition;
 import com.glia.widgets.view.head.controller.ActivityWatcherForChatHeadContract;
 import com.glia.widgets.view.head.controller.ActivityWatcherForChatHeadController;
@@ -53,7 +50,7 @@ public class ControllerFactory {
     private final ChatHeadPosition chatHeadPosition;
     private SurveyController surveyController;
     private CallVisualizerController callVisualizerController;
-    private ActivityWatcherController activityWatcherController;
+    private ActivityWatcherForCallVisualizerController activityWatcherforCallVisualizerController;
     private ActivityWatcherForChatHeadController activityWatcherForChatHeadController;
     private static ServiceChatHeadController serviceChatHeadController;
     private static ApplicationChatHeadLayoutController applicationChatHeadController;
@@ -356,14 +353,14 @@ public class ControllerFactory {
                 repositoryFactory.getGliaEngagementRepository());
     }
 
-    public ActivityWatcherContract.Controller getActivityWatcherController() {
-        if (activityWatcherController == null) {
-            activityWatcherController = new ActivityWatcherController(
+    public ActivityWatcherForCallVisualizerContract.Controller getActivityWatcherForCallVisualizerController() {
+        if (activityWatcherforCallVisualizerController == null) {
+            activityWatcherforCallVisualizerController = new ActivityWatcherForCallVisualizerController(
                     getCallVisualizerController(),
                     getScreenSharingController(),
                     useCaseFactory.createIsShowOverlayPermissionRequestDialogUseCase());
         }
-        return activityWatcherController;
+        return activityWatcherforCallVisualizerController;
     }
 
     public ActivityWatcherForChatHeadContract.Controller getActivityWatcherForChatHeadController() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -70,7 +70,7 @@ public class Dependencies {
         ActivityWatcherForCallVisualizer activityWatcherForCallVisualizer =
                 new ActivityWatcherForCallVisualizer(
                         getControllerFactory().getDialogController(),
-                        getControllerFactory().getActivityWatcherController()
+                        getControllerFactory().getActivityWatcherForCallVisualizerController()
                 );
         application.registerActivityLifecycleCallbacks(activityWatcherForCallVisualizer);
 

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerControllerTest.kt
@@ -23,15 +23,15 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.*
 import java.util.function.Consumer
 
-internal class ActivityWatcherControllerTest {
+internal class ActivityWatcherForCallVisualizerControllerTest {
 
     private val callVisualizerRepository = mock(CallVisualizerRepository::class.java)
     private val callVisualizerController = mock(CallVisualizerController::class.java)
     private val screenSharingController = mock(ScreenSharingController::class.java)
     private val isCallOrChatActiveUseCase = mock(IsCallOrChatScreenActiveUseCase::class.java)
-    private val watcher = mock(ActivityWatcherContract.Watcher::class.java)
+    private val watcher = mock(ActivityWatcherForCallVisualizerContract.Watcher::class.java)
     private val isShowOverlayPermissionRequestDialogUseCase = mock(IsShowOverlayPermissionRequestDialogUseCase::class.java)
-    private val controller = ActivityWatcherController(callVisualizerController, screenSharingController, isShowOverlayPermissionRequestDialogUseCase)
+    private val controller = ActivityWatcherForCallVisualizerController(callVisualizerController, screenSharingController, isShowOverlayPermissionRequestDialogUseCase)
     private val activity = mock(AppCompatActivity::class.java)
     private val supportActivity = mock(CallVisualizerSupportActivity::class.java)
     private val mediaUpgradeOffer = mock(MediaUpgradeOffer::class.java)


### PR DESCRIPTION
According to a chat with Karl, I think it makes sense to rename `ActivityWatcherController` to `ActivityWatcherForCallVisualizerController`.

Pros:
- corresponds to `ActivityWatcherForCallVisualizer`
- name will be aligned with `ActivityWatcherForChatHeadController`

Cons:
- longer name