### PR TITLE
Fix ActivityWatcher getting registered for Dialog events multiple times

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -51,7 +51,9 @@ internal class ActivityWatcherForCallVisualizer(
     }
 
     var alertDialog: AlertDialog? = null
-    var dialogCallback: DialogController.Callback? = null
+    val dialogCallback: DialogController.Callback = DialogController.Callback {
+        controller.onDialogControllerCallback(it)
+    }
     var cameraPermissionLauncher: ActivityResultLauncher<String>? = null
     var overlayPermissionLauncher: ActivityResultLauncher<String>? = null
 
@@ -344,9 +346,6 @@ internal class ActivityWatcherForCallVisualizer(
     }
 
     override fun setupDialogCallback() {
-        dialogCallback = DialogController.Callback {
-            controller.onDialogControllerCallback(it)
-        }
         dialogController.addCallback(dialogCallback)
     }
 


### PR DESCRIPTION


**Jira issue:**
https://glia.atlassian.net/browse/MOB-2181

**Additional info:**
ActivityWhatcherForCallVIsualizer was failing to unregister the callback for Glia Alerts because of race condition - it created a new callback and overrode the old one before unregistering the old one from DialogController

**Screenshots:**
