### PR TITLE
Fixed the documentation for the CustomCardAdapter class

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/ExampleCustomCardAdapter.java
+++ b/app/src/main/java/com/glia/exampleapp/ExampleCustomCardAdapter.java
@@ -66,7 +66,7 @@ public class ExampleCustomCardAdapter extends CustomCardAdapter {
             return message.getMetadata()
                     .optBoolean(NativeViewViewHolder.SHOW_BUTTON_KEY, false);
         }
-        return super.shouldShowCard(message, viewType);
+        return super.isInteractable(message, viewType);
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/CustomCardAdapter.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/CustomCardAdapter.java
@@ -98,8 +98,8 @@ public abstract class CustomCardAdapter {
      * @param message a chat message with metadata.
      * @param viewType the view type of the new view.
      *                 The type is provided by {@link #getItemViewType(ChatMessage)}.
-     * @return a boolean indicating if the custom card view should be shown when
-     *         the card is interactable and an option is selected.
+     * @return a boolean indicating if the input field should be locked
+     *         until a visitor selects an option from the card.
      *         The default implementation returns {@code true}.
      */
     public boolean isInteractable(ChatMessage message, int viewType) {


### PR DESCRIPTION
The method `CustomCardAdapter.isInteractable()` had the wrong description.