### PR TITLE
Dismiss screen sharing notification if visitor rejects system permission

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
@@ -24,6 +24,7 @@ class ActivityWatcherForCallVisualizerContract {
         fun onInitialCameraPermissionResult(isGranted: Boolean, isComponentActivity: Boolean = true)
         fun onRequestedCameraPermissionResult(isGranted: Boolean)
         fun onMediaProjectionPermissionResult(isGranted: Boolean, context: Context)
+        fun onMediaProjectionRejected()
     }
 
     interface Watcher {
@@ -43,7 +44,7 @@ class ActivityWatcherForCallVisualizerContract {
         fun removeDialogCallback()
         fun requestCameraPermission()
         fun requestOverlayPermission()
-        fun openComponentActivity()
+        fun openSupportActivity(permissionType: PermissionType)
         fun destroySupportActivityIfExists()
         fun checkInitialCameraPermission()
         fun callOverlayDialog()

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
@@ -1,5 +1,17 @@
 package com.glia.widgets.callvisualizer
 
+import android.os.Parcelable
 import androidx.appcompat.app.AppCompatActivity
+import com.glia.widgets.callvisualizer.controller.CallVisualizerController
+import kotlinx.parcelize.Parcelize
 
-class CallVisualizerSupportActivity : AppCompatActivity()
+class CallVisualizerSupportActivity : AppCompatActivity() {
+    companion object {
+        val PERMISSION_TYPE_TAG: String = CallVisualizerController::class.java.simpleName
+    }
+}
+
+@Parcelize
+sealed class PermissionType : Parcelable
+object ScreenSharing : PermissionType()
+object Camera : PermissionType()

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/GliaScreenSharingCallback.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/GliaScreenSharingCallback.java
@@ -14,4 +14,6 @@ public interface GliaScreenSharingCallback {
     void onScreenSharingRequestSuccess();
 
     void onForceStopScreenSharing();
+
+    void hideScreenSharingEnabledNotification();
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
@@ -112,6 +112,7 @@ internal class ScreenSharingController(
         dialogController.dismissCurrentDialog()
         repository.onScreenSharingDeclined()
         hasPendingScreenSharingRequest = false
+        hideScreenSharingEnabledNotification()
     }
 
     fun onScreenSharingNotificationEndPressed() {
@@ -131,7 +132,7 @@ internal class ScreenSharingController(
         showScreenSharingNotificationUseCase.invoke()
     }
 
-    private fun hideScreenSharingEnabledNotification() {
+    override fun hideScreenSharingEnabledNotification() {
         removeScreenSharingNotificationUseCase.invoke()
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepository.java
@@ -2,12 +2,8 @@ package com.glia.widgets.core.screensharing.data;
 
 import static com.glia.androidsdk.screensharing.ScreenSharing.Status.NOT_SHARING;
 import static com.glia.androidsdk.screensharing.ScreenSharing.Status.SHARING;
-import static com.glia.widgets.core.screensharing.MediaProjectionService.Actions.START;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Intent;
-import android.os.Build;
 
 import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.Glia;
@@ -20,7 +16,6 @@ import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.androidsdk.screensharing.ScreenSharingRequest;
 import com.glia.androidsdk.screensharing.VisitorScreenSharingState;
 import com.glia.widgets.core.screensharing.GliaScreenSharingCallback;
-import com.glia.widgets.core.screensharing.MediaProjectionService;
 import com.glia.widgets.di.GliaCore;
 import com.glia.widgets.helper.Logger;
 
@@ -61,7 +56,6 @@ public class GliaScreenSharingRepository {
             ScreenSharing.Mode screenSharingMode
     ) {
         Logger.d(TAG, "screen sharing accepted by the user");
-        startMediaProjectionService(activity);
         screenSharingRequest.accept(
                 screenSharingMode,
                 activity,
@@ -70,20 +64,11 @@ public class GliaScreenSharingRepository {
         );
     }
 
-    @SuppressLint("ShouldUseStaticImport")
-    private void startMediaProjectionService(Activity activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            Intent intent = new Intent(activity, MediaProjectionService.class);
-            intent.setAction(START);
-            activity.startForegroundService(intent);
-        }
-    }
-
     public void onScreenSharingAcceptedAndPermissionAsked(
             Activity activity,
             ScreenSharing.Mode screenSharingMode
     ) {
-        Logger.d(TAG, "screen sharing accepted by the user");
+        Logger.d(TAG, "Screen sharing accepted by the user, permission asked");
 
         screenSharingRequest.accept(
                 screenSharingMode,


### PR DESCRIPTION
Changes overview:
- Dismiss screen sharing notification if visitor rejects system permission
- Fix broken mechanism of requesting permissions through CallVisualizerSupportActivity
- Expand this mechanism to be able to use for requesting screen-sharing permission for a non ComponentActivity

