### PR TITLE
Update CV in Test App to behave same as in iOS

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.java
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.java
@@ -188,8 +188,11 @@ public class MainFragment extends Fragment {
     }
 
     private void listenForCallVisualizerEngagements() {
+        // If Visitor Code is displayed as embedded view then it should be hidden on engagement start
         GliaWidgets.getCallVisualizer().onEngagementStart(() -> {
-            showToast("Call Visualiser engagement established");
+            FragmentActivity activity = getActivity();
+            if (activity == null) return;
+            activity.runOnUiThread(this::removeVisitorCodeFromDedicatedView);
         });
     }
 
@@ -481,8 +484,15 @@ public class MainFragment extends Fragment {
     private void showVisitorCodeInADedicatedView() {
         VisitorCodeView visitorCodeView = GliaWidgets.getCallVisualizer().createVisitorCodeView(getContext());
         CardView cv = containerView.findViewById(R.id.container);
+        cv.removeAllViews();
         cv.addView(visitorCodeView);
         cv.setVisibility(View.VISIBLE);
+    }
+
+    private void removeVisitorCodeFromDedicatedView() {
+        CardView cv = containerView.findViewById(R.id.container);
+        cv.removeAllViews();
+        cv.setVisibility(View.GONE);
     }
 
     private void showToast(String message) {


### PR DESCRIPTION
During exploratory testing, some differences in the behavior of the Call Visualizer in the testing app caused small confusion. To prevent that from happening in the future I have removed the Toast message from appearing on CV engagement start and made the Visitor Code view to be hidden on CV engagement start
