### PR TITLE
Fix: Messages with attachments are not delivered if an engagement starts

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
@@ -3,6 +3,7 @@ package com.glia.widgets.chat.data;
 import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.Glia;
 import com.glia.androidsdk.GliaException;
+import com.glia.androidsdk.RequestCallback;
 import com.glia.androidsdk.chat.Chat;
 import com.glia.androidsdk.chat.ChatMessage;
 import com.glia.androidsdk.chat.MessageAttachment;
@@ -65,6 +66,11 @@ public class GliaChatRepository {
                 value.getChat().sendMessagePreview(message));
     }
 
+    public void sendMessage(String message, RequestCallback<VisitorMessage> callback) {
+        gliaCore.getCurrentEngagement().ifPresent(engagement ->
+                engagement.getChat().sendMessage(message, callback));
+    }
+
     public void sendMessage(String message, Listener listener) {
         gliaCore.getCurrentEngagement().ifPresent(engagement ->
                 engagement.getChat().sendMessage(message, (visitorMessage, ex) -> onMessageReceived(visitorMessage, ex, listener)));
@@ -73,6 +79,12 @@ public class GliaChatRepository {
     public void sendMessageSingleChoice(SingleChoiceAttachment singleChoiceAttachment, Listener listener) {
         gliaCore.getCurrentEngagement().ifPresent(engagement ->
                 engagement.getChat().sendMessage(singleChoiceAttachment, (visitorMessage, ex) -> onMessageReceived(visitorMessage, ex, listener)));
+    }
+
+    public void sendMessageWithAttachment(String message, MessageAttachment attachment, RequestCallback<VisitorMessage> callback) {
+        gliaCore.getCurrentEngagement().ifPresent(engagement ->
+                engagement.getChat().sendMessage(message, attachment, callback)
+        );
     }
 
     public void sendMessageWithAttachment(String message, MessageAttachment attachment, Listener listener) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SendSecureMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SendSecureMessageUseCase.kt
@@ -3,6 +3,8 @@ package com.glia.widgets.core.secureconversations.domain
 import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.VisitorMessage
+import com.glia.widgets.chat.data.GliaChatRepository
+import com.glia.widgets.core.engagement.GliaEngagementRepository
 import com.glia.widgets.core.fileupload.SecureFileAttachmentRepository
 import com.glia.widgets.core.fileupload.model.FileAttachment
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
@@ -12,8 +14,13 @@ class SendSecureMessageUseCase(
     private val queueId: String,
     private val sendMessageRepository: SendMessageRepository,
     private val secureConversationsRepository: SecureConversationsRepository,
-    private val fileAttachmentRepository: SecureFileAttachmentRepository
+    private val fileAttachmentRepository: SecureFileAttachmentRepository,
+    private val chatRepository: GliaChatRepository,
+    private val engagementRepository: GliaEngagementRepository
 ) {
+
+    private val hasOngoingEngagement: Boolean
+        get() = engagementRepository.hasOngoingEngagement()
 
     operator fun invoke(
         callback: RequestCallback<VisitorMessage?>
@@ -21,8 +28,35 @@ class SendSecureMessageUseCase(
         val message = sendMessageRepository.value
         val queueIds = arrayOf(queueId)
         val fileAttachments = fileAttachmentRepository.getReadyToSendFileAttachments()
+        sendMessage(message, queueIds, fileAttachments, callback)
+    }
+
+    private fun sendMessage(
+        message: String,
+        queueIds: Array<String>,
+        fileAttachments: List<FileAttachment>,
+        callback: RequestCallback<VisitorMessage?>
+    ) {
         if (fileAttachments.isNotEmpty()) {
-            sendMessageWithAttachments(message, queueIds, fileAttachments, callback)
+            sendMessageWithAttachments(message, queueIds, fileAttachments) { result, ex ->
+                if (ex == null) {
+                    sendMessageRepository.reset()
+                    fileAttachmentRepository.detachFiles(fileAttachments)
+                }
+                callback.onResult(result, ex)
+            }
+        } else {
+            sendMessage(message, queueIds, callback)
+        }
+    }
+
+    private fun sendMessage(
+        message: String,
+        queueIds: Array<String>,
+        callback: RequestCallback<VisitorMessage?>
+    ) {
+        if (hasOngoingEngagement) {
+            chatRepository.sendMessage(message, callback)
         } else {
             secureConversationsRepository.send(message, queueIds, callback)
         }
@@ -39,12 +73,10 @@ class SendSecureMessageUseCase(
             .toTypedArray()
             .let { FilesAttachment.from(it) }
 
-        secureConversationsRepository.send(message, queueIds, filesAttachment) { result, ex ->
-            if (ex == null) {
-                sendMessageRepository.reset()
-                fileAttachmentRepository.detachFiles(fileAttachments)
-            }
-            callback.onResult(result, ex)
+        if (hasOngoingEngagement) {
+            chatRepository.sendMessageWithAttachment(message, filesAttachment, callback)
+        } else {
+            secureConversationsRepository.send(message, queueIds, filesAttachment, callback)
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -192,7 +192,7 @@ public class RepositoryFactory {
 
     public SecureFileAttachmentRepository getSecureFileAttachmentRepository() {
         if (secureFileAttachmentRepository == null) {
-            secureFileAttachmentRepository = new SecureFileAttachmentRepository(gliaCore.getSecureConversations());
+            secureFileAttachmentRepository = new SecureFileAttachmentRepository(gliaCore);
         }
         return secureFileAttachmentRepository;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -639,7 +639,10 @@ public class UseCaseFactory {
                 queueId,
                 repositoryFactory.getSendMessageRepository(),
                 repositoryFactory.getSecureConversationsRepository(),
-                repositoryFactory.getSecureFileAttachmentRepository());
+                repositoryFactory.getSecureFileAttachmentRepository(),
+                repositoryFactory.getGliaMessageRepository(),
+                repositoryFactory.getGliaEngagementRepository()
+        );
     }
 
     @NonNull


### PR DESCRIPTION
Use live chat endpoints for message sending when an engagement started for the Welcome to Message Center screen

[MOB-2159](https://glia.atlassian.net/browse/MOB-2159)

[MOB-2159]: https://glia.atlassian.net/browse/MOB-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ