### PR TITLE
Update "Deploy to bitrise.io" step

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -97,7 +97,7 @@ workflows:
           inputs:
             - custom_id: $BROWSERSTACK_APP_ID
           title: Upload APP to BrowserStack
-      - deploy-to-bitrise-io@1:
+      - deploy-to-bitrise-io@2.2:
           inputs:
             - notify_email_list: $BUILD_EMAILS
       - cache-push@2: { }
@@ -149,7 +149,7 @@ workflows:
             - module: $EXAMPLE_APP_MODULE
             - variant: $INTEGRATOR_VARIANT
           title: Unit Test for APP
-      - deploy-to-bitrise-io@1:
+      - deploy-to-bitrise-io@2.2:
           inputs:
             - notify_email_list: $BUILD_EMAILS
       - cache-push@2: { }
@@ -198,7 +198,7 @@ workflows:
           inputs:
             - custom_id: $BROWSERSTACK_APP_ID
           title: Upload APP to BrowserStack
-      - deploy-to-bitrise-io@1:
+      - deploy-to-bitrise-io@2.2:
           inputs:
             - notify_email_list: $BUILD_EMAILS
       - slack@3:


### PR DESCRIPTION
[MOB-2022](https://glia.atlassian.net/browse/MOB-2022)

The aim of this PR is to get rid of the "You're using an outdated version of the "Deploy to bitrise.io" Step." warning to be able to check tests summary in Bitrise.


<img width="760" alt="Screenshot 2023-06-07 at 17 45 46" src="https://github.com/salemove/android-sdk-widgets/assets/57521863/c2f482b8-09d5-4f45-bec1-32e590bc32cb">


[MOB-2022]: https://glia.atlassian.net/browse/MOB-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ