### PR TITLE
Fix Activity onPause/onResume breaking the permission dialog

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -37,6 +37,7 @@ import com.glia.widgets.call.CallState.ViewState
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.core.dialog.Dialog
 import com.glia.widgets.core.dialog.DialogController
+import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.core.dialog.model.DialogState.MediaUpgrade
 import com.glia.widgets.core.dialog.model.DialogState.OperatorName
 import com.glia.widgets.core.notification.openNotificationChannelScreen
@@ -136,6 +137,7 @@ internal class CallView(
 
     private var operatorVideoView: VideoView? = null
     private var alertDialog: AlertDialog? = null
+    private var currentDialogState: DialogState? = null
 
     @JvmOverloads
     constructor(
@@ -218,6 +220,10 @@ internal class CallView(
     private fun setupControllers() {
         callController = Dependencies.getControllerFactory().getCallController(this)
         dialogCallback = DialogController.Callback {
+            if (it.mode == currentDialogState?.mode) {
+                return@Callback
+            }
+            currentDialogState = it
             when (it.mode) {
                 Dialog.MODE_NONE -> dismissAlertDialog()
                 Dialog.MODE_UNEXPECTED_ERROR -> post { showUnexpectedErrorDialog() }
@@ -751,6 +757,7 @@ internal class CallView(
     }
 
     private fun dismissAlertDialog() {
+        currentDialogState = null
         alertDialog?.apply {
             dismiss()
             alertDialog = null

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -53,6 +53,7 @@ import com.glia.widgets.chat.model.history.VisitorAttachmentItem
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.core.dialog.Dialog
 import com.glia.widgets.core.dialog.DialogController
+import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.core.dialog.model.DialogState.MediaUpgrade
 import com.glia.widgets.core.dialog.model.DialogState.OperatorName
 import com.glia.widgets.core.fileupload.model.FileAttachment
@@ -106,6 +107,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     ) : this(context, attrs, defStyleAttr, R.style.Application_Glia_Chat)
 
     private var alertDialog: AlertDialog? = null
+    private var currentDialogState: DialogState? = null
     private var callback: ChatViewCallback? = null
     private var controller: ChatController? = null
     private var dialogCallback: DialogController.Callback? = null
@@ -446,6 +448,10 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
     private fun setupDialogCallback() {
         dialogCallback = DialogController.Callback {
+            if (it.mode == currentDialogState?.mode) {
+                return@Callback
+            }
+            currentDialogState = it
             when (it.mode) {
                 Dialog.MODE_NONE -> dismissAlertDialog()
                 Dialog.MODE_MESSAGE_CENTER_UNAVAILABLE -> post { showChatUnavailableView() }
@@ -963,6 +969,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     }
 
     private fun dismissAlertDialog() {
+        currentDialogState = null
         alertDialog?.dismiss()
         alertDialog = null
     }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2171

**Additional info:**
The issue was caused by the DialogController addCallback() method, which always fired the current dialog state. 

CallActivity and ChatActivity always add/remove the callback on Activity onResume/onPause to prevent the same dialog from appearing on both Activities. But as a result, because of this, a duplicate second dialog was being with Activity having no callbacks attached to it.

Ideally, need the full refactoring of the Alert dialogs logic in Widgets SDK. Asked this refactoring request to be added to the Android tech depts.

**Screenshots:**
