### PR TITLE
Do not display End button on Call screen for Call Visualizer

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -888,11 +888,8 @@ internal class CallView(
             //No need to manage the remaining view's states if only time has changed
             if (callState.isOnlyTimeChanged) return@post
 
-            if (callState.isMediaEngagementStarted) {
-                appBar.showEndButton()
-            } else {
-                appBar.showXButton()
-            }
+            setupEndButton(callState)
+
             if (screenSharingController?.isSharingScreen == true) {
                 appBar.showEndScreenSharingButton()
             } else {
@@ -991,6 +988,16 @@ internal class CallView(
                 )
 
             applyTextThemeBasedOnCallState(callState)
+        }
+    }
+
+    private fun setupEndButton(callState: CallState) {
+        if (callState.isCallVisualizer) {
+            appBar.hideXAndEndButton()
+        } else if (callState.isMediaEngagementStarted) {
+            appBar.showEndButton()
+        } else {
+            appBar.showXButton()
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
@@ -6,7 +6,6 @@ import android.view.MenuItem
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.AppCompatImageButton
-import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import androidx.core.view.children
 import androidx.core.view.isGone
@@ -143,6 +142,11 @@ class AppBarView @JvmOverloads constructor(
 
     fun showEndButton() {
         binding.endButton.isVisible = true
+        leaveQueueIcon.isVisible = false
+    }
+
+    fun hideXAndEndButton() {
+        binding.endButton.isGone = true
         leaveQueueIcon.isVisible = false
     }
 


### PR DESCRIPTION
[MOB-2075](https://glia.atlassian.net/browse/MOB-2075)

There was an End and X button for video, it should not be there for Call Visualizer engagement per the design.

[MOB-2075]: https://glia.atlassian.net/browse/MOB-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ