### PR TITLE
Close keyboard when chat is scrolled

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -164,6 +164,13 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                 super.onScrolled(recyclerView, dx, dy)
                 controller?.onRecyclerviewPositionChanged(!recyclerView.canScrollVertically(1))
             }
+
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+
+                // hide the keyboard on chat scroll
+                insetsController?.hideKeyboard()
+            }
         }
     private val onCustomCardResponse =
         OnCustomCardResponse { messageId: String, text: String?, value: String? ->


### PR DESCRIPTION
Close the keyboard when the chat is scrolled.
To align platforms, scrolling needs to close the keyboard for better visibility of the transcript.

[MOB-2449](https://glia.atlassian.net/browse/MOB-2449)


[MOB-2449]: https://glia.atlassian.net/browse/MOB-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ