### PR TITLE
Fix crash on restoring CV video engagement from bubble

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementRepository.java
@@ -31,6 +31,10 @@ public class GliaEngagementRepository {
     }
 
     public void unregisterEngagementEndListener(Runnable engagementEnded) {
+        // Engagement#off(Event, Callback) does not support `null` callback
+        if (engagementEnded == null) {
+            return;
+        }
         gliaCore.getCurrentEngagement().ifPresent(
                 engagement -> engagement.off(Engagement.Events.END, engagementEnded));
     }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2455

**Additional info:**
This crash started happening after upgrade of the Core SDK. The cause of the crash is annotation on method argument (@NotNull) for the callback.

**Screenshots:**
