### PR TITLE
Fixed no survey chat engagement end

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -1638,9 +1638,10 @@ internal class ChatController(
                 dialogController.showEngagementEndedDialog()
             }
 
-            shouldHandleEndedEngagement -> {
+            else -> {
                 // Close chat screen
                 Dependencies.getControllerFactory().destroyControllers()
+                destroyView()
             }
         }
     }


### PR DESCRIPTION
During converting from if statements to when statements it seems that one close condition got modified a little that changed the logic in case of no surveys and manual end engagement on android side.