### PR TITLE
Show chat bubble on Chat screen if visitor comes from Call screen

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
@@ -25,8 +25,7 @@ internal abstract class IsDisplayChatHeadUseCase(
     abstract fun isDisplayBasedOnPermission(): Boolean
 
     open operator fun invoke(viewName: String?) : Boolean {
-        return (isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
-        )
+        return (isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName))
     }
 
     private fun isShowForEngagement(viewName: String?) =
@@ -44,19 +43,22 @@ internal abstract class IsDisplayChatHeadUseCase(
     }
 
     private fun isShowForMediaEngagement(viewName: String?): Boolean {
-        return isMediaEngagementOrQueueingOngoing() && isNotInListOfGliaViews(viewName)
+        return isMediaEngagementOrQueueingOngoing() && isNotInListOfGliaViewsExceptChat(viewName)
     }
 
     private fun isShowForChatEngagement(viewName: String?): Boolean {
         return isChatEngagementOrQueueingOngoing() && isNotInListOfGliaViews(viewName)
     }
 
-    private fun isNotInListOfGliaViews(viewName: String?): Boolean {
-        return viewName != ChatView::class.java.simpleName &&
-                viewName != CallView::class.java.simpleName &&
+    private fun isNotInListOfGliaViewsExceptChat(viewName: String?): Boolean {
+        return viewName != CallView::class.java.simpleName &&
                 viewName != FilePreviewView::class.java.simpleName &&
                 viewName != EndScreenSharingView::class.java.simpleName &&
                 viewName != MessageCenterView::class.java.simpleName
+    }
+
+    private fun isNotInListOfGliaViews(viewName: String?): Boolean {
+        return viewName != ChatView::class.java.simpleName && isNotInListOfGliaViewsExceptChat(viewName)
     }
 
     private fun isChatEngagementOrQueueingOngoing(): Boolean {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
@@ -127,7 +127,6 @@ internal class ActivityWatcherForChatHead(
         activity?.let {
             gliaView = it.findViewById(R.id.call_view)
                 ?: it.findViewById<FilePreviewView>(R.id.file_preview_view)
-                        ?: it.findViewById<ChatView>(R.id.chat_view)
                         ?: it.findViewById<EndScreenSharingView>(R.id.screen_sharing_screen_view)
         }
         return gliaView != null


### PR DESCRIPTION
[MOB-2068](https://glia.atlassian.net/browse/MOB-2068)

It was decided to display chat bubble for this flow:
1. Start audio/video engagement
2. audio/video call view opens
3. tap on “chat” button
4. Chat view opens

Expected result: bubble is displayed and navigates the visitor to Call screen once it’s tapped.


[MOB-2068]: https://glia.atlassian.net/browse/MOB-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ