### PR TITLE
Fix white lable behavior

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -174,7 +174,7 @@ object Dialogs {
                 applyAlertTheme(alertTheme)
             }
             findViewById<ImageView>(R.id.logo_view).apply {
-                isVisible = theme.whiteLabel ?: false
+                isVisible = theme.whiteLabel?.not() ?: true
                 applyImageColorTheme(baseShadeColor)
             }
         }
@@ -289,7 +289,7 @@ object Dialogs {
                 applyAlertTheme(alertTheme)
             }
             findViewById<ImageView>(R.id.logo_view).apply {
-                isVisible = theme.whiteLabel ?: false
+                isVisible = theme.whiteLabel?.not() ?: true
                 applyImageColorTheme(baseShadeColor)
             }
 
@@ -403,7 +403,7 @@ object Dialogs {
                 applyAlertTheme(alertTheme)
             }
             findViewById<ImageView>(R.id.logo_view).apply {
-                isVisible = theme.whiteLabel ?: false
+                isVisible = theme.whiteLabel?.not() ?: true
                 applyImageColorTheme(baseShadeColor)
             }
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
@@ -53,7 +53,7 @@ class VisitorCodeView internal constructor(
     private var progressBar: ProgressBar
     private var refreshButton: GliaPositiveButton
     private var closeButton: AppCompatImageButton
-    private var whiteLabelView: ImageView
+    private var logoView: ImageView
 
     init {
         layoutInflater.inflate(R.layout.visitor_code_view, this, true)
@@ -67,7 +67,7 @@ class VisitorCodeView internal constructor(
         refreshButton.setOnClickListener { controller.onLoadVisitorCode() }
         closeButton = findViewById(R.id.close_button)
         closeButton.setOnClickListener { controller.onCloseButtonClicked() }
-        whiteLabelView = findViewById(R.id.logo_view)
+        logoView = findViewById(R.id.logo_view)
         readTypedArray()
         applyRemoteThemeConfig(Dependencies.getGliaThemeManager().theme)
 
@@ -218,8 +218,8 @@ class VisitorCodeView internal constructor(
             textColor = baseLightColor,
             textFont = fontFamily
         )
-        whiteLabelView.apply {
-            isVisible = theme.whiteLabel ?: false
+        logoView.apply {
+            isVisible = theme.whiteLabel?.not() ?: true
             applyImageColorTheme(baseShadeColor)
         }
         progressBar.applyProgressColorTheme(brandPrimaryColor)


### PR DESCRIPTION
White label stands for overriding product branding. Defaoult value for white label should be 'false' as it is purchasable feature. And 'whiteLable=false' means that Glia logo should be visible by default.

MOB-2074