### PR TITLE
Fix sending custom card response

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -166,7 +166,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
             }
         }
     private val onCustomCardResponse =
-        OnCustomCardResponse { messageId: String, text: String?, value: String? ->
+        OnCustomCardResponse { messageId: String, text: String, value: String ->
             controller?.sendCustomCardResponse(messageId, text, value)
         }
     private val dataObserver: AdapterDataObserver = object : AdapterDataObserver() {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
@@ -208,7 +208,7 @@ internal class ChatAdapter(
             }
             is SystemChatItem -> (holder as SystemMessageViewHolder).bind(chatItem.message)
             is CustomCardItem -> {
-                (holder as CustomCardViewHolder).bind(chatItem.message) { text: String?, value: String? ->
+                (holder as CustomCardViewHolder).bind(chatItem.message) { text: String, value: String ->
                     onCustomCardResponse.onCustomCardResponse(chatItem.getId(), text, value)
                 }
             }
@@ -245,7 +245,7 @@ internal class ChatAdapter(
     }
 
     fun interface OnCustomCardResponse {
-        fun onCustomCardResponse(messageId: String, text: String?, value: String?)
+        fun onCustomCardResponse(messageId: String, text: String, value: String)
     }
 
     companion object {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
@@ -99,18 +99,9 @@ public class GliaChatRepository {
         );
     }
 
-    public void sendResponse(String cardMessageId, String text, String value, Listener listener) {
+    public void sendResponse(SingleChoiceAttachment attachment, RequestCallback<VisitorMessage> callback) {
         gliaCore.getCurrentEngagement().ifPresent(engagement ->
-                engagement.getChat().sendResponse(cardMessageId, text, value, (result, ex) -> {
-                    if (listener != null) {
-                        if (ex != null) {
-                            listener.error(ex);
-                        } else {
-                            listener.messageSent(result.getVisitorResponseMessage());
-                            listener.onCardMessageUpdated(result.getCardMessage());
-                        }
-                    }
-                })
+                engagement.getChat().sendMessage(attachment, callback)
         );
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaSendMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaSendMessageUseCase.kt
@@ -1,6 +1,7 @@
 package com.glia.widgets.chat.domain
 
 import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.OperatorMessage
 import com.glia.androidsdk.chat.SingleChoiceAttachment
@@ -23,7 +24,7 @@ class GliaSendMessageUseCase(
 ) {
     interface Listener {
         fun messageSent(message: VisitorMessage?)
-        fun onCardMessageUpdated(message: OperatorMessage)
+        fun onCardMessageUpdated(message: ChatMessage)
         fun onMessageValidated()
         fun errorOperatorNotOnline(message: String)
         fun errorMessageInvalid()
@@ -89,8 +90,34 @@ class GliaSendMessageUseCase(
         chatRepository.sendMessageSingleChoice(singleChoiceAttachment, listener)
     }
 
-    fun execute(cardMessageId: String?, text: String?, value: String?, listener: Listener?) {
-        chatRepository.sendResponse(cardMessageId, text, value, listener)
+    fun execute(chatMessage: ChatMessage?, text: String, value: String, listener: Listener?) {
+        val attachment = SingleChoiceAttachment.from(value, text)
+        chatRepository.sendResponse(attachment) { result: VisitorMessage?, ex: GliaException? ->
+            listener?.let {
+                if (ex != null) {
+                    listener.error(ex)
+                }
+                if (result != null) {
+                    listener.messageSent(result)
+
+                    chatMessage?.let {
+                        it as? OperatorMessage
+                    }?.let {
+                        listener.onCardMessageUpdated(
+                            ChatMessage(
+                                it.id,
+                                it.content,
+                                it.timestamp,
+                                ChatMessage.Sender(it.senderType, it.operatorHref, it.operatorId),
+                                it.deliveredAt,
+                                attachment,
+                                it.metadata
+                            )
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private val isOperatorOnline: Boolean


### PR DESCRIPTION
Used the `sendMessage` method with `SingleChoiceAttachment` for sending the custom message response instead of the deprecated method.
Also refactored the sending custom card response methods.

This PR needs the additional release of the Core SDK, because it uses a method that is currently not available.

[MOB-2289](https://glia.atlassian.net/browse/MOB-2289)

[MOB-2289]: https://glia.atlassian.net/browse/MOB-2289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ