### PR TITLE
Make visitor code number boxes fit screen width

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/CharCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/CharCodeView.kt
@@ -80,16 +80,20 @@ class CharCodeView @JvmOverloads constructor(
 
     private fun createCharSlotView(character: Char, runtimeTheme: UiTheme?, remoteTheme: VisitorCodeTheme?): TextView {
 
-        val charView = TextView(context, null, R.attr.visitorCodeStyle, R.style.Application_Glia_VisitorCode) // TODO: confirm this
+        val charView = TextView(context, null, R.attr.visitorCodeStyle, R.style.Application_Glia_VisitorCode)
         charView.isFocusable = false
         charView.text = character.toString()
-        charView.gravity = TEXT_ALIGNMENT_CENTER
+        charView.textAlignment = TEXT_ALIGNMENT_CENTER
         charView.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
 
         applyRuntimeTheme(runtimeTheme, charView)
         applyRemoteTheme(remoteTheme, charView)
 
-        val charViewLayout = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        val charViewLayout = LayoutParams(
+            WIDTH_NOT_SPECIFIED,
+            LayoutParams.WRAP_CONTENT,
+            USE_ALL_AVAILABLE_WIDTH
+        )
         charViewLayout.setMargins(
             charViewProps.horizonMargin,
             charViewProps.verticalMargin,
@@ -98,11 +102,7 @@ class CharCodeView @JvmOverloads constructor(
         )
         charView.layoutParams = charViewLayout
 
-        charView.setPadding(
-            charViewProps.horizonPadding,
-            charViewProps.verticalPadding,
-            charViewProps.horizonPadding,
-            charViewProps.verticalPadding
+        charView.setPadding(0, charViewProps.verticalPadding, 0, charViewProps.verticalPadding
         )
 
         return charView
@@ -143,6 +143,11 @@ class CharCodeView @JvmOverloads constructor(
 
         charView.applyLayerTheme(theme.numberSlotBackground)
         charView.applyTextTheme(theme.numberSlotText, withAlignment = false)
+    }
+
+    companion object {
+        private const val WIDTH_NOT_SPECIFIED = 0
+        private const val USE_ALL_AVAILABLE_WIDTH = 1f
     }
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -86,10 +86,13 @@ object Dialogs {
         context: Context,
         theme: UiTheme,
         view: VisitorCodeView,
+        horizontalInset: Int = 0,
         cancelable: Boolean = true
     ): AlertDialog {
         return MaterialAlertDialogBuilder(context)
             .setView(view)
+            .setBackgroundInsetStart(horizontalInset)
+            .setBackgroundInsetEnd(horizontalInset)
             .setCancelable(cancelable)
             .show()
             .also { setDialogBackground(it, theme.gliaChatBackgroundColor) }

--- a/widgetssdk/src/main/res/layout/visitor_code_view.xml
+++ b/widgetssdk/src/main/res/layout/visitor_code_view.xml
@@ -20,9 +20,11 @@
             android:id="@+id/success_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
             android:clipChildren="false"
-            android:clipToPadding="false">
+            android:clipToPadding="false"
+            android:paddingStart="@dimen/glia_large_x_large"
+            android:paddingEnd="@dimen/glia_large_x_large"
+            android:visibility="gone">
 
             <TextView
                 android:id="@+id/success_title_view"


### PR DESCRIPTION
[Bad accessibility compatibility for when text is set too big](https://glia.atlassian.net/browse/MOB-2252)

Changes overview:
- set `CharCodeView` width to `0` and weight to `1` to fit available width
- set start and end insets of the visitor code dialog to 0
- set `textAlignment` instead of `gravity` to align have number centered inside the box
- set start and end padding for the first and last digit box
