### PR TITLE
Finish Chat screen when navigating back to Call screen

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/ChatFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/ChatFragment.java
@@ -21,17 +21,7 @@ public class ChatFragment extends Fragment {
 
     private NavController navController;
     private ChatView chatView;
-    private ChatView.OnBackClickedListener onBackClickedListener = () -> {
-        chatView.backPressed();
-        navController.popBackStack();
-    };
     private ChatView.OnEndListener onEndListener = () -> navController.popBackStack();
-    private final NavController.OnDestinationChangedListener onDestinationChangedListener =
-            (controller, destination, arguments) -> {
-                if (destination.getId() == R.id.main_fragment && chatView != null) {
-                    chatView.backPressed();
-                }
-            };
 
     @Nullable
     @Override
@@ -46,13 +36,11 @@ public class ChatFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         navController = NavHostFragment.findNavController(this);
-        navController.addOnDestinationChangedListener(onDestinationChangedListener);
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
         chatView = view.findViewById(R.id.chat_view);
         UiTheme theme = Utils.getUiThemeByPrefs(sharedPreferences, getResources());
         chatView.setUiTheme(theme);
         chatView.setOnEndListener(onEndListener);
-        chatView.setOnBackClickedListener(onBackClickedListener);
         chatView.startChat(
                 Utils.getStringFromPrefs(R.string.pref_company_name, getString(R.string.settings_value_default_company_name), sharedPreferences, getResources()),
                 Utils.getStringFromPrefs(R.string.pref_queue_id, getString(R.string.glia_queue_id), sharedPreferences, getResources()),
@@ -67,10 +55,7 @@ public class ChatFragment extends Fragment {
 
     @Override
     public void onDestroyView() {
-        onBackClickedListener = null;
         onEndListener = null;
-        navController.removeOnDestinationChangedListener(onDestinationChangedListener);
-        onBackClickedListener = null;
         chatView.onDestroyView(true);
         super.onDestroyView();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -18,24 +18,9 @@ import com.glia.widgets.call.Configuration;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.helper.Utils;
 import com.glia.widgets.survey.SurveyActivity;
-import com.glia.widgets.view.head.ChatHeadLayout;
 
 public class ChatActivity extends AppCompatActivity {
     private ChatView chatView;
-    private ChatView.OnBackClickedListener onBackClickedListener = () -> {
-        if (chatView.backPressed()) finish();
-    };
-
-    private ChatView.OnNavigateToCallListener onNavigateToCallListener =
-            (UiTheme theme, String mediaType) -> {
-                navigateToCall(mediaType);
-                chatView.navigateToCallSuccess();
-            };
-    private ChatView.OnNavigateToSurveyListener onNavigateToSurveyListener =
-            (UiTheme theme, Survey survey) -> {
-                navigateToSurvey(theme, survey);
-                finish();
-            };
 
     private GliaSdkConfiguration configuration;
 
@@ -72,8 +57,8 @@ public class ChatActivity extends AppCompatActivity {
 
         chatView.setConfiguration(configuration);
         chatView.setUiTheme(configuration.getRunTimeTheme());
-        chatView.setOnBackClickedListener(onBackClickedListener);
-        chatView.setOnBackToCallListener(this::backToCall);
+        chatView.setOnBackClickedListener(this::finish);
+        chatView.setOnBackToCallListener(this::backToCallScreen);
 
         // In case the engagement ends, Activity is removed from the device's Recents menu
         // to avoid app users to accidentally start queueing for another call when they resume
@@ -81,8 +66,8 @@ public class ChatActivity extends AppCompatActivity {
         chatView.setOnEndListener(this::finishAndRemoveTask);
 
         chatView.setOnMinimizeListener(this::finish);
-        chatView.setOnNavigateToCallListener(onNavigateToCallListener);
-        chatView.setOnNavigateToSurveyListener(onNavigateToSurveyListener);
+        chatView.setOnNavigateToCallListener(this::startCallScreen);
+        chatView.setOnNavigateToSurveyListener(this::navigateToSurvey);
         chatView.startChat(
                 configuration.getCompanyName(),
                 configuration.getQueueId(),
@@ -107,16 +92,13 @@ public class ChatActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        onBackClickedListener = null;
-        onNavigateToCallListener = null;
-        onNavigateToSurveyListener = null;
         chatView.onDestroyView(isFinishing());
         super.onDestroy();
     }
 
     @Override
     public void onBackPressed() {
-        if (chatView.backPressed()) super.onBackPressed();
+        chatView.onBackPressed();
     }
 
     @Override
@@ -139,7 +121,7 @@ public class ChatActivity extends AppCompatActivity {
                 .build();
     }
 
-    private void navigateToCall(String mediaType) {
+    private void startCallScreen(UiTheme theme, String mediaType) {
         startActivity(
                 CallActivity.getIntent(
                         getApplicationContext(),
@@ -148,12 +130,12 @@ public class ChatActivity extends AppCompatActivity {
                                 .build()
                 )
         );
+        finish();
     }
 
-    private void backToCall() {
+    private void backToCallScreen() {
         startActivity(CallActivity.getIntent(getApplicationContext(), getConfigurationBuilder().build()));
-
-        chatView.navigateToCallSuccess();
+        finish();
     }
 
     private Configuration.Builder getConfigurationBuilder() {
@@ -165,5 +147,6 @@ public class ChatActivity extends AppCompatActivity {
         newIntent.putExtra(GliaWidgets.UI_THEME, theme);
         newIntent.putExtra(GliaWidgets.SURVEY, (Parcelable) survey);
         startActivity(newIntent);
+        finish();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -114,7 +114,6 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     private var defaultStatusBarColor: Int? = null
     private var statusBarColor: Int by Delegates.notNull()
     private var onTitleUpdatedListener: OnTitleUpdatedListener? = null
-    private var onBackClickedListener: OnBackClickedListener? = null
     private var onEndListener: OnEndListener? = null
     private var onMinimizeListener: OnMinimizeListener? = null
     private var onNavigateToCallListener: OnNavigateToCallListener? = null
@@ -228,9 +227,8 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
      * Used to tell the view that the user has pressed the back button so that the view can
      * set its state accordingly.
      */
-    fun backPressed(): Boolean {
+    fun onBackPressed() {
         controller?.onBackArrowClicked()
-        return true
     }
 
     fun setOnTitleUpdatedListener(onTitleUpdatedListener: OnTitleUpdatedListener?) {
@@ -244,7 +242,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
      * @param onBackClicked The callback which is fired when the button is clicked.
      */
     fun setOnBackClickedListener(onBackClicked: OnBackClickedListener?) {
-        onBackClickedListener = onBackClicked
+        controller?.setOnBackClickedListener(onBackClicked)
     }
 
     /**
@@ -309,7 +307,6 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
         alertDialog = null
 
         onEndListener = null
-        onBackClickedListener = null
         onNavigateToCallListener = null
         onNavigateToSurveyListener = null
         destroyController()
@@ -319,14 +316,6 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
         binding.chatRecyclerView.removeOnScrollListener(onScrollListener)
         binding.addAttachmentQueue.adapter = null
         dialogController = null
-    }
-
-    /**
-     * Use this method together with [.setOnNavigateToCallListener]
-     * to notify the view that you have finished navigating.
-     */
-    fun navigateToCallSuccess() {
-        controller?.navigateToCallSuccess()
     }
 
     fun shouldShow(): Boolean {
@@ -733,7 +722,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
             controller?.sendMessage(message)
         }
         setupAddAttachmentButton()
-        binding.appBarView.setOnBackClickedListener { controller?.onBackArrowClicked(onBackClickedListener) }
+        binding.appBarView.setOnBackClickedListener { controller?.onBackArrowClicked() }
         binding.appBarView.setOnEndChatClickedListener { controller?.leaveChatClicked() }
         binding.appBarView.setOnEndCallButtonClickedListener {
             screenSharingController?.onForceStopScreenSharing()

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -376,7 +376,9 @@ public class ControllerFactory {
                     serviceChatHeadController,
                     getChatHeadLayoutController(),
                     getScreenSharingController(),
-                    useCaseFactory.createOnEngagementUseCase());
+                    useCaseFactory.createOnEngagementUseCase(),
+                    useCaseFactory.createIsFromCallScreenUseCase(),
+                    useCaseFactory.createUpdateFromCallScreenUseCase());
         }
         return activityWatcherForChatHeadController;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
@@ -75,6 +75,11 @@ internal class ActivityWatcherForChatHead(
 
                 override fun onNavigateToCall() {
                     navigateToCall(resumedActivity.get())
+                    if (controller.isFromCallScreen()) {
+                        // Finish ChatActivity if bubble is tapped from ChatActivity
+                        controller.resetFromCallScreen()
+                        resumedActivity.get()?.finish()
+                    }
                 }
             }
         )

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadContract.kt
@@ -9,6 +9,8 @@ internal class ActivityWatcherForChatHeadContract {
         fun onActivityPaused()
         fun onActivityResumed()
         fun shouldShowBubble(gliaOrRootView: String?): Boolean
+        fun isFromCallScreen(): Boolean
+        fun resetFromCallScreen()
     }
 
     interface Watcher {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
@@ -1,7 +1,8 @@
 package com.glia.widgets.view.head.controller
 
 import com.glia.androidsdk.Glia
-import com.glia.androidsdk.GliaException
+import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
+import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase
 import com.glia.widgets.core.screensharing.ScreenSharingController
 import com.glia.widgets.helper.Logger
@@ -11,6 +12,8 @@ internal class ActivityWatcherForChatHeadController(
     private var applicationChatHeadController: ApplicationChatHeadLayoutController,
     private val screenSharingController: ScreenSharingController,
     private val gliaOnEngagementUseCase: GliaOnEngagementUseCase,
+    private val isFromCallScreenUseCase: IsFromCallScreenUseCase,
+    private val updateFromCallScreenUseCase: UpdateFromCallScreenUseCase,
 ) : ActivityWatcherForChatHeadContract.Controller {
 
     private lateinit var watcher: ActivityWatcherForChatHeadContract.Watcher
@@ -27,6 +30,14 @@ internal class ActivityWatcherForChatHeadController(
 
     override fun shouldShowBubble(gliaOrRootView: String?): Boolean {
         return shouldShowAppBubble(gliaOrRootView)
+    }
+
+    override fun isFromCallScreen(): Boolean {
+        return isFromCallScreenUseCase.isFromCallScreen
+    }
+
+    override fun resetFromCallScreen() {
+        updateFromCallScreenUseCase.updateFromCallScreen(false)
     }
 
     override fun onActivityResumed() {

--- a/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
@@ -3,6 +3,8 @@ package com.glia.widgets.view.head
 import android.app.Activity
 import android.view.View
 import android.view.Window
+import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
+import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase
 import com.glia.widgets.core.screensharing.ScreenSharingController
 import com.glia.widgets.view.head.controller.ActivityWatcherForChatHeadContract
@@ -22,11 +24,15 @@ internal class ActivityWatcherForChatHeadTest {
     private val applicationChatHeadController = Mockito.mock(ApplicationChatHeadLayoutController::class.java)
     private val screenSharingController = Mockito.mock(ScreenSharingController::class.java)
     private val onEngagementUseCase = Mockito.mock(GliaOnEngagementUseCase::class.java)
+    private val isFromCallScreenUseCase = Mockito.mock(IsFromCallScreenUseCase::class.java)
+    private val updateFromCallScreenUseCase = Mockito.mock(UpdateFromCallScreenUseCase::class.java)
     private val controller = ActivityWatcherForChatHeadController(
         serviceChatHeadController,
         applicationChatHeadController,
         screenSharingController,
         onEngagementUseCase,
+        isFromCallScreenUseCase,
+        updateFromCallScreenUseCase
     )
     private val activity = Mockito.mock(Activity::class.java)
     private val view = Mockito.mock(View::class.java)


### PR DESCRIPTION
[MOB-2055](https://glia.atlassian.net/browse/MOB-2055)

Steps:

1. start audio engagement (Call screen is opened)
2. Tap "Chat" icon (Chat screen is opened)
3. Tap "back" icon from application (Call screen is opened)
4. Tap "back" icon from application

**Expected result:** Call screen is closed, Main screen is opened
**Actual result:** Chat screen is opened again (loops back several times)

PR fixes this.

Besides, there was (and still is) a difference between application "back" and device "back" behavior on the 3rd step.
Application "back" closes Chat screen and navigates to Call screen. I would say it's expected.
Device "back" closes Chat screen and navigates to Main screen. 
I haven't found a way to align the behaviors, unfortunately.
If you have an idea - I would appreciate it.
Anyway, right now behavior is improved (primary goal of the ticket is achieved).

[MOB-2055]: https://glia.atlassian.net/browse/MOB-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ