### PR TITLE
Fix wrong image preview

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -445,6 +445,21 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                     }
                 }
             }
+
+            override fun navigateToPreview(attachmentFile: AttachmentFile) {
+                context.startActivity(
+                    FilePreviewActivity.intent(
+                        context,
+                        attachmentFile.id,
+                        attachmentFile.name,
+                        theme
+                    )
+                )
+            }
+
+            override fun fileIsNotReadyForPreview() {
+                showToast(context.getString(R.string.glia_view_file_not_ready_for_preview))
+            }
         }
     }
 
@@ -493,7 +508,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
             item.showChatHead,
             item.attachmentFile,
             item.operatorProfileImgUrl,
-            item.attachmentFile.isDownloaded,
+            item.attachmentFile.isDownloaded(context),
             item.isDownloading,
             item.operatorId,
             item.messageId,
@@ -502,7 +517,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
         is VisitorAttachmentItem -> VisitorAttachmentItem.editDownloadedStatus(
             item,
-            item.attachmentFile.isDownloaded
+            item.attachmentFile.isDownloaded(context)
         )
 
         else -> item
@@ -1103,7 +1118,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     }
 
     override fun onImageItemClick(item: AttachmentFile) {
-        context.startActivity(FilePreviewActivity.intent(this.context, item.id, item.name, theme))
+        controller?.onImageItemClick(item)
     }
 
     fun onRequestPermissionsResult(requestCode: Int, grantResults: IntArray) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
@@ -37,4 +37,8 @@ public interface ChatViewCallback {
     void fileDownloadSuccess(AttachmentFile attachmentFile);
 
     void clearMessageInput();
+
+    void navigateToPreview(AttachmentFile attachmentFile);
+
+    void fileIsNotReadyForPreview();
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.java
@@ -48,6 +48,8 @@ public class ImageAttachmentViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void bind(AttachmentFile attachmentFile) {
+        imageView.setImageResource(android.R.color.transparent); // clear the previous view state
+
         String imageName = FileHelper.getFileName(attachmentFile);
         disposable = getImageFileFromCacheUseCase.execute(imageName)
                 .doOnError(error -> Logger.e(TAG, "failed loading from cache: " + imageName + " reason: " + error.getMessage()))

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -101,6 +101,7 @@ import com.glia.widgets.core.survey.OnSurveyListener
 import com.glia.widgets.core.survey.domain.GliaSurveyUseCase
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.filepreview.domain.usecase.DownloadFileUseCase
+import com.glia.widgets.filepreview.domain.usecase.IsFileReadyForPreviewUseCase
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.TimeCounter
@@ -167,7 +168,8 @@ internal class ChatController(
     private val setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase,
     private val isCallVisualizerUseCase: IsCallVisualizerUseCase,
     private val preEngagementMessageUseCase: PreEngagementMessageUseCase,
-    private val addNewMessagesDividerUseCase: AddNewMessagesDividerUseCase
+    private val addNewMessagesDividerUseCase: AddNewMessagesDividerUseCase,
+    private val isFileReadyForPreviewUseCase: IsFileReadyForPreviewUseCase
 ) : GliaOnEngagementUseCase.Listener, GliaOnEngagementEndUseCase.Listener, OnSurveyListener {
     private var backClickedListener: ChatView.OnBackClickedListener? = null
     private var viewCallback: ChatViewCallback? = null
@@ -357,6 +359,14 @@ internal class ChatController(
         messagesNotSeenHandler.onChatWentBackground()
         surveyUseCase.unregisterListener(this)
         mediaUpgradeOfferRepositoryCallback?.let { removeMediaUpgradeCallbackUseCase(it) }
+    }
+
+    fun onImageItemClick(item: AttachmentFile) {
+        if (isFileReadyForPreviewUseCase(item)) {
+            viewCallback?.navigateToPreview(item)
+        } else {
+            viewCallback?.fileIsNotReadyForPreview()
+        }
     }
 
     fun onMessageTextChanged(message: String) {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -133,7 +133,8 @@ public class ControllerFactory {
                     useCaseFactory.createSetPendingSurveyUsed(),
                     useCaseFactory.createIsCallVisualizerUseCase(),
                     useCaseFactory.createPreEngagementMessageUseCase(),
-                    useCaseFactory.createAddNewMessagesDividerUseCase()
+                    useCaseFactory.createAddNewMessagesDividerUseCase(),
+                    useCaseFactory.createIsFileReadyForPreviewUseCase()
             );
         } else {
             Logger.d(TAG, "retained chat controller");

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -100,6 +100,7 @@ import com.glia.widgets.filepreview.domain.usecase.DownloadFileUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromCacheUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromDownloadsUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromNetworkUseCase;
+import com.glia.widgets.filepreview.domain.usecase.IsFileReadyForPreviewUseCase;
 import com.glia.widgets.filepreview.domain.usecase.PutImageFileToDownloadsUseCase;
 import com.glia.widgets.helper.rx.Schedulers;
 import com.glia.widgets.view.floatingvisitorvideoview.domain.IsShowOnHoldUseCase;
@@ -761,6 +762,11 @@ public class UseCaseFactory {
     @NonNull
     public AddNewMessagesDividerUseCase createAddNewMessagesDividerUseCase() {
         return new AddNewMessagesDividerUseCase(createFindNewMessagesDividerIndexUseCase());
+    }
+
+    @NonNull
+    public IsFileReadyForPreviewUseCase createIsFileReadyForPreviewUseCase() {
+        return new IsFileReadyForPreviewUseCase(repositoryFactory.getGliaFileRepository());
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/data/GliaFileRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/data/GliaFileRepository.kt
@@ -7,6 +7,7 @@ import io.reactivex.Maybe
 import java.io.InputStream
 
 interface GliaFileRepository {
+    fun isReadyForPreview(attachmentFile: AttachmentFile): Boolean
     fun loadImageFromCache(fileName: String): Maybe<Bitmap>
     fun putImageToCache(fileName: String, bitmap: Bitmap)
     fun loadImageFromDownloads(fileName: String): Maybe<Bitmap>

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/data/GliaFileRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/data/GliaFileRepositoryImpl.kt
@@ -25,6 +25,10 @@ internal class GliaFileRepositoryImpl(
         gliaCore.secureConversations
     }
 
+    override fun isReadyForPreview(attachmentFile: AttachmentFile): Boolean =
+        downloadsFolderDataSource.isDownloaded(attachmentFile) ||
+        bitmapCache.getBitmapById(attachmentFile.fileName) != null
+
     override fun loadImageFromCache(fileName: String): Maybe<Bitmap> = Maybe.create { emitter ->
         bitmapCache.getBitmapById(fileName)?.let {
             emitter.onSuccess(it)

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/IsFileReadyForPreviewUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/IsFileReadyForPreviewUseCase.kt
@@ -1,0 +1,11 @@
+package com.glia.widgets.filepreview.domain.usecase
+
+import com.glia.androidsdk.chat.AttachmentFile
+import com.glia.widgets.filepreview.data.GliaFileRepository
+
+internal class IsFileReadyForPreviewUseCase(
+    private val fileRepository: GliaFileRepository
+) {
+    operator fun invoke(attachmentFile: AttachmentFile): Boolean =
+        fileRepository.isReadyForPreview(attachmentFile)
+}

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
 
     <string name="glia_messaging_title">Messaging</string>
     <string name="glia_view_file_error_message">Can\'t open file</string>
+    <string name="glia_view_file_not_ready_for_preview">The image is not ready for preview. Please try again later.</string>
 
     <!--    top app bar-->
     <string name="glia_top_app_bar_close">Close</string>

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -52,6 +52,7 @@ import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCas
 import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase
 import com.glia.widgets.core.survey.domain.GliaSurveyUseCase
 import com.glia.widgets.filepreview.domain.usecase.DownloadFileUseCase
+import com.glia.widgets.filepreview.domain.usecase.IsFileReadyForPreviewUseCase
 import com.glia.widgets.helper.TimeCounter
 import com.glia.widgets.view.MessagesNotSeenHandler
 import com.glia.widgets.view.MinimizeHandler
@@ -121,6 +122,7 @@ class ChatControllerTest {
     private lateinit var isCallVisualizerUseCase: IsCallVisualizerUseCase
     private lateinit var preEngagementMessageUseCase: PreEngagementMessageUseCase
     private lateinit var addNewMessagesDividerUseCase: AddNewMessagesDividerUseCase
+    private lateinit var isFileReadyForPreviewUseCase: IsFileReadyForPreviewUseCase
 
     private lateinit var chatController: ChatController
 
@@ -177,6 +179,7 @@ class ChatControllerTest {
         isCallVisualizerUseCase = mock()
         preEngagementMessageUseCase = mock()
         addNewMessagesDividerUseCase = mock()
+        isFileReadyForPreviewUseCase = mock()
 
         chatController = ChatController(
             chatViewCallback = chatViewCallback,
@@ -229,7 +232,8 @@ class ChatControllerTest {
             setPendingSurveyUsedUseCase = setPendingSurveyUsedUseCase,
             isCallVisualizerUseCase = isCallVisualizerUseCase,
             preEngagementMessageUseCase = preEngagementMessageUseCase,
-            addNewMessagesDividerUseCase = addNewMessagesDividerUseCase
+            addNewMessagesDividerUseCase = addNewMessagesDividerUseCase,
+            isFileReadyForPreviewUseCase = isFileReadyForPreviewUseCase
         )
     }
 


### PR DESCRIPTION
Fixed wrong image preview.
Prevent opening an image unless it is ready for preview (same behavior as on iOS).
Also, refactored work with files.

[MOB-2190](https://glia.atlassian.net/browse/MOB-2190)

[MOB-2190]: https://glia.atlassian.net/browse/MOB-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ