### PR TITLE
Apply SDK default configs consistently for Call Visualizer and Chat/Call screens

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.java
@@ -15,6 +15,10 @@ import kotlin.Deprecated;
  * @see GliaWidgetsConfig.Builder
  */
 public class GliaWidgetsConfig {
+
+    public static final boolean DEFAULT_USE_OVERLAY = true;
+    public static final ScreenSharing.Mode DEFAULT_SCREEN_SHARING_MODE = ScreenSharing.Mode.UNBOUNDED;
+
     private final String appToken;
     private final String siteId;
     private final SiteApiKey siteApiKey;
@@ -65,8 +69,8 @@ public class GliaWidgetsConfig {
         this.requestCode = builder.requestCode;
         this.uiJsonRemoteConfig = builder.uiJsonRemoteConfig;
         this.companyName = builder.companyName;
-        this.screenSharingMode = builder.screenSharingMode != null ? builder.screenSharingMode : ScreenSharing.Mode.UNBOUNDED;
-        this.useOverlay = builder.useOverlay;
+        this.screenSharingMode = builder.screenSharingMode != null ? builder.screenSharingMode : DEFAULT_SCREEN_SHARING_MODE;
+        this.useOverlay = builder.useOverlay != null ? builder.useOverlay : DEFAULT_USE_OVERLAY;
         this.uiTheme = builder.uiTheme;
     }
 
@@ -176,7 +180,7 @@ public class GliaWidgetsConfig {
         String uiJsonRemoteConfig;
         String companyName;
         ScreenSharing.Mode screenSharingMode;
-        boolean useOverlay;
+        Boolean useOverlay;
         UiTheme uiTheme;
 
         public Builder() {
@@ -267,7 +271,7 @@ public class GliaWidgetsConfig {
          * @param useOverlay - Is it allowed to overlay the application
          * @return Builder instance
          */
-        public Builder setUseOverlay(@Nullable boolean useOverlay) {
+        public Builder setUseOverlay(boolean useOverlay) {
             this.useOverlay = useOverlay;
             return this;
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.java
@@ -10,10 +10,6 @@ import com.glia.widgets.chat.ChatType;
 import com.glia.widgets.di.Dependencies;
 
 public class GliaSdkConfiguration {
-
-    private static final boolean DEFAULT_USE_OVERLAY = true;
-    public static final ScreenSharing.Mode DEFAULT_SCREEN_SHARING_MODE =
-            ScreenSharing.Mode.UNBOUNDED;
     private static final ChatType DEFAULT_CHAT_TYPE = ChatType.LIVE_CHAT;
 
     private final String companyName;
@@ -111,11 +107,11 @@ public class GliaSdkConfiguration {
             UiTheme tempTheme = intent.getParcelableExtra(GliaWidgets.UI_THEME);
             this.runTimeTheme = tempTheme != null ? tempTheme : Dependencies.getSdkConfigurationManager().getUiTheme();
             this.contextAssetId = intent.getStringExtra(GliaWidgets.CONTEXT_ASSET_ID);
-            this.useOverlay = intent.getBooleanExtra(GliaWidgets.USE_OVERLAY, DEFAULT_USE_OVERLAY);
+            this.useOverlay = intent.getBooleanExtra(GliaWidgets.USE_OVERLAY, Dependencies.getSdkConfigurationManager().isUseOverlay());
             ScreenSharing.Mode tempMode = intent.hasExtra(GliaWidgets.SCREEN_SHARING_MODE)
                     ? (ScreenSharing.Mode) intent.getSerializableExtra(GliaWidgets.SCREEN_SHARING_MODE)
                     : Dependencies.getSdkConfigurationManager().getScreenSharingMode();
-            this.screenSharingMode = tempMode != null ? tempMode : DEFAULT_SCREEN_SHARING_MODE;
+            this.screenSharingMode = tempMode != null ? tempMode : Dependencies.getSdkConfigurationManager().getScreenSharingMode();
             this.chatType = intent.hasExtra(GliaWidgets.CHAT_TYPE)
                     ? intent.getParcelableExtra(GliaWidgets.CHAT_TYPE)
                     : DEFAULT_CHAT_TYPE;

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
@@ -1,7 +1,5 @@
 package com.glia.widgets.core.configuration;
 
-import static com.glia.widgets.core.configuration.GliaSdkConfiguration.DEFAULT_SCREEN_SHARING_MODE;
-
 import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.widgets.UiTheme;
 
@@ -40,11 +38,7 @@ public class GliaSdkConfigurationManager {
     }
 
     public ScreenSharing.Mode getScreenSharingMode() {
-        if (screenSharingMode == null) {
-            return DEFAULT_SCREEN_SHARING_MODE;
-        } else {
-            return screenSharingMode;
-        }
+        return screenSharingMode;
     }
 
     public void setScreenSharingMode(ScreenSharing.Mode screenSharingMode) {


### PR DESCRIPTION
[Screen sharing bubble is not displayed until the app passes chat engagement flow](https://glia.atlassian.net/browse/MOB-2216)

What problems do these changes solve?
- If `GliaWidgetsConfig.setUseOverlay()` is not set on Glia init, bubble is not displayed for CallVisualizer screen sharing (wrong)  but is displayed for regular engagements (correct)
- If `GliaWidgetsConfig.setUseOverlay(false)` is set, bubble is not displayed for CallVisualizer screen sharing (correct) but is still displayed for regular engagements (wrong)

The reason for that was the inconsistent usage of default values.