### PR TITLE
Parse base domain from deep link and pass to Core SDK

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/GliaWidgetsConfigManager.kt
+++ b/app/src/main/java/com/glia/exampleapp/GliaWidgetsConfigManager.kt
@@ -26,6 +26,8 @@ object GliaWidgetsConfigManager {
     private const val REGION_KEY = "environment"
     private const val REGION_BETA = "beta"
     private const val REGION_ACCEPTANCE = "acceptance"
+    private const val BASE_DOMAIN = "base_domain"
+    private const val DEFAULT_BASE_DOMAIN = "at.samo.io"
     @JvmStatic
     fun obtainConfigFromDeepLink(data: Uri, applicationContext: Context): GliaWidgetsConfig {
         saveQueueIdToPrefs(data, applicationContext)
@@ -39,12 +41,14 @@ object GliaWidgetsConfigManager {
             throw RuntimeException("deep link must start with \"glia://widgets/secret\"")
         }
         val region = data.getQueryParameter(REGION_KEY) ?: REGION_ACCEPTANCE
+        val baseDomain = data.getQueryParameter(BASE_DOMAIN) ?: DEFAULT_BASE_DOMAIN
 
         // By this point all settings from deep link where saved to the shared prefs overriding the
         // defaults combining both together
         return createDefaultConfig(
             context = applicationContext,
-            region = region
+            region = region,
+            baseDomain = baseDomain
         )
     }
 
@@ -91,6 +95,7 @@ object GliaWidgetsConfigManager {
         uiJsonRemoteConfig: String? = null,
         runtimeConfig: UiTheme? = null,
         region: String = REGION_BETA,
+        baseDomain: String = DEFAULT_BASE_DOMAIN,
         preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
     ): GliaWidgetsConfig {
         val apiKeyId = preferences.getString(
@@ -121,6 +126,7 @@ object GliaWidgetsConfigManager {
             .setSiteApiKey(SiteApiKey(apiKeyId!!, apiKeySecret!!))
             .setSiteId(siteId)
             .setRegion(region)
+            .setBaseDomain(baseDomain)
             .setCompanyName(companyName)
             .setUseOverlay(useOverlay)
             .setScreenSharingMode(screenSharingMode)

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -137,7 +137,8 @@ public class GliaWidgets {
      * @param gliaWidgetsConfig Glia configuration
      */
     public synchronized static void init(GliaWidgetsConfig gliaWidgetsConfig) {
-        Dependencies.glia().init(createGliaConfig(gliaWidgetsConfig));
+        GliaConfig gliaConfig = createGliaConfig(gliaWidgetsConfig);
+        Dependencies.glia().init(gliaConfig);
         Dependencies.init(gliaWidgetsConfig);
         Dependencies.getGliaThemeManager().applyJsonConfig(gliaWidgetsConfig.getUiJsonRemoteConfig());
         Logger.d(TAG, "init");
@@ -149,6 +150,7 @@ public class GliaWidgets {
         return builder
                 .setSiteId(gliaWidgetsConfig.getSiteId())
                 .setRegion(gliaWidgetsConfig.getRegion())
+                .setBaseDomain(gliaWidgetsConfig.getBaseDomain())
                 .setContext(gliaWidgetsConfig.getContext())
                 .build();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.java
@@ -20,6 +20,7 @@ public class GliaWidgetsConfig {
     private final SiteApiKey siteApiKey;
     private final Context context;
     private final String region;
+    private final String baseDomain;
     private final int requestCode;
     private final String uiJsonRemoteConfig;
     private final String companyName;
@@ -62,6 +63,7 @@ public class GliaWidgetsConfig {
         this.siteId = builder.siteId;
         this.context = builder.context;
         this.region = builder.region;
+        this.baseDomain = builder.baseDomain;
         this.requestCode = builder.requestCode;
         this.uiJsonRemoteConfig = builder.uiJsonRemoteConfig;
         this.companyName = builder.companyName;
@@ -84,6 +86,10 @@ public class GliaWidgetsConfig {
 
     public String getRegion() {
         return region;
+    }
+
+    public String getBaseDomain() {
+        return baseDomain;
     }
 
     public SiteApiKey getSiteApiKey() {
@@ -172,6 +178,7 @@ public class GliaWidgetsConfig {
         SiteApiKey siteApiKey;
         Context context;
         String region;
+        String baseDomain;
         int requestCode;
         String uiJsonRemoteConfig;
         String companyName;
@@ -230,6 +237,16 @@ public class GliaWidgetsConfig {
             return this;
         }
 
+        /**
+         * @hidden
+         * @param baseDomain Base domain to be used.
+         * @return Builder instance
+         */
+        public Builder setBaseDomain(String baseDomain) {
+            this.baseDomain = baseDomain;
+            return this;
+        }
+
         public Builder setSiteApiKey(SiteApiKey siteApiKey) {
             this.siteApiKey = siteApiKey;
             return this;
@@ -267,7 +284,7 @@ public class GliaWidgetsConfig {
          * @param useOverlay - Is it allowed to overlay the application
          * @return Builder instance
          */
-        public Builder setUseOverlay(@Nullable boolean useOverlay) {
+        public Builder setUseOverlay(boolean useOverlay) {
             this.useOverlay = useOverlay;
             return this;
         }


### PR DESCRIPTION
[MOB-2154](https://glia.atlassian.net/browse/MOB-2154)

The whole scope of changes includes:
- Changes in acceptance tests: [pull request](https://github.com/salemove/acceptance_tests/pull/3284)
- Changes in Android Widgets SDK: [pull request](https://github.com/salemove/android-sdk-widgets/pull/596)
- Changes in Android Core SDK: [pull request](https://github.com/salemove/android-sdk/pull/459)

Also, removed `@Nullable` from a primitive type (Lint warning).

[MOB-2154]: https://glia.atlassian.net/browse/MOB-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ