### PR TITLE
Handle attachments from web sockets

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
@@ -1,6 +1,7 @@
 package com.glia.widgets.chat.data;
 
 import com.glia.androidsdk.Engagement;
+import com.glia.androidsdk.Glia;
 import com.glia.androidsdk.GliaException;
 import com.glia.androidsdk.chat.Chat;
 import com.glia.androidsdk.chat.ChatMessage;
@@ -9,9 +10,16 @@ import com.glia.androidsdk.chat.OperatorTypingStatus;
 import com.glia.androidsdk.chat.SingleChoiceAttachment;
 import com.glia.androidsdk.chat.VisitorMessage;
 import com.glia.widgets.chat.domain.GliaSendMessageUseCase.Listener;
-import com.glia.widgets.di.Dependencies;
+import com.glia.widgets.di.GliaCore;
+
+import java.util.function.Consumer;
 
 public class GliaChatRepository {
+    private final GliaCore gliaCore;
+
+    public GliaChatRepository(GliaCore gliaCore) {
+        this.gliaCore = gliaCore;
+    }
     public interface HistoryLoadedListener {
         void loaded(ChatMessage[] messages, Throwable error);
     }
@@ -25,54 +33,62 @@ public class GliaChatRepository {
     }
 
     public void loadHistory(HistoryLoadedListener historyLoadedListener) {
-        Dependencies.glia().getChatHistory(historyLoadedListener::loaded);
+        gliaCore.getChatHistory(historyLoadedListener::loaded);
     }
 
-    public void listenForMessages(MessageListener listener, Engagement engagement) {
+    public void listenForEngagementMessages(MessageListener listener, Engagement engagement) {
         engagement.getChat().on(Chat.Events.MESSAGE, listener::onMessage);
+    }
+
+    public void listenForAllMessages(Consumer<ChatMessage> listener) {
+        gliaCore.on(Glia.Events.CHAT_MESSAGE, listener);
     }
 
     public void listenForOperatorTyping(OperatorTypingListener listener, Engagement engagement) {
         engagement.getChat().on(Chat.Events.OPERATOR_TYPING_STATUS, listener::onOperatorTyping);
     }
 
-    public void unregisterMessageListener(MessageListener listener) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(engagement -> engagement.getChat().off(Chat.Events.MESSAGE, listener::onMessage));
+    public void unregisterEngagementMessageListener(MessageListener listener) {
+        gliaCore.getCurrentEngagement().ifPresent(engagement -> engagement.getChat().off(Chat.Events.MESSAGE, listener::onMessage));
+    }
+
+    public void unregisterAllMessageListener(Consumer<ChatMessage> listener) {
+        gliaCore.off(Glia.Events.CHAT_MESSAGE, listener);
     }
 
     public void unregisterOperatorTypingListener(OperatorTypingListener listener) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(engagement -> engagement.getChat().off(Chat.Events.OPERATOR_TYPING_STATUS, listener::onOperatorTyping));
+        gliaCore.getCurrentEngagement().ifPresent(engagement -> engagement.getChat().off(Chat.Events.OPERATOR_TYPING_STATUS, listener::onOperatorTyping));
     }
 
     public void sendMessagePreview(String message) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(value ->
+        gliaCore.getCurrentEngagement().ifPresent(value ->
                 value.getChat().sendMessagePreview(message));
     }
 
     public void sendMessage(String message, Listener listener) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(engagement ->
+        gliaCore.getCurrentEngagement().ifPresent(engagement ->
                 engagement.getChat().sendMessage(message, (visitorMessage, ex) -> onMessageReceived(visitorMessage, ex, listener)));
     }
 
     public void sendMessageSingleChoice(SingleChoiceAttachment singleChoiceAttachment, Listener listener) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(engagement ->
+        gliaCore.getCurrentEngagement().ifPresent(engagement ->
                 engagement.getChat().sendMessage(singleChoiceAttachment, (visitorMessage, ex) -> onMessageReceived(visitorMessage, ex, listener)));
     }
 
     public void sendMessageWithAttachment(String message, MessageAttachment attachment, Listener listener) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(engagement ->
+        gliaCore.getCurrentEngagement().ifPresent(engagement ->
                 engagement.getChat().sendMessage(message, attachment, (visitorMessage, ex) -> onMessageReceived(visitorMessage, ex, listener))
         );
     }
 
     public void sendMessageAttachment(MessageAttachment attachment, Listener listener) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(engagement ->
+        gliaCore.getCurrentEngagement().ifPresent(engagement ->
                 engagement.getChat().sendMessage("", attachment, (visitorMessage, ex) -> onMessageReceived(visitorMessage, ex, listener))
         );
     }
 
     public void sendResponse(String cardMessageId, String text, String value, Listener listener) {
-        Dependencies.glia().getCurrentEngagement().ifPresent(engagement ->
+        gliaCore.getCurrentEngagement().ifPresent(engagement ->
                 engagement.getChat().sendResponse(cardMessageId, text, value, (result, ex) -> {
                     if (listener != null) {
                         if (ex != null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaOnMessageUseCase.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaOnMessageUseCase.java
@@ -38,13 +38,13 @@ public class GliaOnMessageUseCase implements
     }
 
     public void unregisterListener() {
-            messageRepository.unregisterMessageListener(this);
-            onEngagementUseCase.unregisterListener(this);
+        messageRepository.unregisterEngagementMessageListener(this);
+        onEngagementUseCase.unregisterListener(this);
     }
 
     @Override
     public void newEngagementLoaded(OmnicoreEngagement engagement) {
-        messageRepository.listenForMessages(this, engagement);
+        messageRepository.listenForEngagementMessages(this, engagement);
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/UnengagementMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/UnengagementMessageUseCase.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.chat.domain
+
+import com.glia.androidsdk.chat.ChatMessage
+import com.glia.widgets.chat.data.GliaChatRepository
+import com.glia.widgets.core.engagement.GliaEngagementRepository
+import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase
+import com.glia.widgets.core.engagement.domain.MapOperatorUseCase
+import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
+import io.reactivex.Observable
+import java.util.function.Consumer
+
+class UnengagementMessageUseCase(
+    private val messageRepository: GliaChatRepository,
+    private val engagementRepository: GliaEngagementRepository,
+    private val onEngagementUseCase: GliaOnEngagementUseCase,
+    private val mapOperatorUseCase: MapOperatorUseCase
+) {
+
+    fun execute(): Observable<ChatMessageInternal> {
+        if (engagementRepository.hasOngoingEngagement()) {
+            return Observable.empty()
+        }
+        return Observable.create { observer ->
+            val messageListener = Consumer<ChatMessage> { chatMessage ->
+                observer.onNext(chatMessage)
+            }
+
+            val engagementListener = GliaOnEngagementUseCase.Listener {
+                observer.onComplete()
+            }
+
+            messageRepository.listenForAllMessages(messageListener)
+            onEngagementUseCase.execute(engagementListener)
+
+            observer.setCancellable {
+                messageRepository.unregisterAllMessageListener(messageListener)
+                onEngagementUseCase.unregisterListener(engagementListener)
+            }
+        }
+            .flatMapSingle { chatMessage: ChatMessage? -> mapOperatorUseCase.execute(chatMessage) }
+            .doOnError { obj: Throwable -> obj.printStackTrace() }
+            .share()
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -135,7 +135,8 @@ public class ControllerFactory {
                     useCaseFactory.createMarkMessagesReadUseCase(),
                     useCaseFactory.createHasPendingSurveyUseCase(),
                     useCaseFactory.createSetPendingSurveyUsed(),
-                    useCaseFactory.createIsCallVisualizerUseCase()
+                    useCaseFactory.createIsCallVisualizerUseCase(),
+                    useCaseFactory.createUnengagementMessageUseCase()
             );
         } else {
             Logger.d(TAG, "retained chat controller");

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -74,7 +74,7 @@ public class RepositoryFactory {
     }
 
     public GliaChatRepository getGliaMessageRepository() {
-        return new GliaChatRepository();
+        return new GliaChatRepository(gliaCore);
     }
 
     public GliaEngagementRepository getGliaEngagementRepository() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -23,6 +23,7 @@ import com.glia.widgets.chat.domain.IsFromCallScreenUseCase;
 import com.glia.widgets.chat.domain.IsSecureConversationsChatAvailableUseCase;
 import com.glia.widgets.chat.domain.IsShowSendButtonUseCase;
 import com.glia.widgets.chat.domain.SiteInfoUseCase;
+import com.glia.widgets.chat.domain.UnengagementMessageUseCase;
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
@@ -324,6 +325,16 @@ public class UseCaseFactory {
     @NonNull
     public SetPendingSurveyUsedUseCase createSetPendingSurveyUsed() {
         return new SetPendingSurveyUsedUseCase(surveyStateManager);
+    }
+
+    @NonNull
+    public UnengagementMessageUseCase createUnengagementMessageUseCase() {
+        return new UnengagementMessageUseCase(
+                repositoryFactory.getGliaMessageRepository(),
+                repositoryFactory.getGliaEngagementRepository(),
+                createOnEngagementUseCase(),
+                getMapOperatorUseCase()
+        );
     }
 
     @NonNull

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -88,6 +88,7 @@ class ChatControllerTest {
     private lateinit var hasPendingSurveyUseCase: HasPendingSurveyUseCase
     private lateinit var setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase
     private lateinit var isCallVisualizerUseCase: IsCallVisualizerUseCase
+    private lateinit var unengagementMessageUseCase: UnengagementMessageUseCase
 
     private lateinit var chatController: ChatController
 
@@ -144,6 +145,7 @@ class ChatControllerTest {
         hasPendingSurveyUseCase = mock()
         setPendingSurveyUsedUseCase = mock()
         isCallVisualizerUseCase = mock()
+        unengagementMessageUseCase = mock()
 
         chatController = ChatController(
             chatViewCallback = chatViewCallback,
@@ -196,7 +198,8 @@ class ChatControllerTest {
             isQueueingEngagementUseCase = isQueueingEngagementUseCase,
             hasPendingSurveyUseCase = hasPendingSurveyUseCase,
             setPendingSurveyUsedUseCase = setPendingSurveyUsedUseCase,
-            isCallVisualizerUseCase = isCallVisualizerUseCase
+            isCallVisualizerUseCase = isCallVisualizerUseCase,
+            unengagementMessageUseCase = unengagementMessageUseCase
         )
     }
 


### PR DESCRIPTION
Replace an attachment for the visitor messages with an attachment from messages received from web sockets if a message was sent using the secure conversation endpoint.

[MOB-2046](https://glia.atlassian.net/browse/MOB-2046)

[MOB-2046]: https://glia.atlassian.net/browse/MOB-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ