### PR TITLE
Fixed unwanted behaiour on visitor code view, added logging

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/VisitorCodeController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/VisitorCodeController.kt
@@ -18,6 +18,7 @@ class VisitorCodeController(
 
     private var disposable: Disposable? = null
     private val onEngagementStartConsumer: (Engagement) -> Unit = {
+        view.destroyTimer()
         dialogController.dismissVisitorCodeDialog()
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
@@ -93,18 +93,21 @@ class VisitorCodeView internal constructor(
     }
 
     override fun setTimer(duration: Long) {
+        Logger.d(TAG, "Setting visitor code timeout to $duration")
         timer = object : CountDownTimer(duration, duration) {
             override fun onTick(p0: Long) {
-            //no-op
+                // no-op
             }
 
             override fun onFinish() {
+                Logger.d(TAG, "Reloading Visitor Code")
                 controller.onLoadVisitorCode()
             }
         }.start()
     }
 
     override fun destroyTimer() {
+        Logger.d(TAG, "Dismissing Visitor Code reload timer")
         timer?.cancel()
         timer = null
     }


### PR DESCRIPTION
MOB-2063

Described issue no longer reproducible since core version was updated. Found one other issue where when dialog was dismissed by starting engagement, the timer was not reset. Added some logging to visitor code refresh timer for clarity.
