### PR TITLE
Do not allow to open Chat screen in Call Visualizer flow

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -64,6 +64,12 @@ public class ChatActivity extends AppCompatActivity {
 
         chatView.setOnTitleUpdatedListener(this::setTitle);
         configuration = createConfiguration(getIntent());
+
+        if (!chatView.shouldShow()) {
+            finishAndRemoveTask();
+            return;
+        }
+
         chatView.setConfiguration(configuration);
         chatView.setUiTheme(configuration.getRunTimeTheme());
         chatView.setOnBackClickedListener(onBackClickedListener);

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -329,6 +329,14 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
         controller?.navigateToCallSuccess()
     }
 
+    fun shouldShow(): Boolean {
+        return controller?.let { !it.isCallVisualizerOngoing() }
+            ?: run {
+                Logger.e(TAG, "ChatController is unexpectedly null")
+                false
+            }
+    }
+
     private fun setupControllers() {
         setupChatStateCallback()
         controller = Dependencies.getControllerFactory().getChatController(callback)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -22,6 +22,7 @@ import com.glia.widgets.chat.domain.*
 import com.glia.widgets.chat.model.ChatInputMode
 import com.glia.widgets.chat.model.ChatState
 import com.glia.widgets.chat.model.history.*
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase
 import com.glia.widgets.core.chathead.domain.HasPendingSurveyUseCase
 import com.glia.widgets.core.chathead.domain.SetPendingSurveyUsedUseCase
 import com.glia.widgets.core.dialog.DialogController
@@ -116,7 +117,8 @@ internal class ChatController(
     private val isSecureEngagementAvailableUseCase: IsSecureConversationsChatAvailableUseCase,
     private val markMessagesReadWithDelayUseCase: MarkMessagesReadWithDelayUseCase,
     private val hasPendingSurveyUseCase: HasPendingSurveyUseCase,
-    private val setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase
+    private val setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase,
+    private val isCallVisualizerUseCase: IsCallVisualizerUseCase,
 ) : GliaOnEngagementUseCase.Listener, GliaOnEngagementEndUseCase.Listener, OnSurveyListener {
     private var viewCallback: ChatViewCallback? = null
     private var mediaUpgradeOfferRepositoryCallback: MediaUpgradeOfferRepositoryCallback? = null
@@ -1660,6 +1662,10 @@ internal class ChatController(
                     Logger.e(TAG, "Error happened while observing queue state : $it")
                 }
         )
+    }
+
+    fun isCallVisualizerOngoing(): Boolean {
+        return isCallVisualizerUseCase()
     }
 
     companion object {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -134,7 +134,8 @@ public class ControllerFactory {
                     useCaseFactory.createIsSecureConversationsChatAvailableUseCase(),
                     useCaseFactory.createMarkMessagesReadUseCase(),
                     useCaseFactory.createHasPendingSurveyUseCase(),
-                    useCaseFactory.createSetPendingSurveyUsed()
+                    useCaseFactory.createSetPendingSurveyUsed(),
+                    useCaseFactory.createIsCallVisualizerUseCase()
             );
         } else {
             Logger.d(TAG, "retained chat controller");

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -5,6 +5,7 @@ import com.glia.widgets.chat.ChatViewCallback
 import com.glia.widgets.chat.domain.*
 import com.glia.widgets.chat.model.history.ChatItem
 import com.glia.widgets.chat.model.history.LinkedChatItem
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase
 import com.glia.widgets.core.chathead.domain.HasPendingSurveyUseCase
 import com.glia.widgets.core.chathead.domain.SetPendingSurveyUsedUseCase
 import com.glia.widgets.core.dialog.DialogController
@@ -86,6 +87,7 @@ class ChatControllerTest {
     private lateinit var isQueueingEngagementUseCase: IsQueueingEngagementUseCase
     private lateinit var hasPendingSurveyUseCase: HasPendingSurveyUseCase
     private lateinit var setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase
+    private lateinit var isCallVisualizerUseCase: IsCallVisualizerUseCase
 
     private lateinit var chatController: ChatController
 
@@ -141,6 +143,7 @@ class ChatControllerTest {
         isQueueingEngagementUseCase = mock()
         hasPendingSurveyUseCase = mock()
         setPendingSurveyUsedUseCase = mock()
+        isCallVisualizerUseCase = mock()
 
         chatController = ChatController(
             chatViewCallback = chatViewCallback,
@@ -192,7 +195,8 @@ class ChatControllerTest {
             markMessagesReadWithDelayUseCase = markMessagesReadWithDelayUseCase,
             isQueueingEngagementUseCase = isQueueingEngagementUseCase,
             hasPendingSurveyUseCase = hasPendingSurveyUseCase,
-            setPendingSurveyUsedUseCase = setPendingSurveyUsedUseCase
+            setPendingSurveyUsedUseCase = setPendingSurveyUsedUseCase,
+            isCallVisualizerUseCase = isCallVisualizerUseCase
         )
     }
 


### PR DESCRIPTION
[MOB-2071](https://glia.atlassian.net/browse/MOB-2071)

Flow:
1. Start Call Visualizer engagement
2. From Main screen of example app tap “Start new chat flow”.

**Expected result is:** tap is ignored, nothing should happen.
**Actual result is:** Chat screen is opened, visitor can send a message.


[MOB-2071]: https://glia.atlassian.net/browse/MOB-2071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ