### PR TITLE
Made the text entry field expand in the presence of long text

### DIFF
--- a/widgetssdk/src/main/res/layout/chat_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_view.xml
@@ -111,7 +111,7 @@
             android:id="@+id/chat_edit_text"
             style="@style/Application.Glia.Chat.Edittext"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:hint="@string/glia_chat_enter_message"
             android:importantForAutofill="no"
@@ -120,6 +120,8 @@
             android:paddingStart="@dimen/glia_large"
             android:textColor="?attr/gliaBaseDarkColor"
             android:textColorHint="?attr/gliaBaseNormalColor"
+            android:maxLines="4"
+            android:maxLength="10000"
             tools:ignore="RtlSymmetry"
             tools:textColor="@color/glia_black_color" />
 

--- a/widgetssdk/src/main/res/values/dimens.xml
+++ b/widgetssdk/src/main/res/values/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="glia_chat_new_messages_bottom_edge_radius">17dp</dimen>
     <dimen name="glia_chat_new_messages_card_corner_radius">21dp</dimen>
     <dimen name="glia_chat_new_messages_elevation">2dp</dimen>
-    <dimen name="glia_chat_edit_text_min_height">48dp</dimen>
+    <dimen name="glia_chat_edit_text_min_height">56dp</dimen>
 
     <dimen name="glia_chat_attachment_corner_radius">4dp</dimen>
     <dimen name="glia_chat_attachment_stroke_width">1dp</dimen>


### PR DESCRIPTION
Made the chat text field expandable for long text. The max lines are 4.

[MOB-2335](https://glia.atlassian.net/browse/MOB-2335)

<img src="https://github.com/salemove/android-sdk-widgets/assets/79906470/1c3b1662-e1c4-4742-b356-0933fb4f9bda" width="300">

[MOB-2335]: https://glia.atlassian.net/browse/MOB-2335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ