### PR TITLE
Added additional null check to serviceChatHeadController

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 
 
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$testLibraryVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
@@ -38,6 +38,7 @@ internal class ActivityWatcherForChatHead(
      * Returns last activity that called [Activity.onResume], but didn't call [Activity.onPause] yet
      * @return Currently resumed activity.
      */
+
     private var resumedActivity: WeakReference<Activity?> = WeakReference(null)
     private var chatHeadLayout: WeakReference<ChatHeadLayout> = WeakReference(null)
     private var screenOrientation: Int? = null

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
@@ -270,7 +270,8 @@ public class ServiceChatHeadController
     }
 
     private void clearResumedViewName(View view) {
-        if (isResumedView(view)) {
+        // On quick configuration changes view can be null
+        if (view != null && isResumedView(view)) {
             resumedViewName = null;
         }
     }


### PR DESCRIPTION
MOB-2115

**Steps to reproduce:**

Start Call Visualizer engagement with screen sharing ongoing and bubble on screen

Open EndScreenSharingView by clicking on the bubble

Make quick subsequent configuration changes

**Expected result:**

Application lives through the configuration changes and restores view

**Actual result:**

Application crashes with a NPE
