### PR TITLE
Migrate agp to 8.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
     }
     signingConfigs {
         debug {

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,461 +1,429 @@
----
-format_version: '8'
-default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
+format_version: "8"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: android
 workflows:
   _increment_project_version:
     steps:
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # make pipelines' return status equal the last command to exit with
-            a non-zero status, or zero if all commands exit successfully
-
-            set -o pipefail
-
-            # debug log
-
-            set -x
-
-
-            if [ ! -z "$GITHUB_VERSION_INCREMENT_TYPE" ] ; then
-              envman add --key VERSION_INCREMENT_TYPE --value "$GITHUB_VERSION_INCREMENT_TYPE"
-            fi
-    - gradle-runner@2:
-        inputs:
-        - gradle_file: $PROJECT_LOCATION/build.gradle
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-        - gradle_task: saveWidgetsVersion --type=$VERSION_INCREMENT_TYPE
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # make pipelines' return status equal the last command to exit with
-            a non-zero status, or zero if all commands exit successfully
-
-            set -o pipefail
-
-            # debug log
-
-            set -x
-
-
-            NEW_VERSION=`./gradlew -q printCurrentVersionName`
-
-            BRANCH_NAME="project-version-increment/${NEW_VERSION}"
-
-            MESSAGE="Increment project version to ${NEW_VERSION}"
-
-
-            git checkout -b $BRANCH_NAME
-
-            git add -A
-
-            git commit -m "$MESSAGE"
-
-            git push origin "$BRANCH_NAME":"$BRANCH_NAME"
-
-
-            PULL_REQUEST_NUMBER=$(curl \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $GITHUB_API_TOKEN" \
-              https://api.github.com/repos/salemove/android-sdk-widgets/pulls \
-              -d "{\"title\":\"${MESSAGE}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"master\"}" | jq --raw-output '.number')
-
-            curl \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $GITHUB_API_TOKEN" \
-              https://api.github.com/repos/salemove/android-sdk-widgets/pulls/$PULL_REQUEST_NUMBER/requested_reviewers \
-              -d "{\"team_reviewers\":[\"tm-mobile-android\"]}"
+      - script@1:
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # fail if any commands fails
+                set -e
+                # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+                set -o pipefail
+                # debug log
+                set -x
+                
+                if [ ! -z "$GITHUB_VERSION_INCREMENT_TYPE" ] ; then
+                  envman add --key VERSION_INCREMENT_TYPE --value "$GITHUB_VERSION_INCREMENT_TYPE"
+                fi
+      - gradle-runner@2:
+          inputs:
+            - gradle_file: $PROJECT_LOCATION/build.gradle
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradle_task: saveWidgetsVersion --type=$VERSION_INCREMENT_TYPE
+      - script@1:
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # fail if any commands fails
+                set -e
+                # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+                set -o pipefail
+                # debug log
+                set -x
+                
+                NEW_VERSION=`./gradlew -q printCurrentVersionName`
+                BRANCH_NAME="project-version-increment/${NEW_VERSION}"
+                MESSAGE="Increment project version to ${NEW_VERSION}"
+                
+                git checkout -b $BRANCH_NAME
+                git add -A
+                git commit -m "$MESSAGE"
+                git push origin "$BRANCH_NAME":"$BRANCH_NAME"
+                
+                PULL_REQUEST_NUMBER=$(curl \
+                  -X POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+                  https://api.github.com/repos/salemove/android-sdk-widgets/pulls \
+                  -d "{\"title\":\"${MESSAGE}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"master\"}" | jq --raw-output '.number')
+                
+                curl \
+                  -X POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+                  https://api.github.com/repos/salemove/android-sdk-widgets/pulls/$PULL_REQUEST_NUMBER/requested_reviewers \
+                  -d "{\"team_reviewers\":[\"tm-mobile-android\"]}"
     envs:
-    - opts:
-        is_expand: false
-      VERSION_INCREMENT_TYPE: patch
+      - opts:
+          is_expand: false
+        VERSION_INCREMENT_TYPE: patch
   authenticated_increment_project_version:
     description: Task builds an SDK and uploads it to Nexus.
     steps:
-    - activate-ssh-key@4: {}
-    - git-clone@6: {}
-    - cache-pull@2: {}
-    - install-missing-android-tools@3:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-    - cache-push@2: {}
+      - activate-ssh-key@4: { }
+      - git-clone@6: { }
+      - cache-pull@2: { }
+      - set-java-version@1.1:
+          is_always_run: true
+          inputs:
+            - set_java_version: "17"
+      - install-missing-android-tools@3:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+      - cache-push@2: { }
     after_run:
-    - _increment_project_version
+      - _increment_project_version
   browserstack_upload:
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@6.1: {}
-    - cache-pull@2: {}
-    - install-missing-android-tools@3.0:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-    - android-build@1.0:
-        inputs:
-        - variant: $INTEGRATOR_VARIANT
-        - module: $EXAMPLE_APP_MODULE
-    - browserstack-upload@0:
-        inputs:
-        - custom_id: $BROWSERSTACK_APP_ID
-        title: Upload APP to BrowserStack
-    - deploy-to-bitrise-io@1:
-        inputs:
-        - notify_email_list: $BUILD_EMAILS
-    - cache-push@2: {}
+      - activate-ssh-key@4:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@6.1: { }
+      - cache-pull@2: { }
+      - set-java-version@1.1:
+          is_always_run: true
+          inputs:
+            - set_java_version: "17"
+      - install-missing-android-tools@3.0:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+      - android-build@1.0:
+          inputs:
+            - variant: $INTEGRATOR_VARIANT
+            - module: $EXAMPLE_APP_MODULE
+      - browserstack-upload@0:
+          inputs:
+            - custom_id: $BROWSERSTACK_APP_ID
+          title: Upload APP to BrowserStack
+      - deploy-to-bitrise-io@1:
+          inputs:
+            - notify_email_list: $BUILD_EMAILS
+      - cache-push@2: { }
   develop:
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
-    - script@1:
-        inputs:
-        - content: >-
-            sudo update-alternatives --set javac
-            /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
-
-            sudo update-alternatives --set java
-            /usr/lib/jvm/java-11-openjdk-amd64/bin/java
-
-            export JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
-
-            envman add --key JAVA_HOME --value
-            '/usr/lib/jvm/java-11-openjdk-amd64'
-    - cache-pull@2: {}
-    - install-missing-android-tools@2:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-    - android-build@0:
-        inputs:
-        - variant: $INTEGRATOR_VARIANT
-        - module: $EXAMPLE_APP_MODULE
-    - android-lint@0:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $WIDGET_SDK_MODULE
-        - variant: $SDK_VARIANT
-        title: Run Lint for SDK
-    - android-unit-test@1:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $WIDGET_SDK_MODULE
-        - variant: $SDK_VARIANT
-        title: Unit Test for SDK
-    - android-lint@0:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $EXAMPLE_APP_MODULE
-        - variant: $INTEGRATOR_VARIANT
-        title: Run Lint for APP
-    - android-unit-test@1:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $EXAMPLE_APP_MODULE
-        - variant: $INTEGRATOR_VARIANT
-        title: Unit Test for APP
-    - deploy-to-bitrise-io@1:
-        inputs:
-        - notify_email_list: $BUILD_EMAILS
-    - cache-push@2: {}
+      - activate-ssh-key@4:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@4: { }
+      - script@1:
+          inputs:
+            - content: |-
+                sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+                sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+                export JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
+                envman add --key JAVA_HOME --value '/usr/lib/jvm/java-11-openjdk-amd64'
+      - cache-pull@2: { }
+      - set-java-version@1.1:
+          is_always_run: true
+          inputs:
+            - set_java_version: "17"
+      - install-missing-android-tools@2:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+      - android-build@0:
+          inputs:
+            - variant: $INTEGRATOR_VARIANT
+            - module: $EXAMPLE_APP_MODULE
+      - android-lint@0:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $WIDGET_SDK_MODULE
+            - variant: $SDK_VARIANT
+          title: Run Lint for SDK
+      - android-unit-test@1:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $WIDGET_SDK_MODULE
+            - variant: $SDK_VARIANT
+          title: Unit Test for SDK
+      - android-lint@0:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $EXAMPLE_APP_MODULE
+            - variant: $INTEGRATOR_VARIANT
+          title: Run Lint for APP
+      - android-unit-test@1:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $EXAMPLE_APP_MODULE
+            - variant: $INTEGRATOR_VARIANT
+          title: Unit Test for APP
+      - deploy-to-bitrise-io@1:
+          inputs:
+            - notify_email_list: $BUILD_EMAILS
+      - cache-push@2: { }
   master:
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
-    - cache-pull@2: {}
-    - install-missing-android-tools@2:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-    - android-build@0:
-        inputs:
-        - variant: $INTEGRATOR_VARIANT
-        - module: $EXAMPLE_APP_MODULE
-    - android-lint@0:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $WIDGET_SDK_MODULE
-        - variant: $SDK_VARIANT
-        title: Run Lint for SDK
-    - android-unit-test@1:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $WIDGET_SDK_MODULE
-        - variant: $SDK_VARIANT
-        title: Unit Test for SDK
-    - android-lint@0:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $EXAMPLE_APP_MODULE
-        - variant: $INTEGRATOR_VARIANT
-        title: Run Lint for APP
-    - android-unit-test@1:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $EXAMPLE_APP_MODULE
-        - variant: $INTEGRATOR_VARIANT
-        title: Unit Test for APP
-    - browserstack-upload@0:
-        inputs:
-        - custom_id: $BROWSERSTACK_APP_ID
-        title: Upload APP to BrowserStack
-    - deploy-to-bitrise-io@1:
-        inputs:
-        - notify_email_list: $BUILD_EMAILS
-    - slack@3:
-        is_always_run: true
-        inputs:
-        - channel: '#tm-mobile-builds'
-        - text: Android Build Succeeded!
-        - webhook_url_on_error: $SLACK_ANDROID_WEBHOOK
-        - channel_on_error: '#tm-mobile'
-        - text_on_error: "@mobile-caretaker Android Build Failed! (master-build)"
-        - emoji_on_error: "\U0001F4A5"
-        - color_on_error: '#d9482b'
-        - from_username_on_error: Bitrise
-        - pretext: ''
-        - webhook_url: $SLACK_ANDROID_WEBHOOK
-    - cache-push@2: {}
+      - activate-ssh-key@4:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@4: { }
+      - cache-pull@2: { }
+      - set-java-version@1.1:
+          is_always_run: true
+          inputs:
+            - set_java_version: "17"
+      - install-missing-android-tools@2:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+      - android-build@0:
+          inputs:
+            - variant: $INTEGRATOR_VARIANT
+            - module: $EXAMPLE_APP_MODULE
+      - android-lint@0:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $WIDGET_SDK_MODULE
+            - variant: $SDK_VARIANT
+          title: Run Lint for SDK
+      - android-unit-test@1:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $WIDGET_SDK_MODULE
+            - variant: $SDK_VARIANT
+          title: Unit Test for SDK
+      - android-lint@0:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $EXAMPLE_APP_MODULE
+            - variant: $INTEGRATOR_VARIANT
+          title: Run Lint for APP
+      - android-unit-test@1:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $EXAMPLE_APP_MODULE
+            - variant: $INTEGRATOR_VARIANT
+          title: Unit Test for APP
+      - browserstack-upload@0:
+          inputs:
+            - custom_id: $BROWSERSTACK_APP_ID
+          title: Upload APP to BrowserStack
+      - deploy-to-bitrise-io@1:
+          inputs:
+            - notify_email_list: $BUILD_EMAILS
+      - slack@3:
+          is_always_run: true
+          inputs:
+            - channel: '#tm-mobile-builds'
+            - text: Android Build Succeeded!
+            - webhook_url_on_error: $SLACK_ANDROID_WEBHOOK
+            - channel_on_error: '#tm-mobile'
+            - text_on_error: '@mobile-caretaker Android Build Failed! (master-build)'
+            - emoji_on_error: "\U0001F4A5"
+            - color_on_error: '#d9482b'
+            - from_username_on_error: Bitrise
+            - pretext: ""
+            - webhook_url: $SLACK_ANDROID_WEBHOOK
+      - cache-push@2: { }
   post_release:
     steps:
-    - trigger-bitrise-workflow@0:
-        inputs:
-        - api_token: $ANDROID_CORTEX_BANKING_APP_BUILD_TRIGGER_TOKEN
-        - workflow_id: upgrade_dependencies
-        - exported_environment_variable_names: NEW_VERSION
-        - app_slug: $ANDROID_CORTEX_BANKING_APP_SLUG
+      - trigger-bitrise-workflow@0:
+          inputs:
+            - api_token: $ANDROID_CORTEX_BANKING_APP_BUILD_TRIGGER_TOKEN
+            - workflow_id: upgrade_dependencies
+            - exported_environment_variable_names: NEW_VERSION
+            - app_slug: $ANDROID_CORTEX_BANKING_APP_SLUG
   publish_to_nexus:
     description: Task builds an SDK and uploads it to Nexus.
     steps:
-    - activate-ssh-key@4: {}
-    - git-clone:
-        inputs:
-        - fetch_tags: 'yes'
-    - cache-pull@2: {}
-    - install-missing-android-tools@3:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-    - android-build@1:
-        inputs:
-        - variant: $INTEGRATOR_VARIANT
-        - module: $EXAMPLE_APP_MODULE
-    - android-unit-test@1:
-        inputs:
-        - module: $WIDGET_SDK_MODULE
-        - variant: $SDK_VARIANT
-        - project_location: $PROJECT_LOCATION
-    - android-unit-test@1:
-        inputs:
-        - module: $EXAMPLE_APP_MODULE
-        - variant: $INTEGRATOR_VARIANT
-        - project_location: $PROJECT_LOCATION
-    - script@1:
-        title: Publish Android SDK to Nexus Repository Manager (Staging)
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # debug log
-
-            set -x
-
-
-            # this will run Gradle script to deploy library and related
-            artifacts to Maven Central
-
-            ./gradlew clean
-            widgetssdk:publishReleasePublicationToSonatypeRepository
-    - git-tag@1:
-        inputs:
-        - tag: $NEW_VERSION
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # make pipelines' return status equal the last command to exit with
-            a non-zero status, or zero if all commands exit successfully
-
-            set -o pipefail
-
-            # debug log
-
-            set -x
-
-
-            git fetch --tags
-    - generate-changelog@0: {}
-    - github-release@0:
-        inputs:
-        - username: $GITHUB_USERNAME
-        - tag: $NEW_VERSION
-        - commit: $GIT_CLONE_COMMIT_HASH
-        - name: Glia Android Widgets $NEW_VERSION
-        - body: $BITRISE_CHANGELOG
-        - draft: 'no'
-        - api_token: $GITHUB_API_TOKEN
-    - cache-push@2: {}
+      - activate-ssh-key@4: { }
+      - git-clone:
+          inputs:
+            - fetch_tags: "yes"
+      - cache-pull@2: { }
+      - set-java-version@1.1:
+          is_always_run: true
+          inputs:
+            - set_java_version: "17"
+      - install-missing-android-tools@3:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+      - android-build@1:
+          inputs:
+            - variant: $INTEGRATOR_VARIANT
+            - module: $EXAMPLE_APP_MODULE
+      - android-unit-test@1:
+          inputs:
+            - module: $WIDGET_SDK_MODULE
+            - variant: $SDK_VARIANT
+            - project_location: $PROJECT_LOCATION
+      - android-unit-test@1:
+          inputs:
+            - module: $EXAMPLE_APP_MODULE
+            - variant: $INTEGRATOR_VARIANT
+            - project_location: $PROJECT_LOCATION
+      - script@1:
+          title: Publish Android SDK to Nexus Repository Manager (Staging)
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # fail if any commands fails
+                set -e
+                # debug log
+                set -x
+                
+                # this will run Gradle script to deploy library and related artifacts to Maven Central
+                ./gradlew clean widgetssdk:publishReleasePublicationToSonatypeRepository
+      - git-tag@1:
+          inputs:
+            - tag: $NEW_VERSION
+      - script@1:
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # fail if any commands fails
+                set -e
+                # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+                set -o pipefail
+                # debug log
+                set -x
+                
+                git fetch --tags
+      - generate-changelog@0: { }
+      - github-release@0:
+          inputs:
+            - username: $GITHUB_USERNAME
+            - tag: $NEW_VERSION
+            - commit: $GIT_CLONE_COMMIT_HASH
+            - name: Glia Android Widgets $NEW_VERSION
+            - body: $BITRISE_CHANGELOG
+            - draft: "no"
+            - api_token: $GITHUB_API_TOKEN
+      - cache-push@2: { }
     after_run:
-    - _increment_project_version
+      - _increment_project_version
   pull_request:
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
-    - cache-pull@2: {}
-    - install-missing-android-tools@2:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-    - android-build@0:
-        inputs:
-        - variant: $INTEGRATOR_VARIANT
-        - module: $EXAMPLE_APP_MODULE
-    - android-lint@0:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $WIDGET_SDK_MODULE
-        - variant: $SDK_VARIANT
-        title: Run Lint for SDK
-    - android-unit-test@1:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $WIDGET_SDK_MODULE
-        - variant: $SDK_VARIANT
-        title: Unit Test for SDK
-    - android-lint@0:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $EXAMPLE_APP_MODULE
-        - variant: $INTEGRATOR_VARIANT
-        title: Run Lint for APP
-    - android-unit-test@1:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $EXAMPLE_APP_MODULE
-        - variant: $INTEGRATOR_VARIANT
-        title: Unit Test for APP
-    - gradle-runner@2:
-        inputs:
-        - gradlew_path: ./gradlew
-        - gradle_task: ':$WIDGET_SDK_MODULE:assembleDebugAndroidTest'
-        title: Assemble SDK for instrumentation tests
-    - virtual-device-testing-for-android@1:
-        title: UI Test for APP
-        inputs:
-        - test_type: instrumentation
-        - use_verbose_log: true
-    - cache-push@2: {}
+      - activate-ssh-key@4:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@4: { }
+      - cache-pull@2: { }
+      - set-java-version@1.1:
+          is_always_run: true
+          inputs:
+            - set_java_version: "17"
+      - install-missing-android-tools@2:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+      - android-build@0:
+          inputs:
+            - variant: $INTEGRATOR_VARIANT
+            - module: $EXAMPLE_APP_MODULE
+      - android-lint@0:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $WIDGET_SDK_MODULE
+            - variant: $SDK_VARIANT
+          title: Run Lint for SDK
+      - android-unit-test@1:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $WIDGET_SDK_MODULE
+            - variant: $SDK_VARIANT
+          title: Unit Test for SDK
+      - android-lint@0:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $EXAMPLE_APP_MODULE
+            - variant: $INTEGRATOR_VARIANT
+          title: Run Lint for APP
+      - android-unit-test@1:
+          inputs:
+            - project_location: $PROJECT_LOCATION
+            - module: $EXAMPLE_APP_MODULE
+            - variant: $INTEGRATOR_VARIANT
+          title: Unit Test for APP
+      - gradle-runner@2:
+          inputs:
+            - gradlew_path: ./gradlew
+            - gradle_task: :$WIDGET_SDK_MODULE:assembleDebugAndroidTest
+          title: Assemble SDK for instrumentation tests
+      - virtual-device-testing-for-android@1:
+          title: UI Test for APP
+          inputs:
+            - test_type: instrumentation
+            - use_verbose_log: true
+      - cache-push@2: { }
   upgrade_dependencies:
     steps:
-    - activate-ssh-key@4: {}
-    - git-clone@6: {}
-    - cache-pull@2: {}
-    - install-missing-android-tools@3:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-    - gradle-runner@2:
-        inputs:
-        - gradlew_path: $PROJECT_LOCATION/gradlew
-        - gradle_file: $PROJECT_LOCATION/build.gradle
-        - gradle_task: saveCoreSdkVersion --coreSdkVersion=$NEW_VERSION
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # make pipelines' return status equal the last command to exit with
-            a non-zero status, or zero if all commands exit successfully
-
-            set -o pipefail
-
-            # debug log
-
-            set -x
-
-
-            BRANCH_NAME="core-sdk-version-increment/${NEW_VERSION}"
-
-            MESSAGE="Increment Core SDK version to ${NEW_VERSION}"
-
-
-            git checkout -b $BRANCH_NAME
-
-            git add -A
-
-            git commit -m "$MESSAGE"
-
-            git push origin "$BRANCH_NAME":"$BRANCH_NAME"
-
-
-            PULL_REQUEST_NUMBER=$(curl \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $GITHUB_API_TOKEN" \
-              https://api.github.com/repos/salemove/android-sdk-widgets/pulls \
-              -d "{\"title\":\"${MESSAGE}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"master\"}" | jq --raw-output '.number')
-
-            curl \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $GITHUB_API_TOKEN" \
-              https://api.github.com/repos/salemove/android-sdk-widgets/pulls/$PULL_REQUEST_NUMBER/requested_reviewers \
-              -d "{\"team_reviewers\":[\"tm-mobile-android\"]}"
-    - cache-push@2: {}
+      - activate-ssh-key@4: { }
+      - git-clone@6: { }
+      - cache-pull@2: { }
+      - set-java-version@1.1:
+          is_always_run: true
+          inputs:
+            - set_java_version: "17"
+      - install-missing-android-tools@3:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+      - gradle-runner@2:
+          inputs:
+            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradle_file: $PROJECT_LOCATION/build.gradle
+            - gradle_task: saveCoreSdkVersion --coreSdkVersion=$NEW_VERSION
+      - script@1:
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # fail if any commands fails
+                set -e
+                # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+                set -o pipefail
+                # debug log
+                set -x
+                
+                BRANCH_NAME="core-sdk-version-increment/${NEW_VERSION}"
+                MESSAGE="Increment Core SDK version to ${NEW_VERSION}"
+                
+                git checkout -b $BRANCH_NAME
+                git add -A
+                git commit -m "$MESSAGE"
+                git push origin "$BRANCH_NAME":"$BRANCH_NAME"
+                
+                PULL_REQUEST_NUMBER=$(curl \
+                  -X POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+                  https://api.github.com/repos/salemove/android-sdk-widgets/pulls \
+                  -d "{\"title\":\"${MESSAGE}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"master\"}" | jq --raw-output '.number')
+                
+                curl \
+                  -X POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+                  https://api.github.com/repos/salemove/android-sdk-widgets/pulls/$PULL_REQUEST_NUMBER/requested_reviewers \
+                  -d "{\"team_reviewers\":[\"tm-mobile-android\"]}"
+      - cache-push@2: { }
 app:
   envs:
-  - opts:
-      is_expand: false
-    PROJECT_LOCATION: .
-  - opts:
-      is_expand: false
-    EXAMPLE_APP_MODULE: app
-  - opts:
-      is_expand: false
-    WIDGET_SDK_MODULE: widgetssdk
-  - opts:
-      is_expand: false
-    SDK_VARIANT: debug
-  - opts:
-      is_expand: false
-    BROWSERSTACK_APP_ID: WidgetsSdkAndroidTestApp
-  - opts:
-      is_expand: false
-    TEST_APP_MODULE: app
-  - opts:
-      is_expand: false
-    ANDROID_CORTEX_BANKING_APP_SLUG: 0376f45568cb22dd
-  - opts:
-      is_expand: false
-    INTEGRATOR_VARIANT: debug
+    - opts:
+        is_expand: false
+      PROJECT_LOCATION: .
+    - opts:
+        is_expand: false
+      EXAMPLE_APP_MODULE: app
+    - opts:
+        is_expand: false
+      WIDGET_SDK_MODULE: widgetssdk
+    - opts:
+        is_expand: false
+      SDK_VARIANT: debug
+    - opts:
+        is_expand: false
+      BROWSERSTACK_APP_ID: WidgetsSdkAndroidTestApp
+    - opts:
+        is_expand: false
+      TEST_APP_MODULE: app
+    - opts:
+        is_expand: false
+      ANDROID_CORTEX_BANKING_APP_SLUG: 0376f45568cb22dd
+    - opts:
+        is_expand: false
+      INTEGRATOR_VARIANT: debug
 trigger_map:
-- push_branch: master
-  workflow: master
-- push_branch: develop
-  workflow: develop
-- pull_request_target_branch: '*'
-  workflow: pull_request
+  - push_branch: master
+    workflow: master
+  - push_branch: develop
+    workflow: develop
+  - pull_request_target_branch: '*'
+    workflow: pull_request

--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,31 @@
 buildscript {
     ext {
-        kotlin_version = '1.7.21'
+        kotlin_version = '1.8.20'
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("org.jetbrains.kotlin.android") version "$kotlin_version" apply false
 }
 
 allprojects {
     repositories {
         google()
         mavenCentral()
-//        Needed for some libraries e.g. Webrtc
-        maven { url 'https://plugins.gradle.org/m2/' }
         flatDir {
             dirs '../libs'
         }
         //TODO Needed to use not public new Core SDK release, remove before release
-        maven { url 'https://s01.oss.sonatype.org/content/repositories/comglia-1183' }
+        maven { url 'https://s01.oss.sonatype.org/content/repositories/comglia-1184' }
     }
 }
 
@@ -56,12 +55,12 @@ ext {
     leakCanaryVersion = '2.6'
     espressoVersion = '3.5.1'
     junitVersion = '4.13.2'
-    testLibraryVersion = '1.1.3'
+    testLibraryVersion = '1.1.5'
     androidXTestVersion = '1.1.5'
     mockitoVersion = '5.1.1'
     mockitoKotlinVersion = '4.1.0'
     mockitoAndroidTestVersion = '4.3.1'
-    archCoreVersion = '2.1.0'
+    archCoreVersion = '2.2.0'
     testRulesVersion = '1.5.0'
 
     //kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+#When android.enableBuildConfigAsBytecode=true,
+# the BuildConfig file isn't generated as a Java file, but as a compiled file.
+# This avoids the Java compilation step!
+# https://medium.com/androiddevelopers/5-ways-to-prepare-your-app-build-for-android-studio-flamingo-release-da34616bb946
+android.enableBuildConfigAsBytecode=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -13,11 +13,13 @@ afterEvaluate {
                 artifactId PUBLISH_ARTIFACT_ID
                 version PUBLISH_VERSION
 
-                // Two artifacts, the `aar` (or `jar`) and the sources
-                if (project.plugins.findPlugin("com.android.library")) {
-                    from components.release
-                } else {
-                    from components.java
+                afterEvaluate {
+                    // Two artifacts, the `aar` (or `jar`) and the sources
+                    if (project.plugins.findPlugin("com.android.library")) {
+                        from components.release
+                    } else {
+                        from components.java
+                    }
                 }
 
                 pom {
@@ -28,21 +30,21 @@ afterEvaluate {
                         license {
                             url = 'https://raw.githubusercontent.com/salemove/android-sdk-widgets/master/LICENSE.txt'
                         }
-                    }
-                    organization {
-                        name = PUBLISH_ORGANISATION_NAME
-                        url = PUBLISH_ORGANISATION_URL
-                    }
-                    developers {
-                        developer {
-                            name = 'Glia Technologies'
+                        }
+                        organization {
+                            name = PUBLISH_ORGANISATION_NAME
                             url = PUBLISH_ORGANISATION_URL
                         }
+                        developers {
+                            developer {
+                                name = 'Glia Technologies'
+                                url = PUBLISH_ORGANISATION_URL
+                            }
+                        }
+                        scm {
+                            url = 'https://github.com/salemove/android-sdk-widgets.git'
+                        }
                     }
-                    scm {
-                        url = 'https://github.com/salemove/android-sdk-widgets.git'
-                    }
-                }
             }
         }
     }

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion 31
@@ -24,8 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
     }
     lint {
         disable 'WrongLayoutName',
@@ -40,6 +45,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
     namespace 'com.glia.widgets'
 }
@@ -92,5 +98,3 @@ ext {
 }
 
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
-apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'kotlin-parcelize'

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/AttachmentPopup.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/AttachmentPopup.kt
@@ -28,7 +28,7 @@ internal class AttachmentPopup(anchor: View, private val theme: AttachmentsPopup
             popupView.measuredHeight,
             true
         ).apply {
-            animationStyle = R.style.Animation_AppCompat_Dialog
+            animationStyle = androidx.appcompat.R.style.Animation_AppCompat_Dialog
             inputMethodMode = PopupWindow.INPUT_METHOD_NOT_NEEDED
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/UploadAttachmentAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/UploadAttachmentAdapter.kt
@@ -18,13 +18,20 @@ import com.glia.widgets.core.fileupload.model.FileAttachment.Status
 import com.glia.widgets.databinding.ChatAttachmentUploadedItemBinding
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.getFileExtensionOrEmpty
-import com.glia.widgets.view.unifiedui.extensions.*
+import com.glia.widgets.view.unifiedui.extensions.applyCardLayerTheme
+import com.glia.widgets.view.unifiedui.extensions.applyColorTheme
+import com.glia.widgets.view.unifiedui.extensions.applyImageColorTheme
+import com.glia.widgets.view.unifiedui.extensions.applyTextTheme
+import com.glia.widgets.view.unifiedui.extensions.getColorCompat
+import com.glia.widgets.view.unifiedui.extensions.getColorStateListCompat
+import com.glia.widgets.view.unifiedui.extensions.layoutInflater
 import com.glia.widgets.view.unifiedui.theme.chat.FilePreviewTheme
 import com.glia.widgets.view.unifiedui.theme.chat.FileUploadBarTheme
 import com.glia.widgets.view.unifiedui.theme.chat.UploadFileTheme
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.squareup.picasso.Picasso
+import com.google.android.material.R as Material_R
 
 /**
  * [DiffUtil.ItemCallback] for [FileAttachment] type
@@ -180,7 +187,7 @@ class ViewHolder(
 
     private fun updateTitleAndStatusText(fileName: String, byteSize: String, status: Status) {
         val textColorRes =
-            if (status.isError) R.color.design_default_color_error else R.color.glia_base_normal_color
+            if (status.isError) Material_R.color.design_default_color_error else R.color.glia_base_normal_color
         titleText.setTextColor(itemView.getColorCompat(textColorRes))
 
         titleText.text =
@@ -231,7 +238,7 @@ class ViewHolder(
         val normalColor = theme?.progress?.primaryColor
             ?: itemView.getColorCompat(R.color.glia_brand_primary_color)
         val errorColor = theme?.errorProgress?.primaryColor
-            ?: itemView.getColorCompat(R.color.design_default_color_error)
+            ?: itemView.getColorCompat(com.google.android.material.R.color.design_default_color_error)
 
         when {
             status == Status.UPLOADING -> updateProgress(

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Utils.java
@@ -288,7 +288,7 @@ public class Utils {
                         typedArray,
                         context,
                         R.styleable.GliaView_android_fontFamily,
-                        R.attr.fontFamily
+                        androidx.appcompat.R.attr.fontFamily
                 )
         );
         defaultThemeBuilder.setIconAppBarBack(
@@ -515,7 +515,7 @@ public class Utils {
     @Nullable
     public static Typeface getFont(TypedArray typedArray, Context context) {
         int resId = getTypedArrayIntegerValue(
-                typedArray, context, R.styleable.GliaView_android_fontFamily, R.attr.fontFamily
+                typedArray, context, R.styleable.GliaView_android_fontFamily, androidx.appcompat.R.attr.fontFamily
         );
 
         if (resId > 0) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/BadgeTextView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/BadgeTextView.kt
@@ -7,11 +7,15 @@ import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.Gravity
 import com.glia.widgets.R
-import com.glia.widgets.view.unifiedui.extensions.*
+import com.glia.widgets.view.unifiedui.extensions.applyLayerTheme
+import com.glia.widgets.view.unifiedui.extensions.applyTextColorTheme
+import com.glia.widgets.view.unifiedui.extensions.getAttr
+import com.glia.widgets.view.unifiedui.extensions.getColorCompat
 import com.glia.widgets.view.unifiedui.theme.base.BadgeTheme
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.textview.MaterialTextView
 import kotlin.math.max
+import com.google.android.material.R as Material_R
 
 class BadgeTextView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     MaterialTextView(context, attrs) {
@@ -30,7 +34,10 @@ class BadgeTextView @JvmOverloads constructor(context: Context, attrs: Attribute
         elevation = resources.getDimension(R.dimen.glia_chat_head_badge_elevation)
 
         setTextAppearance(
-            getAttr(R.attr.textAppearanceCaption, R.style.Application_Glia_Caption)
+            getAttr(
+                Material_R.attr.textAppearanceCaption,
+                R.style.Application_Glia_Caption
+            )
         )
 
         setTextColor(

--- a/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
@@ -23,7 +23,7 @@ public abstract class BaseConfigurableTextView extends MaterialTextView {
     }
 
     public BaseConfigurableTextView(@NonNull Context context, @Nullable AttributeSet attrs) {
-        this(context, attrs, R.attr.textAppearanceBody1);
+        this(context, attrs, com.google.android.material.R.attr.textAppearanceBody1);
     }
 
     public BaseConfigurableTextView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2085

**Additional info:**
Here is migration guide and description of some changes - https://medium.com/androiddevelopers/5-ways-to-prepare-your-app-build-for-android-studio-flamingo-release-da34616bb946

- Upgrade Kotlin to latest(1.8.20) version
- Upgrade test-related dependencies
- Upgrade secure core_sdk url
- Migrate no non-transitive R class
- Migrate no non-final-resID
- Add the `set java version` step to bitrise, it will change Gradle Java version to 17 and fasten Android build up to 20%