### PR TITLE
Update runtime theme settings to be applied to Call Visualizer

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/GliaWidgetsConfigManager.kt
+++ b/app/src/main/java/com/glia/exampleapp/GliaWidgetsConfigManager.kt
@@ -126,7 +126,7 @@ object GliaWidgetsConfigManager {
             .setScreenSharingMode(screenSharingMode)
             .setContext(context)
             .setUiJsonRemoteConfig(uiJsonRemoteConfig ?: Utils.getRemoteThemeByPrefs(preferences, context.resources))
-            .setUiTheme(runtimeConfig)
+            .setUiTheme(runtimeConfig ?: Utils.getRunTimeThemeByPrefs(preferences, context.resources))
             .build()
     }
 }

--- a/app/src/main/java/com/glia/exampleapp/Utils.java
+++ b/app/src/main/java/com/glia/exampleapp/Utils.java
@@ -30,7 +30,7 @@ class Utils {
 
     @Nullable
     public static String getRemoteThemeByPrefs(SharedPreferences sharedPreferences, Resources resources) throws JSONException {
-        boolean isRemoteThemeEnabled = sharedPreferences.getBoolean(resources.getString(R.string.pref_unified_ui), false);
+        boolean isRemoteThemeEnabled = sharedPreferences.getBoolean(resources.getString(R.string.pref_remote_theme), false);
         if (!isRemoteThemeEnabled) {
             return null;
         }
@@ -68,6 +68,11 @@ class Utils {
     }
 
     public static UiTheme getRunTimeThemeByPrefs(SharedPreferences sharedPreferences, Resources resources) {
+        boolean isRunTimeThemeEnabled = sharedPreferences.getBoolean(resources.getString(R.string.pref_runtime_theme), false);
+        if (!isRunTimeThemeEnabled) {
+            return null;
+        }
+
         String title = Utils.getStringFromPrefs(R.string.pref_header_title, null, sharedPreferences, resources);
         Integer baseLightColor = getColorValueFromPrefs(R.string.pref_base_light_color, sharedPreferences, resources);
         Integer baseDarkColor = getColorValueFromPrefs(R.string.pref_base_dark_color, sharedPreferences, resources);

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -31,7 +31,8 @@
     <string name="pref_context_asset_id">context_asset_id</string>
     <string name="pref_white_label">white_label_toggle</string>
     <string name="pref_use_overlay">use_overlay</string>
-    <string name="pref_unified_ui">unified_ui_toggle</string>
+    <string name="pref_remote_theme">remote_theme_toggle</string>
+    <string name="pref_runtime_theme">runtime_theme_toggle</string>
     <string name="pref_use_alert_dialog_button_vertical_alignment">use_alert_dialog_button_vertical_alignment</string>
     <string name="pref_visitor_message_bg_color">visitor_message_bg_color</string>
     <string name="pref_visitor_message_txt_color">visitor_message_txt_color</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,8 @@
     <string name="settings_queue_id">Queue id</string>
     <string name="settings_white_label">White label</string>
     <string name="settings_use_overlay">Use Overlay</string>
-    <string name="settings_unified_ui">Enable Unified UI</string>
+    <string name="settings_remote_theme">Enable Remote Theme</string>
+    <string name="settings_runtime_theme">Enable Runtime Theme</string>
     <string name="settings_visitor_context_asset_id">Visitor context asset id</string>
     <string name="settings_use_alert_dialog_button_vertical_alignment">Align AlertDialog Buttons Vertically</string>
     <string name="settings_screen_sharing_mode_title">Screen sharing mode</string>

--- a/app/src/main/res/xml/remote_theme_prefs.xml
+++ b/app/src/main/res/xml/remote_theme_prefs.xml
@@ -11,12 +11,12 @@
 
     <SwitchPreference
         app:defaultValue="false"
-        app:key="@string/pref_unified_ui"
-        app:title="@string/settings_unified_ui" />
+        app:key="@string/pref_remote_theme"
+        app:title="@string/settings_remote_theme" />
 
     <PreferenceCategory
         app:title="Global colors"
-        android:dependency="@string/pref_unified_ui">
+        android:dependency="@string/pref_remote_theme">
 
         <ListPreference
             android:defaultValue="@string/default_value"

--- a/app/src/main/res/xml/runtime_theme_prefs.xml
+++ b/app/src/main/res/xml/runtime_theme_prefs.xml
@@ -2,7 +2,20 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <PreferenceCategory app:title="Behavior">
+    <Preference
+        android:title="N.B: For CV elements restart is needed"
+        android:selectable="false"
+        android:enabled="true"
+        android:summary="For live engagement and secure messaging should work without the restart but for Call Visualizer app restart is needed"/>
+
+    <SwitchPreference
+        app:defaultValue="false"
+        app:key="@string/pref_runtime_theme"
+        app:title="@string/settings_runtime_theme" />
+
+    <PreferenceCategory
+        app:title="Behavior"
+        android:dependency="@string/pref_runtime_theme">
 
         <SwitchPreference
             app:defaultValue="false"
@@ -10,7 +23,9 @@
             app:title="@string/settings_white_label" />
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_colors_title">
+    <PreferenceCategory
+        app:title="@string/settings_colors_title"
+        android:dependency="@string/pref_runtime_theme">
 
         <ListPreference
             android:defaultValue="@string/default_value"
@@ -141,7 +156,10 @@
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_operator_layout_styling">
+    <PreferenceCategory
+        app:title="@string/settings_operator_layout_styling"
+        android:dependency="@string/pref_runtime_theme">
+
         <ListPreference
             android:defaultValue="@string/default_value"
             android:entries="@array/colors"
@@ -172,7 +190,10 @@
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_header_styling">
+    <PreferenceCategory
+        app:title="@string/settings_header_styling"
+        android:dependency="@string/pref_runtime_theme">
+
         <ListPreference
             android:defaultValue="@string/default_value"
             android:entries="@array/colors"
@@ -198,7 +219,9 @@
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_typography">
+    <PreferenceCategory
+        app:title="@string/settings_typography"
+        android:dependency="@string/pref_runtime_theme">
 
         <ListPreference
             android:defaultValue="@string/default_value"


### PR DESCRIPTION

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2174

**Additional info:**
Before the runtime theme settings were not applied on the SDK `init` but only when launching ChatActivity or CallActivity. Also added a simple toggle to runtime theme settings to easily enable/disable the runtime theme settings without having to clear app data.

**Screenshots:**
![image](https://user-images.githubusercontent.com/10000880/236430439-1d8e837f-937e-4e1d-9316-85882d70832d.png)

