### PR TITLE
Finish end screen-sharing screen on engagement end by operator

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingActivity.kt
@@ -18,6 +18,7 @@ class EndScreenSharingActivity : AppCompatActivity(), EndScreenSharingView.OnFin
         screenSharingView.onFinishListener = this
 
         val controller = Dependencies.getControllerFactory().endScreenSharingController
+        controller.onActivityCreate()
         screenSharingView.setController(controller)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingContract.kt
@@ -7,6 +7,7 @@ interface EndScreenSharingContract {
 
     interface Controller : BaseController {
         fun setView(view: View)
+        fun onActivityCreate()
         fun onBackArrowClicked()
         fun onEndScreenSharingButtonClicked()
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingController.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.callvisualizer
 
+import com.glia.widgets.GliaWidgets
+
 class EndScreenSharingController : EndScreenSharingContract.Controller {
 
     private var view: EndScreenSharingContract.View? = null
@@ -15,6 +17,10 @@ class EndScreenSharingController : EndScreenSharingContract.Controller {
     override fun onEndScreenSharingButtonClicked() {
         view?.stopScreenSharing()
         view?.finish()
+    }
+
+    override fun onActivityCreate() {
+        GliaWidgets.getCallVisualizer().onEngagementEnd { view?.finish() }
     }
 
     override fun onDestroy() {}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingView.kt
@@ -29,8 +29,9 @@ class EndScreenSharingView (
     defStyleRes
 ), EndScreenSharingContract.View {
 
-    var onFinishListener: OnFinishListener? = null
     private val TAG = EndScreenSharingView::class.java.simpleName
+
+    var onFinishListener: OnFinishListener? = null
     private var controller: EndScreenSharingContract.Controller? = null
     private var uiTheme: UiTheme by Delegates.notNull()
     private var statusBarColor: Int by Delegates.notNull()

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/CallVisualizer.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/CallVisualizer.java
@@ -2,7 +2,6 @@ package com.glia.widgets.core.callvisualizer.domain;
 
 import android.content.Context;
 
-import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.view.VisitorCodeView;
 
 /**
@@ -49,5 +48,15 @@ public interface CallVisualizer {
      * @param runnable The Runnable that will be executed on engagement start
      */
     void onEngagementStart(Runnable runnable);
+
+    /**
+     * Sets callback that will be called when Call Visualizer engagement is ended.
+     *
+     * Callback won't be triggered for engagement ended before the callback has been set.
+     * Setting new callback will override the old one.
+     *
+     * @param runnable The Runnable that will be executed on engagement end
+     */
+    void onEngagementEnd(Runnable runnable);
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementRepository.java
@@ -26,10 +26,13 @@ public class GliaEngagementRepository {
         engagement.on(Engagement.Events.END, engagementEnded);
     }
 
+    public void listenForEngagementEnd(OmnibrowseEngagement engagement, Runnable engagementEnded) {
+        engagement.on(Engagement.Events.END, engagementEnded);
+    }
+
     public void unregisterEngagementEndListener(Runnable engagementEnded) {
-        gliaCore.getCurrentEngagement().ifPresent(engagement -> {
-            engagement.off(Engagement.Events.END, engagementEnded);
-        });
+        gliaCore.getCurrentEngagement().ifPresent(
+                engagement -> engagement.off(Engagement.Events.END, engagementEnded));
     }
 
     public void endEngagement() {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
@@ -192,8 +192,12 @@ public class ServiceChatHeadController
         this.buildTimeTheme = theme;
     }
 
-    private void engagementEnded() {
-        setPendingSurveyUseCase.invoke();
+    private void omnicoreEngagementEnded() {
+        setPendingSurveyUseCase.invoke(); // Survey is supported by omnicore engagement only
+        omnibrowseEngagementEnded();
+    }
+
+    private void omnibrowseEngagementEnded() {
         state = State.ENDED;
         operatorProfileImgUrl = null;
         unreadMessagesCount = 0;
@@ -210,7 +214,7 @@ public class ServiceChatHeadController
                         throwable -> Logger.e(TAG, "getOperatorFlowableUseCase error: " + throwable.getMessage())
                 );
         engagementDisposables.add(operatorDisposable);
-        gliaOnEngagementEndUseCase.execute(this::engagementEnded);
+        gliaOnEngagementEndUseCase.execute(this::omnicoreEngagementEnded);
         toggleChatHeadServiceUseCase.invoke(resumedViewName);
         updateChatHeadView();
     }
@@ -225,7 +229,7 @@ public class ServiceChatHeadController
                 );
         engagementDisposables.add(operatorDisposable);
         // To recieve callback to engagementEnded() after Call Visualizer engagement ends
-        gliaOnCallVisualizerEndUseCase.execute(this::engagementEnded);
+        gliaOnCallVisualizerEndUseCase.execute(this::omnibrowseEngagementEnded);
         updateChatHeadView();
     }
 


### PR DESCRIPTION
[MOB-2048](https://glia.atlassian.net/browse/MOB-2048)

1. Implemented the "end Call Visualizer engagement event" listening.
2. Implemented `EndScreenSharingActivity` finishing.
3. [Handled](https://github.com/salemove/android-sdk-widgets/pull/563/commits/e8dcbe28d1aa4092e75056a59e72cd0b16c3b0ce) survey absence for Call Visualizer

[MOB-2048]: https://glia.atlassian.net/browse/MOB-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ