### PR TITLE
Clear survey and engagement state when clearing visitor session

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -208,6 +208,7 @@ public class GliaWidgets {
     public static void clearVisitorSession() {
         Logger.d(TAG, "clearVisitorSession");
         Dependencies.getControllerFactory().destroyControllers();
+        Dependencies.getUseCaseFactory().resetState();
         Dependencies.glia().clearVisitorSession();
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -63,7 +63,7 @@ internal class CallVisualizerController(
         surveyUseCase.registerListener(this)
     }
 
-    override fun engagementEnded() {
+    override fun callVisualizerEngagementEnded() {
         // Beware, this function is called before onSurveyLoaded()
         // No need to do anything currently
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -339,7 +339,7 @@ internal class ChatController(
         synchronized(this) { viewCallback = null }
         backClickedListener = null
         if (!retain) {
-            disposable.dispose()
+            disposable.clear()
             mediaUpgradeOfferRepository.stopAll()
             mediaUpgradeOfferRepositoryCallback = null
             timerStatusListener = null
@@ -554,7 +554,8 @@ internal class ChatController(
             viewCallback?.backToCall()
         } else {
             backClickedListener?.onBackClicked()
-            Dependencies.getControllerFactory().destroyControllers()
+            Dependencies.getControllerFactory().destroyChatController()
+            Dependencies.getControllerFactory().destroyCallController()
         }
         updateFromCallScreenUseCase.updateFromCallScreen(false)
     }
@@ -1612,12 +1613,15 @@ internal class ChatController(
         Logger.d(TAG, "newSurveyLoaded")
         setPendingSurveyUsedUseCase.invoke()
         if (viewCallback != null && survey != null) {
+            // Show survey
             viewCallback!!.navigateToSurvey(survey)
             Dependencies.getControllerFactory().destroyControllers()
         } else if (shouldHandleEndedEngagement && !isVisitorEndEngagement) {
+            // Show "Engagement ended" pop-up
             shouldHandleEndedEngagement = false
             dialogController.showEngagementEndedDialog()
-        } else {
+        } else if (shouldHandleEndedEngagement) {
+            // Close chat screen
             Dependencies.getControllerFactory().destroyControllers()
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerEndUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerEndUseCase.kt
@@ -20,13 +20,13 @@ internal class GliaOnCallVisualizerEndUseCase(
 ) : GliaOnCallVisualizerUseCase.Listener {
 
     interface Listener {
-        fun engagementEnded()
+        fun callVisualizerEngagementEnded()
     }
 
     inner class EndCallVisualizerRunnable(private val engagement: Engagement) : Runnable {
         override fun run() {
             surveyRepository.onEngagementEnded(engagement)
-            listener?.engagementEnded()
+            listener?.callVisualizerEngagementEnded()
             operatorMediaRepository.stopListening(engagement)
             removeScreenSharingNotificationUseCase()
             callNotificationUseCase.removeAllNotifications()

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
@@ -41,4 +41,8 @@ internal class ToggleChatHeadServiceUseCase(
     override fun isDisplayBasedOnPermission(): Boolean {
         return permissionManager.hasOverlayPermission()
     }
+
+    fun onDestroy() {
+        chatHeadManager.stopChatHeadService()
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -216,7 +216,7 @@ public class ControllerFactory {
         }
     }
 
-    private void destroyChatController() {
+    public void destroyChatController() {
         Logger.d(TAG, "destroyChatController");
         if (retainedChatController != null) {
             retainedChatController.onDestroy(false);

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -778,4 +778,8 @@ public class UseCaseFactory {
     public ResetSurveyUseCase createResetSurveyUseCase() {
         return new ResetSurveyUseCase(surveyStateManager, repositoryFactory.getGliaSurveyRepository());
     }
+
+    public void resetState() {
+        createResetSurveyUseCase().invoke();
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -73,8 +73,6 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     override fun onDestroy() {
-        if (isDisplayApplicationChatHeadUseCase(resumedViewName)) return
-
         chatHeadLayout?.hide()
         gliaOnEngagementUseCase.unregisterListener(this)
         gliaOnCallVisualizerUseCase.unregisterListener(this)
@@ -141,8 +139,12 @@ internal class ApplicationChatHeadLayoutController(
         state = State.ENDED
         operatorProfileImgUrl = null
         unreadMessagesCount = 0
-        engagementDisposables.dispose()
+        engagementDisposables.clear()
         updateChatHeadView()
+    }
+
+    override fun callVisualizerEngagementEnded() {
+        engagementEnded()
     }
 
     private fun onUnreadMessageCountChange(count: Int) {


### PR DESCRIPTION
[MOB-2186](https://glia.atlassian.net/browse/MOB-2186)

Changes overview:
- reset survey from `clearVisitorSession()`
- close bubble when `clearVisitorSession()` is called
- unsubscribe engagement end listeners for a bubble when `clearVisitorSession()` is called
- do not destroy bubble controllers on chat closing
- rename `engagementEnded()` to `callVisualizerEngagementEnded()` for Call Visualizer to have separate handling
- amend `onSurveyLoaded()` logic in `ChatController`

Check list for manual testing is [here](https://glia.atlassian.net/wiki/spaces/ENG/pages/3360489599/End+engagement+and+clear+visitor+session+flows).


[MOB-2186]: https://glia.atlassian.net/browse/MOB-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ