### PR TITLE
Fix ActivityWatchers loosing refference to current Activity

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/base/BaseActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/base/BaseActivityWatcher.kt
@@ -3,12 +3,53 @@ package com.glia.widgets.base
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import io.reactivex.subjects.PublishSubject
+import java.lang.ref.WeakReference
 
 internal open class BaseActivityWatcher : Application.ActivityLifecycleCallbacks {
+
+    private val resumedActivities = object: ArrayList<WeakReference<Activity>>(1) {
+        fun add(activity: Activity) {
+            super.add(WeakReference(activity))
+        }
+
+        fun remove(activity: Activity) {
+            for (i in lastIndex downTo 0) {
+                if (activity == super.get(i).get()) {
+                    super.removeAt(i)
+                }
+            }
+        }
+
+        fun getAll(): List<Activity> {
+            val activityList = ArrayList<Activity>()
+            var iActivity: Activity?
+            for (i in lastIndex downTo 0) {
+                iActivity = super.get(i).get()
+                if (iActivity == null) {
+                    super.removeAt(i)
+                } else {
+                    activityList.add(iActivity)
+                }
+            }
+            return activityList
+        }
+    }
+    private val resumedActivitySubject: PublishSubject<List<Activity>> = PublishSubject.create()
+    val topActivityObserver = resumedActivitySubject
+        .filter { list -> list.isNotEmpty() }
+        .map { list -> list.last() }
+
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
     override fun onActivityStarted(activity: Activity) {}
-    override fun onActivityResumed(activity: Activity) {}
-    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) {
+        resumedActivities.add(activity)
+        resumedActivitySubject.onNext(resumedActivities.getAll())
+    }
+    override fun onActivityPaused(activity: Activity) {
+        resumedActivities.remove(activity)
+        resumedActivitySubject.onNext(resumedActivities.getAll())
+    }
     override fun onActivityStopped(activity: Activity) {}
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
     override fun onActivityDestroyed(activity: Activity) {}

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -43,6 +43,10 @@ internal class ActivityWatcherForCallVisualizer(
 ) : BaseActivityWatcher(), ActivityWatcherForCallVisualizerContract.Watcher {
 
     init {
+        topActivityObserver.subscribe(
+            {activity -> resumedActivity = WeakReference(activity)},
+            {error -> Logger.e(TAG, "Observable monitoring top activity FAILED", error)}
+        )
         controller.setWatcher(this)
     }
 
@@ -58,6 +62,7 @@ internal class ActivityWatcherForCallVisualizer(
     var resumedActivity: WeakReference<Activity?> = WeakReference(null)
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        super.onActivityCreated(activity, savedInstanceState)
         if (controller.isCallOrChatActive(activity)) {
             // Call and Chat screens process screen sharing requests on their own
             controller.removeMediaProjectionLaunchers(activity::class.simpleName)
@@ -70,18 +75,14 @@ internal class ActivityWatcherForCallVisualizer(
     }
 
     override fun onActivityResumed(activity: Activity) {
-        resumedActivity = WeakReference(activity)
+        super.onActivityResumed(activity)
         controller.onActivityResumed(activity)
     }
 
     override fun onActivityPaused(activity: Activity) {
+        super.onActivityPaused(activity)
         controller.onActivityPaused()
-        resumedActivity.clear()
     }
-
-    override fun onActivityStarted(activity: Activity) {}
-    override fun onActivityStopped(activity: Activity) {}
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
 
     override fun checkInitialCameraPermission() {
         resumedActivity.get()?.run {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
@@ -31,6 +31,10 @@ internal class ActivityWatcherForChatHead(
 ) : BaseActivityWatcher(), ActivityWatcherForChatHeadContract.Watcher {
 
     init {
+        topActivityObserver.subscribe(
+            {activity -> resumedActivity = WeakReference(activity)},
+            {error -> Logger.e(TAG, "Observable monitoring top activity FAILED", error)}
+        )
         controller.setWatcher(this)
     }
 
@@ -45,17 +49,17 @@ internal class ActivityWatcherForChatHead(
     private var chatHeadViewPosition: Pair<Int, Int>? = null
 
     override fun onActivityResumed(activity: Activity) {
-        resumedActivity = WeakReference(activity)
+        super.onActivityResumed(activity)
         controller.onActivityResumed()
         if (isSameOrientation(activity)) restoreBubblePosition()
 
     }
 
     override fun onActivityPaused(activity: Activity) {
+        super.onActivityPaused(activity)
         screenOrientation = activity.resources.configuration.orientation
         controller.onActivityPaused()
         removeChatHeadLayoutIfPresent()
-        resumedActivity.clear()
     }
 
     private fun createChatHeadLayout(activity: Activity) {


### PR DESCRIPTION


**Jira issue:**
https://glia.atlassian.net/browse/MOB-2179
https://glia.atlassian.net/browse/MOB-2180

**Additional info:**
ActivityWatchers are losing reference to current activity on screen rotation when multiple activities are being recreated and for some reason, activity from the back gets 'resumed' for a short moment (probably it was partially visible) and then again paused. As a result, ActivityWhatcher thought that all activities are paused.

**Screenshots:**
