### PR TITLE
Remove temporary maven repo used for internal Core SDK build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,6 @@ allprojects {
         flatDir {
             dirs '../libs'
         }
-        //TODO Needed to use not public new Core SDK release, remove before release
-        maven { url 'https://s01.oss.sonatype.org/content/repositories/comglia-1187' }
     }
 }
 


### PR DESCRIPTION
We don't need temporary repo anymore because we are going to release