### PR TITLE
Make CI PR script to create new branch from development

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -37,22 +37,24 @@ workflows:
             set -x
 
             NEW_VERSION=`./gradlew -q printCurrentVersionName`
-            BRANCH_NAME="project-version-increment/${NEW_VERSION}"
+            NEW_BRANCH_NAME="project-version-increment/${NEW_VERSION}"
+            BASE_BRANCH_NAME="development"
             MESSAGE="Increment project version to ${NEW_VERSION}"
 
-            git checkout -b $BRANCH_NAME
+            git fetch origin $BASE_BRANCH_NAME
+            git checkout -b $NEW_BRANCH_NAME origin/$BASE_BRANCH_NAME
             # git add -u stages modifications and deletions, without new files
             # added it to prevent CHANGELOG.md from being included in the PR
             git add -u
             git commit -m "$MESSAGE"
-            git push origin "$BRANCH_NAME":"$BRANCH_NAME"
+            git push origin "$NEW_BRANCH_NAME":"$NEW_BRANCH_NAME"
 
             PULL_REQUEST_NUMBER=$(curl \
               -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer $GITHUB_API_TOKEN" \
               https://api.github.com/repos/salemove/android-sdk-widgets/pulls \
-              -d "{\"title\":\"${MESSAGE}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"development\"}" | jq --raw-output '.number')
+              -d "{\"title\":\"${MESSAGE}\",\"head\":\"${NEW_BRANCH_NAME}\",\"base\":\"development\"}" | jq --raw-output '.number')
 
             curl \
               -X POST \


### PR DESCRIPTION
The previous change made it so that it would merge the PR into the development branch however the branch itself was created from the master and not development. As a result, there were some strange additional commits that should not be there.
