### PR TITLE
Fix Dialog Ttitle and Push Notification Permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-
     <application
         android:name=".Application"
         android:allowBackup="true"

--- a/app/src/main/java/com/glia/exampleapp/UnifiedUiConfigurationLoader.kt
+++ b/app/src/main/java/com/glia/exampleapp/UnifiedUiConfigurationLoader.kt
@@ -11,9 +11,7 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.MessageLengthLimitingLogger
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import java.io.BufferedReader
 
 private fun Context.rawRes(@RawRes resId: Int): String = resources.openRawResource(resId).use {
@@ -46,10 +44,8 @@ object UnifiedUiConfigurationLoader {
     @JvmOverloads
     @JvmStatic
     //No error handling mechanisms because this is only for testing purposes
-    fun fetchRemoteConfiguration(url: String? = null): String = runBlocking(Dispatchers.Main) {
-        withContext(Dispatchers.IO) {
-            ktorClient.get(url ?: defaultUrl).bodyAsText()
-        }
+    fun fetchRemoteConfiguration(url: String? = null): String = runBlocking {
+        ktorClient.get(url ?: defaultUrl).bodyAsText()
     }
 
     @JvmStatic

--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
         <activity

--- a/widgetssdk/src/main/res/layout/options_dialog.xml
+++ b/widgetssdk/src/main/res/layout/options_dialog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -20,7 +21,7 @@
 
     <TextView
         android:id="@+id/dialog_title_view"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_x_large"
         android:gravity="center"
@@ -28,7 +29,9 @@
         app:layout_constraintEnd_toStartOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginTop="@dimen/glia_x_large" />
+        app:layout_goneMarginTop="@dimen/glia_x_large"
+        tools:text="@string/glia_dialog_overlay_permissions_title"
+        tools:textSize="20sp" />
 
     <TextView
         android:id="@+id/dialog_message_view"

--- a/widgetssdk/src/main/res/layout/options_dialog_reversed.xml
+++ b/widgetssdk/src/main/res/layout/options_dialog_reversed.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.Guideline
@@ -20,7 +21,7 @@
 
     <TextView
         android:id="@+id/dialog_title_view"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_x_large"
         android:gravity="center"
@@ -28,7 +29,9 @@
         app:layout_constraintEnd_toStartOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginTop="@dimen/glia_x_large" />
+        app:layout_goneMarginTop="@dimen/glia_x_large"
+        tools:text="@string/glia_dialog_overlay_permissions_title"
+        tools:textSize="20sp" />
 
     <TextView
         android:id="@+id/dialog_message_view"

--- a/widgetssdk/src/main/res/layout/options_dialog_vertical.xml
+++ b/widgetssdk/src/main/res/layout/options_dialog_vertical.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -20,7 +21,7 @@
 
     <TextView
         android:id="@+id/dialog_title_view"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_x_large"
         android:gravity="center"
@@ -28,7 +29,9 @@
         app:layout_constraintEnd_toStartOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginTop="@dimen/glia_x_large" />
+        app:layout_goneMarginTop="@dimen/glia_x_large"
+        tools:text="@string/glia_dialog_overlay_permissions_title"
+        tools:textSize="20sp" />
 
     <TextView
         android:id="@+id/dialog_message_view"

--- a/widgetssdk/src/main/res/layout/options_dialog_vertical_reversed.xml
+++ b/widgetssdk/src/main/res/layout/options_dialog_vertical_reversed.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -20,7 +21,7 @@
 
     <TextView
         android:id="@+id/dialog_title_view"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_x_large"
         android:gravity="center"
@@ -28,7 +29,9 @@
         app:layout_constraintEnd_toStartOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginTop="@dimen/glia_x_large" />
+        app:layout_goneMarginTop="@dimen/glia_x_large"
+        tools:text="@string/glia_dialog_overlay_permissions_title"
+        tools:textSize="20sp" />
 
     <TextView
         android:id="@+id/dialog_message_view"


### PR DESCRIPTION
Fixed some minor bugs I found during work on big tasks. These are not critical, and not so big to make different PRs for each.

- Moved `android.permission.POST_NOTIFICATIONS` permission declaration from testing app `Manifest` to widget module `Manifest`. After this change, integrators will no longer need to manually declare this permission.

- Modified dialog title for some views to make it responsive. This fixes the bug when the title goes out of its paddings when a title text is long.

- Fixed UnifiedUiConfigurationLoader to make it not block the main thread when loading remote configurations.

**Additional info:**
Will merge after release, that’s the only reason I made it draft
