### PR TITLE
Renaming UnengagementMessage to PreEngagementMessage

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -42,7 +42,7 @@ import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.IsSecureConversationsChatAvailableUseCase
 import com.glia.widgets.chat.domain.IsShowSendButtonUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
-import com.glia.widgets.chat.domain.UnengagementMessageUseCase
+import com.glia.widgets.chat.domain.PreEngagementMessageUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.chat.model.ChatInputMode
 import com.glia.widgets.chat.model.ChatState
@@ -166,7 +166,7 @@ internal class ChatController(
     private val hasPendingSurveyUseCase: HasPendingSurveyUseCase,
     private val setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase,
     private val isCallVisualizerUseCase: IsCallVisualizerUseCase,
-    private val unengagementMessageUseCase: UnengagementMessageUseCase,
+    private val preEngagementMessageUseCase: PreEngagementMessageUseCase,
     private val addNewMessagesDividerUseCase: AddNewMessagesDividerUseCase
 ) : GliaOnEngagementUseCase.Listener, GliaOnEngagementEndUseCase.Listener, OnSurveyListener {
     private var backClickedListener: ChatView.OnBackClickedListener? = null
@@ -392,15 +392,15 @@ internal class ChatController(
                 .subscribe())
     }
 
-    private fun subscribeToUnengagementMessages() {
-        val subscribe = unengagementMessageUseCase.execute()
-            .doOnNext { onUnengagementMessage(it) }
+    private fun subscribeToPreEngagementMessage() {
+        val subscribe = preEngagementMessageUseCase.execute()
+            .doOnNext { onPreEngagementMessage(it) }
             .subscribe()
         disposable.add(subscribe)
         unengagementMessagesDisposable = subscribe
     }
 
-    private fun onUnengagementMessage(messageInternal: ChatMessageInternal) {
+    private fun onPreEngagementMessage(messageInternal: ChatMessageInternal) {
         emitChatItems {
             val message = messageInternal.chatMessage
             if (message.senderType == Chat.Participant.VISITOR && message.attachment != null
@@ -1487,7 +1487,7 @@ internal class ChatController(
         }
 
         initGliaEngagementObserving()
-        subscribeToUnengagementMessages()
+        subscribeToPreEngagementMessage()
     }
 
     private fun submitHistoryItems(

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/PreEngagementMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/PreEngagementMessageUseCase.kt
@@ -9,7 +9,7 @@ import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
 import io.reactivex.Observable
 import java.util.function.Consumer
 
-internal class UnengagementMessageUseCase(
+internal class PreEngagementMessageUseCase(
     private val messageRepository: GliaChatRepository,
     private val engagementRepository: GliaEngagementRepository,
     private val onEngagementUseCase: GliaOnEngagementUseCase,

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -132,7 +132,7 @@ public class ControllerFactory {
                     useCaseFactory.createHasPendingSurveyUseCase(),
                     useCaseFactory.createSetPendingSurveyUsed(),
                     useCaseFactory.createIsCallVisualizerUseCase(),
-                    useCaseFactory.createUnengagementMessageUseCase(),
+                    useCaseFactory.createPreEngagementMessageUseCase(),
                     useCaseFactory.createAddNewMessagesDividerUseCase()
             );
         } else {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -25,7 +25,7 @@ import com.glia.widgets.chat.domain.IsFromCallScreenUseCase;
 import com.glia.widgets.chat.domain.IsSecureConversationsChatAvailableUseCase;
 import com.glia.widgets.chat.domain.IsShowSendButtonUseCase;
 import com.glia.widgets.chat.domain.SiteInfoUseCase;
-import com.glia.widgets.chat.domain.UnengagementMessageUseCase;
+import com.glia.widgets.chat.domain.PreEngagementMessageUseCase;
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerEndUseCase;
 import com.glia.widgets.core.callvisualizer.domain.GliaOnCallVisualizerUseCase;
@@ -312,8 +312,8 @@ public class UseCaseFactory {
     }
 
     @NonNull
-    public UnengagementMessageUseCase createUnengagementMessageUseCase() {
-        return new UnengagementMessageUseCase(
+    public PreEngagementMessageUseCase createPreEngagementMessageUseCase() {
+        return new PreEngagementMessageUseCase(
                 repositoryFactory.getGliaMessageRepository(),
                 repositoryFactory.getGliaEngagementRepository(),
                 createOnEngagementUseCase(),

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -17,7 +17,7 @@ import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.IsSecureConversationsChatAvailableUseCase
 import com.glia.widgets.chat.domain.IsShowSendButtonUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
-import com.glia.widgets.chat.domain.UnengagementMessageUseCase
+import com.glia.widgets.chat.domain.PreEngagementMessageUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.chat.model.history.ChatItem
 import com.glia.widgets.chat.model.history.LinkedChatItem
@@ -119,7 +119,7 @@ class ChatControllerTest {
     private lateinit var hasPendingSurveyUseCase: HasPendingSurveyUseCase
     private lateinit var setPendingSurveyUsedUseCase: SetPendingSurveyUsedUseCase
     private lateinit var isCallVisualizerUseCase: IsCallVisualizerUseCase
-    private lateinit var unengagementMessageUseCase: UnengagementMessageUseCase
+    private lateinit var preEngagementMessageUseCase: PreEngagementMessageUseCase
     private lateinit var addNewMessagesDividerUseCase: AddNewMessagesDividerUseCase
 
     private lateinit var chatController: ChatController
@@ -175,7 +175,7 @@ class ChatControllerTest {
         hasPendingSurveyUseCase = mock()
         setPendingSurveyUsedUseCase = mock()
         isCallVisualizerUseCase = mock()
-        unengagementMessageUseCase = mock()
+        preEngagementMessageUseCase = mock()
         addNewMessagesDividerUseCase = mock()
 
         chatController = ChatController(
@@ -228,7 +228,7 @@ class ChatControllerTest {
             hasPendingSurveyUseCase = hasPendingSurveyUseCase,
             setPendingSurveyUsedUseCase = setPendingSurveyUsedUseCase,
             isCallVisualizerUseCase = isCallVisualizerUseCase,
-            unengagementMessageUseCase = unengagementMessageUseCase,
+            preEngagementMessageUseCase = preEngagementMessageUseCase,
             addNewMessagesDividerUseCase = addNewMessagesDividerUseCase
         )
     }


### PR DESCRIPTION
Since we decided not to merge the changes for the order of the welcome message fix, I prepared the commit for the relevant renaming that we decided to do there.

`PreEngagementMessage` way better describes the situation there they use instead of `UnengagementMessage`. Thank @andrews-moc for that advice!