### PR TITLE
Create logic to differentiate various persistent button actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,49 +1,49 @@
 buildscript {
-    ext {
-        kotlin_version = '1.8.20'
-    }
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+  ext {
+    kotlin_version = '1.8.20'
+  }
+  repositories {
+    google()
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:8.0.0'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
 }
 
 plugins {
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    id("org.jetbrains.kotlin.android") version "$kotlin_version" apply false
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
+  id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+  id("org.jetbrains.kotlin.android") version "$kotlin_version" apply false
+  id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
 }
 
 allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        flatDir {
-            dirs '../libs'
-        }
+  repositories {
+    google()
+    mavenCentral()
+    flatDir {
+      dirs '../libs'
     }
+  }
 }
 
 subprojects {
-    apply plugin: 'org.jlleitschuh.gradle.ktlint'
+  apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
-    repositories {
-        mavenCentral()
-    }
+  repositories {
+    mavenCentral()
+  }
 
-    ktlint {
-        outputToConsole.set(true)
-        debug.set(true)
-        android.set(true)
-    }
+  ktlint {
+    outputToConsole.set(true)
+    debug.set(true)
+    android.set(true)
+  }
 }
 
 task clean(type: Delete) {
-    delete rootProject.buildDir
+  delete rootProject.buildDir
 }
 
 apply from: "${rootDir}/scripts/publish-settings.gradle"
@@ -52,31 +52,32 @@ apply from: "${rootDir}/scripts/version-updater.gradle"
 ext {
 //    gliaSdkVersion = 'X.X.X' // this property is now attached dynamically during gradle sync
 
-    appCompatVersion = '1.3.1'
-    materialVersion = '1.4.0'
-    constraintLayoutVersion = '2.1.3'
-    navVersion = '2.3.5'
-    lifecycle_process = '2.3.1'
-    rxAndroid = '2.1.0'
-    rxJava = '2.2.6'
-    gson = '2.8.6'
-    preferenceVersion = '1.1.1'
-    picassoVersion = '2.8'
-    lottieVersion = '5.2.0'
-    firebaseVersion = '31.0.2'
-    audioswitch = '1.1.8'
+  appCompatVersion = '1.3.1'
+  materialVersion = '1.4.0'
+  constraintLayoutVersion = '2.1.3'
+  navVersion = '2.3.5'
+  lifecycle_process = '2.3.1'
+  rxAndroid = '2.1.0'
+  rxJava = '2.2.6'
+  gson = '2.8.6'
+  preferenceVersion = '1.1.1'
+  picassoVersion = '2.8'
+  lottieVersion = '5.2.0'
+  firebaseVersion = '31.0.2'
+  audioswitch = '1.1.8'
 
-    leakCanaryVersion = '2.6'
-    espressoVersion = '3.5.1'
-    junitVersion = '4.13.2'
-    testLibraryVersion = '1.1.5'
-    androidXTestVersion = '1.1.5'
-    mockitoVersion = '5.1.1'
-    mockitoKotlinVersion = '4.1.0'
-    mockitoAndroidTestVersion = '4.3.1'
-    archCoreVersion = '2.2.0'
-    testRulesVersion = '1.5.0'
+  leakCanaryVersion = '2.6'
+  espressoVersion = '3.5.1'
+  junitVersion = '4.13.2'
+  testLibraryVersion = '1.1.5'
+  androidXTestVersion = '1.1.5'
+  mockitoVersion = '5.1.1'
+  mockitoKotlinVersion = '4.1.0'
+  mockitoAndroidTestVersion = '4.3.1'
+  archCoreVersion = '2.2.0'
+  testRulesVersion = '1.5.0'
+  robolectricVersion = '4.9'
 
-    //kotlin
-    coreKtxVersion = '1.8.0'
+  //kotlin
+  coreKtxVersion = '1.8.0'
 }

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -3,99 +3,100 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.3"
-    defaultPublishConfig "debug"
-    defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 31
-        versionCode widgetsVersionCode
-        versionName widgetsVersionName
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles "consumer-rules.pro"
-    }
+  compileSdkVersion 31
+  buildToolsVersion "30.0.3"
+  defaultPublishConfig "debug"
+  defaultConfig {
+    minSdkVersion 24
+    targetSdkVersion 31
+    versionCode widgetsVersionCode
+    versionName widgetsVersionName
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    consumerProguardFiles "consumer-rules.pro"
+  }
 
-    buildTypes {
-        all {
-            buildConfigField("String", "GLIA_CORE_SDK_VERSION", "\"$gliaSdkVersion\"")
-            buildConfigField("String", "GLIA_WIDGETS_SDK_VERSION", "\"$defaultConfig.versionName\"")
-        }
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
+  buildTypes {
+    all {
+      buildConfigField("String", "GLIA_CORE_SDK_VERSION", "\"$gliaSdkVersion\"")
+      buildConfigField("String", "GLIA_WIDGETS_SDK_VERSION", "\"$defaultConfig.versionName\"")
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
-    lint {
-        disable 'WrongLayoutName',
-                'LayoutFileNameMatchesClass',
-                'MatchingViewId',
-                'RawDimen',
-                'WrongAnnotationOrder',
-                'ColorCasing',
-                'WrongViewIdFormat',
-                'HardcodedText'
-    }
+  }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
+  }
+  kotlinOptions {
+    jvmTarget = "11"
+  }
+  lint {
+    disable 'WrongLayoutName',
+      'LayoutFileNameMatchesClass',
+      'MatchingViewId',
+      'RawDimen',
+      'WrongAnnotationOrder',
+      'ColorCasing',
+      'WrongViewIdFormat',
+      'HardcodedText'
+  }
 
-    buildFeatures {
-        viewBinding true
-        buildConfig true
-    }
-    namespace 'com.glia.widgets'
+  buildFeatures {
+    viewBinding true
+    buildConfig true
+  }
+  namespace 'com.glia.widgets'
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "com.google.android.material:material:$materialVersion"
-    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
-    implementation "androidx.lifecycle:lifecycle-process:$lifecycle_process"
-    implementation "com.squareup.picasso:picasso:$picassoVersion"
+  implementation "androidx.appcompat:appcompat:$appCompatVersion"
+  implementation "com.google.android.material:material:$materialVersion"
+  implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
+  implementation "androidx.lifecycle:lifecycle-process:$lifecycle_process"
+  implementation "com.squareup.picasso:picasso:$picassoVersion"
 
-    // Used for audio and video permissions by CallActivity
-    implementation "io.reactivex.rxjava2:rxandroid:$rxAndroid"
-    implementation "io.reactivex.rxjava2:rxjava:$rxJava"
+  // Used for audio and video permissions by CallActivity
+  implementation "io.reactivex.rxjava2:rxandroid:$rxAndroid"
+  implementation "io.reactivex.rxjava2:rxjava:$rxJava"
 
-    // removed because becomes slow on Android 11. They say it is fixed, but I still have the issue.
-    // https://square.github.io/leakcanary/changelog/
-    // debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
+  // removed because becomes slow on Android 11. They say it is fixed, but I still have the issue.
+  // https://square.github.io/leakcanary/changelog/
+  // debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
 
-    api "com.glia:android-sdk:$gliaSdkVersion"
-    // Glia sdk aar
-    // implementation(name: "glia-core-sdk-$gliaSdkVersion", ext: 'aar')
+  api "com.glia:android-sdk:$gliaSdkVersion"
+  // Glia sdk aar
+  // implementation(name: "glia-core-sdk-$gliaSdkVersion", ext: 'aar')
 //    api "com.glia:android-sdk:0.26.6-SNAPSHOT" // Used when testing local Core SDK snapshot releases
 
-    implementation "com.twilio:audioswitch:$audioswitch"
-    implementation "com.airbnb.android:lottie:$lottieVersion"
-    implementation "com.google.code.gson:gson:$gson"
-    implementation "androidx.core:core-ktx:$coreKtxVersion"
+  implementation "com.twilio:audioswitch:$audioswitch"
+  implementation "com.airbnb.android:lottie:$lottieVersion"
+  implementation "com.google.code.gson:gson:$gson"
+  implementation "androidx.core:core-ktx:$coreKtxVersion"
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
-    testImplementation "androidx.arch.core:core-testing:$archCoreVersion"
-    androidTestImplementation "org.mockito:mockito-android:$mockitoAndroidTestVersion"
-    androidTestImplementation "androidx.test.ext:junit:$androidXTestVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-    androidTestImplementation "androidx.test:rules:$testRulesVersion"
+  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+  testImplementation "androidx.arch.core:core-testing:$archCoreVersion"
+  testImplementation "org.robolectric:robolectric:$robolectricVersion"
+  androidTestImplementation "org.mockito:mockito-android:$mockitoAndroidTestVersion"
+  androidTestImplementation "androidx.test.ext:junit:$androidXTestVersion"
+  androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
+  androidTestImplementation "androidx.test:rules:$testRulesVersion"
 
-    // Test dependencies to Android native libraries
-    // To prevent unit tests firing errors like 'Method length in org.json.JSONObject not mocked'
-    testImplementation "org.json:json:20220924"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+  // Test dependencies to Android native libraries
+  // To prevent unit tests firing errors like 'Method length in org.json.JSONObject not mocked'
+  testImplementation "org.json:json:20220924"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
 
 ext {
-    PUBLISH_GROUP_ID = 'com.glia'
-    PUBLISH_VERSION = android.defaultConfig.versionName
-    PUBLISH_ARTIFACT_ID = 'android-widgets'
-    PUBLISH_MODULE_DESCRIPTION = 'Glia Android Widgets SDK'
-    PUBLISH_ORGANISATION_NAME = 'Glia'
-    PUBLISH_ORGANISATION_URL = 'https://www.glia.com/'
+  PUBLISH_GROUP_ID = 'com.glia'
+  PUBLISH_VERSION = android.defaultConfig.versionName
+  PUBLISH_ARTIFACT_ID = 'android-widgets'
+  PUBLISH_MODULE_DESCRIPTION = 'Glia Android Widgets SDK'
+  PUBLISH_ORGANISATION_NAME = 'Glia'
+  PUBLISH_ORGANISATION_URL = 'https://www.glia.com/'
 }
 
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -210,6 +210,10 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
         )
     }
 
+    private val onGvaButtonsClickListener = ChatAdapter.OnGvaButtonsClickListener {
+        controller?.onGvaButtonClicked(it)
+    }
+
     init {
         initConfigurations()
         bindViews()
@@ -709,6 +713,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
             this,
             this,
             onCustomCardResponse,
+            onGvaButtonsClickListener,
             GliaWidgets.getCustomCardAdapter(),
             Dependencies.getUseCaseFactory().createGetImageFileFromCacheUseCase(),
             Dependencies.getUseCaseFactory().createGetImageFileFromDownloadsUseCase(),

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
@@ -21,6 +21,7 @@ import com.glia.widgets.chat.adapter.holder.imageattachment.ImageAttachmentViewH
 import com.glia.widgets.chat.adapter.holder.imageattachment.OperatorImageAttachmentViewHolder
 import com.glia.widgets.chat.adapter.holder.imageattachment.VisitorImageAttachmentViewHolder
 import com.glia.widgets.chat.model.Gva
+import com.glia.widgets.chat.model.GvaButton
 import com.glia.widgets.chat.model.history.ChatItem
 import com.glia.widgets.chat.model.history.CustomCardItem
 import com.glia.widgets.chat.model.history.GvaGalleryCards
@@ -51,6 +52,7 @@ internal class ChatAdapter(
     private val onFileItemClickListener: OnFileItemClickListener,
     private val onImageItemClickListener: OnImageItemClickListener,
     private val onCustomCardResponse: OnCustomCardResponse,
+    private val onGvaButtonsClickListener: OnGvaButtonsClickListener,
     private val customCardAdapter: CustomCardAdapter?,
     private val getImageFileFromCacheUseCase: GetImageFileFromCacheUseCase,
     private val getImageFileFromDownloadsUseCase: GetImageFileFromDownloadsUseCase,
@@ -163,18 +165,6 @@ internal class ChatAdapter(
 
 //            TODO should be changed to appropriate ViewHolder later - MOB 2371
             GVA_PERSISTENT_BUTTONS_TYPE -> {
-                SystemMessageViewHolder(
-                    ChatReceiveMessageContentBinding.inflate(
-                        inflater,
-                        parent,
-                        false
-                    ),
-                    uiTheme
-                )
-            }
-
-//            TODO should be changed to appropriate ViewHolder later - MOB 2396
-            GVA_QUICK_REPLIES_TYPE -> {
                 SystemMessageViewHolder(
                     ChatReceiveMessageContentBinding.inflate(
                         inflater,
@@ -322,6 +312,10 @@ internal class ChatAdapter(
         fun onCustomCardResponse(messageId: String, text: String, value: String)
     }
 
+    fun interface OnGvaButtonsClickListener {
+        fun onGvaButtonClicked(gvaButton: GvaButton)
+    }
+
     companion object {
         const val OPERATOR_STATUS_VIEW_TYPE = 0
         const val VISITOR_MESSAGE_TYPE = 1
@@ -337,11 +331,10 @@ internal class ChatAdapter(
         //GVA Types
         const val GVA_RESPONSE_TEXT_TYPE = 10
         const val GVA_PERSISTENT_BUTTONS_TYPE = 11
-        const val GVA_QUICK_REPLIES_TYPE = 12
-        const val GVA_GALLERY_CARDS_TYPE = 13
+        const val GVA_GALLERY_CARDS_TYPE = 12
 
         //Custom Card
-        const val CUSTOM_CARD_TYPE = 14 // Should be the last type with the highest value
+        const val CUSTOM_CARD_TYPE = 13 // Should be the last type with the highest value
     }
 
     @IntDef(
@@ -358,7 +351,6 @@ internal class ChatAdapter(
         CUSTOM_CARD_TYPE,
         GVA_RESPONSE_TEXT_TYPE,
         GVA_PERSISTENT_BUTTONS_TYPE,
-        GVA_QUICK_REPLIES_TYPE,
         GVA_GALLERY_CARDS_TYPE
     )
     @Retention(AnnotationRetention.SOURCE)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -43,10 +43,12 @@ import com.glia.widgets.chat.domain.IsShowSendButtonUseCase
 import com.glia.widgets.chat.domain.PreEngagementMessageUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
+import com.glia.widgets.chat.domain.gva.DetermineGvaButtonTypeUseCase
 import com.glia.widgets.chat.domain.gva.IsGvaUseCase
 import com.glia.widgets.chat.domain.gva.MapGvaUseCase
 import com.glia.widgets.chat.model.ChatInputMode
 import com.glia.widgets.chat.model.ChatState
+import com.glia.widgets.chat.model.Gva
 import com.glia.widgets.chat.model.GvaButton
 import com.glia.widgets.chat.model.history.ChatItem
 import com.glia.widgets.chat.model.history.CustomCardItem
@@ -178,7 +180,8 @@ internal class ChatController(
     private val isFileReadyForPreviewUseCase: IsFileReadyForPreviewUseCase,
     private val acceptMediaUpgradeOfferUseCase: AcceptMediaUpgradeOfferUseCase,
     private val isGvaUseCase: IsGvaUseCase,
-    private val mapGvaUseCase: MapGvaUseCase
+    private val mapGvaUseCase: MapGvaUseCase,
+    private val determineGvaButtonTypeUseCase: DetermineGvaButtonTypeUseCase
 ) : GliaOnEngagementUseCase.Listener, GliaOnEngagementEndUseCase.Listener, OnSurveyListener {
     private var backClickedListener: ChatView.OnBackClickedListener? = null
     private var viewCallback: ChatViewCallback? = null
@@ -1713,5 +1716,15 @@ internal class ChatController(
 
     fun isCallVisualizerOngoing(): Boolean {
         return isCallVisualizerUseCase()
+    }
+
+    fun onGvaButtonClicked(button: GvaButton) {
+        when (determineGvaButtonTypeUseCase(button)) {
+            Gva.ButtonType.BroadcastEvent -> TODO("will be implemented in next tasks")
+            is Gva.ButtonType.Email -> TODO("will be implemented in next tasks")
+            is Gva.ButtonType.Phone -> TODO("will be implemented in next tasks")
+            is Gva.ButtonType.PostBack -> TODO("will be implemented in next tasks")
+            is Gva.ButtonType.Url -> TODO("will be implemented in next tasks")
+        }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/gva/DetermineGvaButtonTypeUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/gva/DetermineGvaButtonTypeUseCase.kt
@@ -1,0 +1,16 @@
+package com.glia.widgets.chat.domain.gva
+
+import com.glia.widgets.chat.model.Gva
+import com.glia.widgets.chat.model.GvaButton
+
+internal const val PHONE_SCHEME = "tel"
+internal const val EMAIL_SCHEME = "mailto"
+
+internal class DetermineGvaButtonTypeUseCase(private val determineGvaUrlTypeUseCase: DetermineGvaUrlTypeUseCase) {
+
+    operator fun invoke(button: GvaButton): Gva.ButtonType = when {
+        !button.destinationPbBroadcastEvent.isNullOrBlank() -> Gva.ButtonType.BroadcastEvent
+        button.url.isNullOrBlank() -> Gva.ButtonType.PostBack(button.toResponse())
+        else -> determineGvaUrlTypeUseCase(button.url)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/gva/DetermineGvaUrlTypeUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/gva/DetermineGvaUrlTypeUseCase.kt
@@ -1,0 +1,16 @@
+package com.glia.widgets.chat.domain.gva
+
+import android.net.Uri
+import com.glia.widgets.chat.model.Gva
+
+internal class DetermineGvaUrlTypeUseCase {
+
+    operator fun invoke(url: String): Gva.ButtonType {
+        val uri = Uri.parse(url)
+        return when (uri.scheme) {
+            PHONE_SCHEME -> Gva.ButtonType.Phone(uri)
+            EMAIL_SCHEME -> Gva.ButtonType.Email(uri)
+            else -> Gva.ButtonType.Url(uri)
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/GvaBaseTypes.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/GvaBaseTypes.kt
@@ -1,6 +1,8 @@
 package com.glia.widgets.chat.model
 
+import android.net.Uri
 import androidx.annotation.StringDef
+import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.google.gson.annotations.SerializedName
 
 internal object Gva {
@@ -32,6 +34,14 @@ internal object Gva {
             const val BLANK = "blank"
         }
     }
+
+    sealed interface ButtonType {
+        object BroadcastEvent : ButtonType
+        data class PostBack(val singleChoiceAttachment: SingleChoiceAttachment) : ButtonType
+        data class Phone(val uri: Uri) : ButtonType
+        data class Email(val uri: Uri) : ButtonType
+        data class Url(val uri: Uri) : ButtonType
+    }
 }
 
 internal data class GvaButton(
@@ -49,13 +59,7 @@ internal data class GvaButton(
     @SerializedName("transferPhoneNumber")
     val transferPhoneNumber: String? = null
 ) {
-    val isPostBack: Boolean
-        get() = url.isNullOrBlank()
-
-    val isBroadCastEvent: Boolean
-        get() = !destinationPbBroadcastEvent.isNullOrBlank()
-
-//    fun toResponse(): SingleChoiceAttachment = SingleChoiceAttachment.from(text, value) TODO should be available with core sdk's next release.
+    fun toResponse(): SingleChoiceAttachment = SingleChoiceAttachment.from(text, value)
 }
 
 internal data class GvaGalleryCard(

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -138,7 +138,8 @@ public class ControllerFactory {
                 useCaseFactory.createIsFileReadyForPreviewUseCase(),
                 useCaseFactory.createAcceptMediaUpgradeOfferUseCase(),
                 useCaseFactory.createIsGvaUseCase(),
-                useCaseFactory.createMapGvaUseCase()
+                useCaseFactory.createMapGvaUseCase(),
+                useCaseFactory.createDetermineGvaButtonTypeUseCase()
             );
         } else {
             Logger.d(TAG, "retained chat controller");

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -27,6 +27,8 @@ import com.glia.widgets.chat.domain.IsShowSendButtonUseCase;
 import com.glia.widgets.chat.domain.PreEngagementMessageUseCase;
 import com.glia.widgets.chat.domain.SiteInfoUseCase;
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase;
+import com.glia.widgets.chat.domain.gva.DetermineGvaButtonTypeUseCase;
+import com.glia.widgets.chat.domain.gva.DetermineGvaUrlTypeUseCase;
 import com.glia.widgets.chat.domain.gva.GetGvaTypeUseCase;
 import com.glia.widgets.chat.domain.gva.IsGvaUseCase;
 import com.glia.widgets.chat.domain.gva.MapGvaGvaGalleryCardsUseCase;
@@ -890,6 +892,16 @@ public class UseCaseFactory {
             createMapGvaGvaQuickRepliesUseCase(),
             createMapGvaGvaGalleryCardsUseCase()
         );
+    }
+
+    @NonNull
+    public DetermineGvaUrlTypeUseCase createDetermineGvaUrlTypeUseCase() {
+        return new DetermineGvaUrlTypeUseCase();
+    }
+
+    @NonNull
+    public DetermineGvaButtonTypeUseCase createDetermineGvaButtonTypeUseCase() {
+        return new DetermineGvaButtonTypeUseCase(createDetermineGvaUrlTypeUseCase());
     }
 
     public void resetState() {

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -18,6 +18,7 @@ import com.glia.widgets.chat.domain.IsShowSendButtonUseCase
 import com.glia.widgets.chat.domain.PreEngagementMessageUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
+import com.glia.widgets.chat.domain.gva.DetermineGvaButtonTypeUseCase
 import com.glia.widgets.chat.domain.gva.IsGvaUseCase
 import com.glia.widgets.chat.domain.gva.MapGvaUseCase
 import com.glia.widgets.chat.model.history.ChatItem
@@ -127,6 +128,7 @@ class ChatControllerTest {
     private lateinit var acceptMediaUpgradeOfferUseCase: AcceptMediaUpgradeOfferUseCase
     private lateinit var isGvaUseCase: IsGvaUseCase
     private lateinit var mapGvaUseCase: MapGvaUseCase
+    private lateinit var determineGvaButtonTypeUseCase: DetermineGvaButtonTypeUseCase
 
     private lateinit var chatController: ChatController
 
@@ -186,6 +188,7 @@ class ChatControllerTest {
         acceptMediaUpgradeOfferUseCase = mock()
         isGvaUseCase = mock()
         mapGvaUseCase = mock()
+        determineGvaButtonTypeUseCase = mock()
 
         chatController = ChatController(
             chatViewCallback = chatViewCallback,
@@ -241,7 +244,8 @@ class ChatControllerTest {
             isFileReadyForPreviewUseCase = isFileReadyForPreviewUseCase,
             acceptMediaUpgradeOfferUseCase = acceptMediaUpgradeOfferUseCase,
             isGvaUseCase = isGvaUseCase,
-            mapGvaUseCase = mapGvaUseCase
+            mapGvaUseCase = mapGvaUseCase,
+            determineGvaButtonTypeUseCase = determineGvaButtonTypeUseCase
         )
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/gva/DetermineGvaButtonTypeUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/gva/DetermineGvaButtonTypeUseCaseTest.kt
@@ -1,0 +1,61 @@
+package com.glia.widgets.chat.domain.gva
+
+import com.glia.androidsdk.chat.SingleChoiceAttachment
+import com.glia.widgets.chat.model.Gva
+import com.glia.widgets.chat.model.GvaButton
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DetermineGvaButtonTypeUseCaseTest {
+    private lateinit var useCase: DetermineGvaButtonTypeUseCase
+    private lateinit var determineGvaUrlTypeUseCase: DetermineGvaUrlTypeUseCase
+    private lateinit var gvaButton: GvaButton
+
+    @Before
+    fun setUp() {
+        determineGvaUrlTypeUseCase = mock()
+        useCase = DetermineGvaButtonTypeUseCase(determineGvaUrlTypeUseCase)
+        gvaButton = mock()
+    }
+
+    @Test
+    fun `invoke returns Broadcast type when destinationPbBroadcastEvent is defined`() {
+        whenever(gvaButton.destinationPbBroadcastEvent) doReturn "stub!"
+
+        val buttonType = useCase(gvaButton)
+        assertTrue(buttonType is Gva.ButtonType.BroadcastEvent)
+    }
+
+    @Test
+    fun `invoke returns PostBack type when url is null or empty`() {
+        whenever(gvaButton.url) doReturn null
+        val value = "value"
+        val text = "text"
+        whenever(gvaButton.toResponse()) doReturn SingleChoiceAttachment.from(value, text)
+
+        val buttonType = useCase(gvaButton)
+        assertTrue(buttonType is Gva.ButtonType.PostBack)
+        (buttonType as Gva.ButtonType.PostBack).apply {
+            assertEquals(value, singleChoiceAttachment.selectedOption)
+            assertEquals(text, singleChoiceAttachment.selectedOptionText)
+        }
+    }
+
+    @Test
+    fun `invoke returns Url type when url is defined and not empty`() {
+        whenever(gvaButton.url) doReturn "asasasasa"
+        whenever(determineGvaUrlTypeUseCase(any())) doReturn Gva.ButtonType.Url(mock())
+
+        val buttonType = useCase(gvaButton)
+        assertTrue(buttonType is Gva.ButtonType.Url)
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/gva/DetermineGvaUrlTypeUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/gva/DetermineGvaUrlTypeUseCaseTest.kt
@@ -1,0 +1,36 @@
+package com.glia.widgets.chat.domain.gva
+
+import com.glia.widgets.chat.model.Gva
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DetermineGvaUrlTypeUseCaseTest {
+    private lateinit var useCase: DetermineGvaUrlTypeUseCase
+
+    @Before
+    fun setUp() {
+        useCase = DetermineGvaUrlTypeUseCase()
+    }
+
+    @Test
+    fun `invoke returns Phone type when url contains phone link`() {
+        val buttonType = useCase("tel:+37200000000")
+        assertTrue(buttonType is Gva.ButtonType.Phone)
+    }
+
+    @Test
+    fun `invoke returns Email type when url contains email link`() {
+        val buttonType = useCase("mailto:asdfg@sdf.com")
+        assertTrue(buttonType is Gva.ButtonType.Email)
+    }
+
+    @Test
+    fun `invoke returns Url type when url contains url or deep link link`() {
+        val buttonType = useCase("glia://test_deep_link")
+        assertTrue(buttonType is Gva.ButtonType.Url)
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2379

The following types should be supported:

- `PostBack` - when `button.url` is not defined. 
- `Broadcast Event`(Not related to Android `BradcastEvents`) - when `button.destinationPbBroadcastEvent` is defined
-  `Phone` - when `url` scheme is `tel:`
-  `Email` - when `url` scheme is `mailto:`
-  `Url` - for the remaining cases, when `url` is defined