### PR TITLE
Implemented new unified strings

### DIFF
--- a/widgetssdk/src/androidTest/java/com/glia/widgets/CallActivityTest.java
+++ b/widgetssdk/src/androidTest/java/com/glia/widgets/CallActivityTest.java
@@ -295,7 +295,7 @@ public class CallActivityTest {
 
             callViewCallback.emitState(callState.makeCallState());
 
-            String expected = appContext.getResources().getQuantityString(R.plurals.glia_call_chat_content_description, 15, 15);
+            String expected = appContext.getResources().getQuantityString(R.plurals.chat_message_unread_accessibility_label, 15, 15);
             onView(withId(R.id.chat_button)).check(matches(withContentDescription(expected)));
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -660,8 +660,7 @@ internal class CallView(
             theme = theme,
             title = resources.getString(R.string.glia_dialog_end_engagement_title),
             message = resources.getString(
-                R.string.glia_dialog_end_engagement_message,
-                operatorName
+                R.string.glia_dialog_end_engagement_message
             ),
             positiveButtonText = resources.getString(R.string.glia_dialog_end_engagement_yes),
             negativeButtonText = resources.getString(R.string.glia_dialog_end_engagement_no),
@@ -1038,7 +1037,7 @@ internal class CallView(
                     resources.getString(R.string.glia_call_chat_zero_content_description)
                 } else {
                     resources.getQuantityString(
-                        R.plurals.glia_call_chat_content_description,
+                        R.plurals.chat_message_unread_accessibility_label,
                         callState.messagesNotSeen,
                         callState.messagesNotSeen
                     )

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -927,8 +927,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
             theme = theme,
             title = resources.getString(R.string.glia_dialog_end_engagement_title),
             message = resources.getString(
-                R.string.glia_dialog_end_engagement_message,
-                operatorName
+                R.string.glia_dialog_end_engagement_message
             ),
             positiveButtonText = resources.getString(R.string.glia_dialog_end_engagement_yes),
             negativeButtonText = resources.getString(R.string.glia_dialog_end_engagement_no),

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/OperatorStatusViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/OperatorStatusViewHolder.kt
@@ -107,7 +107,7 @@ internal class OperatorStatusViewHolder(
         chatStartedCaptionView.text =
             itemView.resources.getString(R.string.glia_chat_operator_has_joined, operatorName)
         itemView.contentDescription = itemView.resources.getString(
-            R.string.glia_chat_operator_has_joined_content_description,
+            R.string.glia_chat_operator_has_joined,
             operatorName
         )
 
@@ -119,7 +119,7 @@ internal class OperatorStatusViewHolder(
         chatStartedCaptionView.text =
             itemView.resources.getString(R.string.glia_chat_operator_has_joined, operatorName)
         itemView.contentDescription = itemView.resources.getString(
-            R.string.glia_chat_operator_has_joined_content_description,
+            R.string.glia_chat_operator_has_joined,
             operatorName
         )
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -26,6 +26,10 @@ internal fun String.separateStringWithSymbol(symbol: String): String =
 
 internal fun Queue.supportsMessaging() = state.medias.contains(Engagement.MediaType.MESSAGING)
 
+internal fun String.combineStringWith(string: String, separator: String) : String {
+    return this + separator + string
+}
+
 internal val Operator.imageUrl: String?
     get() = picture?.url?.orElse(null)
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
@@ -25,6 +25,7 @@ import com.glia.widgets.helper.applyButtonTheme
 import com.glia.widgets.helper.applyImageColorTheme
 import com.glia.widgets.helper.applyProgressColorTheme
 import com.glia.widgets.helper.applyTextTheme
+import com.glia.widgets.helper.combineStringWith
 import com.glia.widgets.helper.getColorCompat
 import com.glia.widgets.helper.getFontCompat
 import com.glia.widgets.helper.getFullHybridTheme
@@ -164,10 +165,8 @@ class VisitorCodeView internal constructor(
     override fun showVisitorCode(visitorCode: VisitorCode) {
         runOnUi {
             showProgressBar(false)
-            successTitle.contentDescription = context.getString(
-                R.string.glia_visitor_code_content_description,
-                visitorCode.code.separateStringWithSymbol("-")
-            )
+            successTitle.contentDescription = context.getString(R.string.glia_visitor_code_content_description)
+                .combineStringWith(visitorCode.code.separateStringWithSymbol("-"), " ")
             successTitle.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
             charCodeView.setText(visitorCode.code)
         }

--- a/widgetssdk/src/main/res/layout/survey_boolean_question_item.xml
+++ b/widgetssdk/src/main/res/layout/survey_boolean_question_item.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:paddingBottom="@dimen/glia_large">
 
     <TextView
@@ -13,7 +14,7 @@
         android:layout_marginStart="@dimen/glia_large_x_large"
         android:layout_marginEnd="@dimen/glia_large_x_large"
         android:textAppearance="?attr/textAppearanceBody1"
-        android:text="@string/glia_survey_scale_item_title"
+        tools:text="Title"
         android:textColor="?attr/gliaBaseDarkColor"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toStartOf="parent"

--- a/widgetssdk/src/main/res/layout/survey_input_question_item.xml
+++ b/widgetssdk/src/main/res/layout/survey_input_question_item.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:paddingTop="@dimen/glia_large"
     android:paddingStart="@dimen/glia_large_x_large"
@@ -15,7 +16,7 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/glia_survey_open_text_item_title"
+        tools:text="Title"
         android:textAppearance="?attr/textAppearanceBody1" />
 
     <EditText

--- a/widgetssdk/src/main/res/layout/survey_scale_question_item.xml
+++ b/widgetssdk/src/main/res/layout/survey_scale_question_item.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:paddingBottom="@dimen/glia_large">
 
     <TextView
@@ -13,7 +14,7 @@
         android:layout_marginStart="@dimen/glia_large_x_large"
         android:layout_marginEnd="@dimen/glia_large_x_large"
         android:textAppearance="?attr/textAppearanceBody1"
-        android:text="@string/glia_survey_scale_item_title"
+        tools:text="Title"
         android:textColor="?attr/gliaBaseDarkColor"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toStartOf="parent"

--- a/widgetssdk/src/main/res/layout/survey_single_question_item.xml
+++ b/widgetssdk/src/main/res/layout/survey_single_question_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/single_choice_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -15,7 +16,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAppearance="?attr/textAppearanceBody1"
-        android:text="@string/glia_survey_single_choice_item_title"
+        tools:text="Title"
         android:textColor="?attr/gliaBaseDarkColor" />
 
     <RadioGroup

--- a/widgetssdk/src/main/res/values/donottranslate.xml
+++ b/widgetssdk/src/main/res/values/donottranslate.xml
@@ -2,4 +2,16 @@
 <resources>
     <string name="glia_outlined_options_icon_content_description">Outlined options icon description</string>
     <string name="glia_file_preview_transition_name">image_preview_transition</string>
+
+    <!-- Survey -->
+    <string name="glia_survey_open_text_item_title" translatable="false">Additional thoughts?</string>
+    <string name="glia_survey_scale_item_title" translatable="false">How would you rate this interaction? (1 - Bad, 5 - Good)</string>
+    <string name="glia_survey_scale_item_1" translatable="false">1</string>
+    <string name="glia_survey_scale_item_2" translatable="false">2</string>
+    <string name="glia_survey_scale_item_3" translatable="false">3</string>
+    <string name="glia_survey_scale_item_4" translatable="false">4</string>
+    <string name="glia_survey_scale_item_5" translatable="false">5</string>
+    <string name="glia_survey_single_choice_item_title" translatable="false">If you hadn\'t chatted with us today, what would you have done?</string>
+    <string name="glia_survey_require_label" translatable="false"><![CDATA[%1$s\u00A0<font color=#%2$s>*</font>]]></string>
+
 </resources>

--- a/widgetssdk/src/main/res/values/donottranslate.xml
+++ b/widgetssdk/src/main/res/values/donottranslate.xml
@@ -4,14 +4,11 @@
     <string name="glia_file_preview_transition_name">image_preview_transition</string>
 
     <!-- Survey -->
-    <string name="glia_survey_open_text_item_title" translatable="false">Additional thoughts?</string>
-    <string name="glia_survey_scale_item_title" translatable="false">How would you rate this interaction? (1 - Bad, 5 - Good)</string>
     <string name="glia_survey_scale_item_1" translatable="false">1</string>
     <string name="glia_survey_scale_item_2" translatable="false">2</string>
     <string name="glia_survey_scale_item_3" translatable="false">3</string>
     <string name="glia_survey_scale_item_4" translatable="false">4</string>
     <string name="glia_survey_scale_item_5" translatable="false">5</string>
-    <string name="glia_survey_single_choice_item_title" translatable="false">If you hadn\'t chatted with us today, what would you have done?</string>
     <string name="glia_survey_require_label" translatable="false"><![CDATA[%1$s\u00A0<font color=#%2$s>*</font>]]></string>
 
 </resources>

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -1,23 +1,105 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!--    chat screen-->
+    <string name="glia_survey_yes_no_item_yes">Yes</string>
+    <string name="glia_survey_yes_no_item_no">No</string>
+    <string name="glia_dialog_yes">Yes</string>
+    <string name="glia_dialog_no">No</string>
+    <string name="glia_dialog_ok">OK</string>
+    <string name="glia_call_visitor_video_on_hold_text">You</string>
+    <string name="glia_dialog_unexpected_error_title">Something went wrong</string>
+    <string name="glia_survey_cancel_label">Cancel</string>
+    <string name="glia_survey_submit_label">Submit</string>
+    <string name="glia_top_app_bar_chat_end">End</string>
+    <string name="glia_chat_attachment_upload_error_internal_error">Internal error</string>
+    <string name="glia_dialog_accept">Accept</string>
+    <string name="glia_dialog_cancel">Cancel</string>
+    <string name="glia_survey_open_text_item_edit_hint">Comment</string>
+    <string name="message_center_send_message_btn">Send</string>
+    <string name="glia_dialog_decline">Decline</string>
+    <string name="glia_chat_glia_logo_content_description">Powered by Glia</string>
     <string name="glia_chat_title">Chat</string>
-    <string name="glia_chat_enter_message">Enter message</string>
-    <string name="glia_chat_in_queue_message">An MSR will be with you shortly.</string>
-    <string name="glia_chat_operator_has_joined">%1$s has joined the conversation</string>
+    <string name="glia_call_audio_app_bar_title">Audio Call</string>
+    <string name="glia_call_video_button_label">Video</string> <!-- TODO unify with glia_call_app_bar_title -->
+    <string name="glia_call_video_app_bar_title">Video Call</string>
+    <string name="glia_chat_add_attachment_description">Pick attachment</string>
+    <string name="glia_chat_send_content_description">Send message</string>
+    <string name="glia_chat_attachment_download_button_label">Download</string>
+    <string name="glia_visitor_code_error_title">Could not load the visitor code. Please try refreshing.</string>
+    <string name="message_center_progress_bar_content_description">Sending</string>
     <string name="glia_chat_delivered">Delivered</string>
-    <string name="glia_chat_upgraded_to_audio_call">Upgraded to audio call</string>
-    <string name="glia_chat_upgraded_to_video_call">Upgraded to video call</string>
-    <string name="glia_chat_not_started_hint">Send a message to start chatting</string>
+    <string name="glia_chat_enter_message">Enter message</string>
+    <string name="glia_call_connecting_with">Connecting with %1$s\n%2$s</string> <!-- TODO remove second arg -->
+    <string name="glia_dialog_engagement_ended_title">Engagement Ended</string>
+    <string name="glia_chat_attachment_upload_error_failed_to_check_safety">Failed to confirm the safety of the file.</string>
+    <string name="glia_chat_attachment_upload_ready_to_send">Ready to send</string>
+    <string name="glia_chat_attachment_upload_error_file_size_over_limit">The file is larger than the 25 MB limit.</string>
+    <string name="glia_chat_attachment_upload_checking_file">Checking file…</string>
+    <string name="message_center_description">Send a message and we\'ll get back to you \nwithin 48 hours</string>
+    <string name="glia_chat_attachment_upload_uploading">Uploading file…</string>
+    <string name="glia_dialog_leave_queue_title">Are you sure you want to leave?</string>
+    <string name="glia_call_continue_browsing">You can continue browsing and we will connect you automatically.</string>
+    <string name="message_center_confirmation_screen_title">Thank you!</string>
+    <string name="glia_dialog_operators_unavailable_title">We\'re sorry</string>
+    <string name="glia_dialog_leave_queue_message">You will lose your place in the queue.</string>
+    <string name="glia_dialog_operators_unavailable_message">Operators are no longer available. Please try again later.</string>
+    <string name="glia_call_minimize_button_label">Minimize</string>
+    <string name="call_visualizer_button">End Screen Sharing</string>
+    <string name="message_center_screen_title">Messaging</string>
+    <string name="glia_dialog_end_engagement_title">End Engagement?</string>
+    <string name="glia_chat_visitor_status_transferring">Transferring</string>
+    <string name="glia_dialog_screen_sharing_offer_title">You are about to share your screen</string>
+    <string name="glia_dialog_unexpected_error_message">Please try again.</string>
+    <string name="glia_dialog_end_engagement_message">Are you sure you want to end engagement?</string>
+    <string name="glia_dialog_engagement_ended_message">This engagement has ended.\nThank you!</string>
+    <string name="glia_dialog_message_center_unavailable_title">Message Center Unavailable</string>
+    <string name="glia_dialog_message_center_unavailable_message">Message center is currently unavailable. Please try again later.</string>
+    <string name="glia_dialog_message_center_unauthorized_message">We could not verify your authentication status.</string>
+    <string name="glia_chat_in_queue_message">We are here to help!</string>
+    <string name="glia_dialog_upgrade_audio_title">%1$s has offered you to upgrade to audio</string>
+    <string name="glia_dialog_upgrade_video_1_way_title">%1$s has offered you to see their video</string>
+    <string name="glia_dialog_upgrade_video_2_way_title">%1$s has offered you to upgrade to video</string>
+    <string name="glia_visitor_code_view_title">Your Visitor Code</string>
+    <string name="glia_call_company_name_hint">Company Name</string>
+    <string name="glia_chat_operator_has_joined">%1$s has joined the conversation</string>
+    <string name="glia_chat_not_started_hint">Send a message to start chatting.</string>
+    <string name="glia_chat_upgraded_to_audio_call">Upgraded to Audio Call</string>
+    <string name="glia_chat_upgraded_to_video_call">Upgraded to Video Call</string>
+    <string name="glia_chat_attachment_upload_menu_gallery">Photo Library</string>
+    <string name="glia_chat_attachment_upload_menu_browse">Browse</string>
+    <string name="glia_chat_attachment_upload_error_file_type_invalid">This file type is not supported.</string>
+    <string name="glia_chat_attachment_downloading_label">Downloading file…</string>
+    <string name="glia_chat_attachment_open_button_label">Open</string>
+    <string name="glia_chat_new_messages">New Messages</string>
+    <string name="glia_chat_attachment_remove_item_content_description">Remove attachment %1$s</string>
+    <string name="glia_top_app_bar_close">Close</string>
+    <string name="glia_call_chat_one_content_description">Chat. %1$d unread message</string>
+    <string name="glia_call_chat_other_content_description">Chat. %1$d unread messages</string>
+    <string name="glia_call_operator_name_hint">Operator name</string>
+    <string name="glia_call_call_duration_hint">Call duration</string>
+    <string name="glia_call_on_hold">On Hold</string>
+    <string name="glia_call_mute_button_mute">Mute</string>
+    <string name="glia_call_mute_button_unmute">Unmute</string>
+    <string name="glia_call_speaker_button_label">Speaker</string>
+    <string name="glia_call_continue_browsing_on_hold">You can continue browsing while you are on hold</string>
+    <string name="glia_call_operator_profile_picture_content_description">Operator Avatar</string>
+    <string name="glia_call_operator_video_content_description">Operator\'s Video</string>
+    <string name="glia_call_visitor_video_content_description">Your Video</string>
+    <string name="glia_survey_required_error_message">Please provide an answer.</string>
+    <string name="glia_survey_require_label_content_description">%1$s. Required.</string>
+    <string name="message_center_message_limit_error_message">The message cannot exceed 10000 characters.</string>
+    <string name="message_center_title">Welcome to Message Center</string>
+    <string name="message_center_check_messages_btn">Check messages</string>
+    <string name="message_center_message_title">Your message</string>
+    <string name="message_center_message_edit_text_hint">Enter your message</string>
+    <string name="glia_messaging_title">Messaging</string>
+    <string name="message_center_confirmation_screen_message">Your message has been sent. We will get back to you within 48 hours.</string>
+    <string name="call_visualizer_screen_sharing_title">Screen Sharing</string>
+    <string name="call_visualizer_label">Your Screen is Being Shared</string>
     <string name="glia_chat_file_download_success_message">The file has been downloaded.</string>
     <string name="glia_chat_file_download_failed_msg">Could not download the file. Please try again.</string>
     <string name="glia_chat_audio_icon_content_description">Audio icon</string>
     <string name="glia_chat_video_icon_content_description">Video icon</string>
-
     <string name="glia_chat_in_queue_message_content_description">%1$s. \n An MSR will be with you shortly.</string>
-    <string name="glia_chat_operator_has_joined_content_description">Operator %1$s has joined the conversation</string>
-    <string name="glia_chat_send_content_description">Send message</string>
-    <string name="glia_chat_add_attachment_description">Add attachment</string>
     <string name="glia_chat_visitor_message_content_description">Your message: %1$s</string>
     <string name="glia_chat_visitor_message_delivered_content_description">Your message: %1$s \n Delivered</string>
     <string name="glia_chat_operator_message_content_description">Operator\'s message: %1$s</string>
@@ -29,137 +111,74 @@
     <string name="glia_chat_visitor_file_delivered_content_description">Your attached file %1$s, size %2$s. \n Delivered</string>
     <string name="glia_chat_operator_file_content_description">Operator\'s attached file %1$s, size %2$s</string>
     <string name="glia_chat_attachment_item_content_description">Attachment %1$s, size %2$s. %3$s</string>
-    <string name="glia_chat_attachment_remove_item_content_description">Remove attachment %1$s</string>
-    <string name="glia_chat_visitor_status_transferring">Transferring</string>
-    <string name="glia_chat_new_messages">New Messages</string>
-
-    <string name="glia_messaging_title">Messaging</string>
     <string name="glia_view_file_error_message">Can\'t open file</string>
     <string name="glia_view_file_not_ready_for_preview">The image is not ready for preview. Please try again later.</string>
-
-    <!--    top app bar-->
-    <string name="glia_top_app_bar_close">Close</string>
-    <string name="glia_top_app_bar_chat_end">End</string>
     <string name="glia_top_app_bar_navigate_up_content_description">Navigate Up</string>
     <string name="glia_top_app_bar_chat_end_content_description">End engagement</string>
-    <string name="glia_top_app_bar_end_screen_sharing_description">End screen sharing</string>
-
-    <!--    dialogs-->
-    <string name="glia_chat_glia_logo_content_description">Powered by Glia</string>
-    <string name="glia_chat_alert_dialog_close_content_description">Close</string>
-
-    <!-- Leave Queue Dialog -->
-    <string name="glia_dialog_leave_queue_title">Are you sure you want to leave?</string>
-    <string name="glia_dialog_leave_queue_message">You will lose your position in the queue.</string>
-    <string name="glia_dialog_leave_queue_yes">@string/glia_dialog_yes</string>
-    <string name="glia_dialog_leave_queue_no">@string/glia_dialog_no</string>
-
-    <!-- Share screen Dialog -->
     <string name="glia_dialog_screen_sharing_offer_enable_notifications_title">Start Screen Sharing?</string>
     <string name="glia_dialog_screen_sharing_offer_enable_notifications_message">The operator has requested to share your screen. To do this, you need to turn on app\'s notifications. Do this now?</string>
-    <string name="glia_dialog_screen_sharing_offer_enable_notifications_yes">@string/glia_dialog_yes</string>
-    <string name="glia_dialog_screen_sharing_offer_enable_notifications_no">@string/glia_dialog_no</string>
     <string name="glia_screensharing_dialog_icon_content_description">Screen sharing icon</string>
-
-    <!-- Allow notifications Dialog -->
     <string name="glia_dialog_allow_notifications_title">Allow Notifications?</string>
     <string name="glia_dialog_allow_notifications_message">We would like to show you notifications in the status bar. Please enable notifications in Settings.</string>
-    <string name="glia_dialog_allow_notifications_yes">@string/glia_dialog_yes</string>
-    <string name="glia_dialog_allow_notifications_no">@string/glia_dialog_no</string>
-
-    <!-- End engagement Dialog -->
-    <string name="glia_dialog_end_engagement_title">End Engagement?</string>
-    <string name="glia_dialog_end_engagement_message">Are you sure you want to end engagement with %1$s?</string>
-    <string name="glia_dialog_end_engagement_yes">@string/glia_dialog_yes</string>
-    <string name="glia_dialog_end_engagement_no">@string/glia_dialog_no</string>
-
-    <!-- ScreenSharing offer Dialog -->
-    <string name="glia_dialog_screen_sharing_offer_title">You are about to share your screen</string>
-    <string name="glia_dialog_screen_sharing_offer_message">Depending on your selection, your entire screen might be shared with the operator, not just the browser window.</string>
-    <string name="glia_dialog_screen_sharing_offer_accept">@string/glia_dialog_accept</string>
-    <string name="glia_dialog_screen_sharing_offer_decline">@string/glia_dialog_decline</string>
-
-    <!-- Engagement ended Dialog -->
-    <string name="glia_dialog_engagement_ended_title">Engagement Ended</string>
-    <string name="glia_dialog_engagement_ended_message">This engagement has ended. Thank you!</string>
-    <string name="glia_dialog_engagement_ended_action_ok">@string/glia_dialog_ok</string>
-
-    <!-- Overlay permissions required Dialog -->
+    <string name="glia_dialog_screen_sharing_offer_message">Depending on your selection, your entire screen might be shared with the operator, not just the application window.</string>
     <string name="glia_dialog_overlay_permissions_title">Screen Overlay Permissions Required</string>
     <string name="glia_dialog_overlay_permissions_message">Allow screen overlay for the proper functioning of the app</string>
-    <string name="glia_dialog_overlay_permissions_ok">@string/glia_dialog_ok</string>
-    <string name="glia_dialog_overlay_permissions_no">@string/glia_dialog_no</string>
-
-    <!-- Upgrade offer Dialog -->
-    <string name="glia_dialog_upgrade_audio_title">%1$s has offered you to upgrade to audio</string>
-    <string name="glia_dialog_upgrade_video_2_way_title">%1$s has offered you to upgrade to video</string>
-    <string name="glia_dialog_upgrade_video_1_way_title">%1$s has offered you to see their video</string>
-    <string name="glia_dialog_upgrade_accept">@string/glia_dialog_accept</string>
-    <string name="glia_dialog_upgrade_decline">@string/glia_dialog_decline</string>
-
-    <!-- Operators unavailable AlertDialog -->
-    <string name="glia_dialog_operators_unavailable_title">We\'re sorry</string>
-    <string name="glia_dialog_operators_unavailable_message">Operators are no longer available. Please try again later.</string>
-
-    <!-- Unexpected error AlertDialog -->
-    <string name="glia_dialog_unexpected_error_title">Something went wrong</string>
-    <string name="glia_dialog_unexpected_error_message">Please try again.</string>
-
-    <!-- Permission error AlertDialog -->
     <string name="glia_dialog_permission_error_title">Additional Permissions Required</string>
     <string name="glia_dialog_permission_error_message">Please make sure all required permissions are enabled.</string>
-
-    <!-- Message Center unavailable AlertDialog -->
-    <string name="glia_dialog_message_center_unavailable_title">Message Center Unavailable</string>
-    <string name="glia_dialog_message_center_unavailable_message">Message center is currently not available. Please try again later.</string>
-    <string name="glia_dialog_message_center_unauthorized_message">We could not verify your authentication status.</string>
-
-    <string name="glia_dialog_yes">Yes</string>
-    <string name="glia_dialog_no">No</string>
-    <string name="glia_dialog_decline">Decline</string>
-    <string name="glia_dialog_accept">Accept</string>
-    <string name="glia_dialog_ok">OK</string>
-    <string name="glia_dialog_cancel">Cancel</string>
-
-    <!--    call screen-->
-    <string name="glia_call_audio_app_bar_title">Audio Call</string>
-    <string name="glia_call_video_app_bar_title">Video Call</string>
-    <string name="glia_call_chat_button_label">Chat</string>
-    <string name="glia_call_video_button_label">Video</string>
-    <string name="glia_call_mute_button_mute">Mute</string>
-    <string name="glia_call_mute_button_unmute">Unmute</string>
-    <string name="glia_call_speaker_button_label">Speaker</string>
-    <string name="glia_call_minimize_button_label">Minimize</string>
-    <string name="glia_call_connecting_with">Connecting with %1$s\n%2$s</string>
     <string name="glia_call_in_queue_message">An operator will be with you shortly.</string>
-    <string name="glia_call_continue_browsing">You can continue browsing and we will connect you automatically.</string>
-    <string name="glia_call_on_hold">On Hold</string>
-    <string name="glia_call_continue_browsing_on_hold">You can continue browsing while you are on hold</string>
-    <string name="glia_call_visitor_video_on_hold_text">You</string>
-
-    <plurals name="glia_call_chat_content_description">
-        <item quantity="one">@string/glia_call_chat_one_content_description</item>
-        <item quantity="other">@string/glia_call_chat_other_content_description</item>
-    </plurals>
-    <string name="glia_call_chat_zero_content_description">Chat</string>
-    <string name="glia_call_chat_one_content_description">Chat. %1$d unread message</string>
-    <string name="glia_call_chat_other_content_description">Chat. %1$d unread messages</string>
     <string name="glia_call_video_on_content_description">Turn off video</string>
     <string name="glia_call_video_off_content_description">Turn on video</string>
     <string name="glia_call_mute_content_description">Unmute microphone</string>
     <string name="glia_call_unmute_content_description">Mute microphone</string>
     <string name="glia_call_speaker_on_content_description">Turn off speaker</string>
     <string name="glia_call_speaker_off_content_description">Turn on speaker</string>
-    <string name="glia_call_minimize_content_description">Minimize</string>
-    <string name="glia_call_operator_profile_picture_content_description">Operator Avatar</string>
-    <string name="glia_call_visitor_video_content_description">Your Video</string>
-    <string name="glia_call_operator_video_content_description">Operator\'s Video</string>
     <string name="glia_call_operator_status_on_hold_description">Operator on hold</string>
-    <string name="glia_call_company_name_hint">Company name</string>
-    <string name="glia_call_operator_name_hint">Operator name</string>
-    <string name="glia_call_call_duration_hint">Call duration</string>
-
-    <!--    statusbar notifications-->
+    <string name="glia_chat_attachment_upload_menu_take_photo">Take Photo or Video</string>
+    <string name="glia_chat_attachment_upload_failed_upload">Could not upload the file.</string>
+    <string name="glia_chat_attachment_upload_error_network_time_out">Network timed out.</string>
+    <string name="glia_chat_attachment_upload_error_invalid_input">Invalid input</string>
+    <string name="glia_chat_attachment_upload_error_read_access_permissions_denied">File read access permission denied</string>
+    <string name="glia_chat_attachment_upload_error_engagement_missing">Engagement missing</string>
+    <string name="glia_chat_attachment_upload_error_file_count_limit_reached">Cannot upload more than 25 files</string>
+    <string name="glia_chat_attachment_upload_error_file_upload_forbidden">File uploading disabled</string>
+    <string name="glia_chat_select_picture_title">Select Picture</string>
+    <string name="glia_chat_select_file_title">Select file</string>
+    <string name="glia_preview_activity_preview_failed_msg">Could not load the image preview. Please try again.</string>
+    <string name="glia_preview_activity_image_save_success_msg">The image was saved successfully.</string>
+    <string name="glia_preview_activity_image_save_fail_msg">Could not save the image.</string>
+    <string name="glia_preview_activity_image_share_fail_msg">Could not share the image. Please try again.</string>
+    <string name="glia_preview_activity_image_share_title">Share Image</string>
+    <string name="glia_preview_activity_toolbar_title">Preview</string>
+    <string name="glia_preview_activity_img_fetch_fail_msg">Could not fetch the image. Please try again.</string>
+    <string name="glia_preview_activity_menu_save_button">Save</string>
+    <string name="glia_preview_activity_menu_share_button">Share</string>
+    <string name="glia_preview_activity_image_content_description">Preview content</string>
+    <string name="glia_survey_network_unavailable">The survey could not be submitted due to a network error. Please try again.</string>
+    <string name="glia_chat_head_view_content_description">Back to the Engagement. Floating Button.</string>
+    <string name="glia_visitor_code_content_description">Your five-digit visitor code is</string>
+    <string name="glia_visitor_code_loading">Loading your visitor code</string>
+    <string name="glia_visitor_code_refresh_button">Refresh</string>
+    <string name="glia_call_minimize_content_description">@string/glia_call_minimize_button_label</string>
+    <string name="glia_top_app_bar_end_screen_sharing_description">@string/call_visualizer_button</string>
+    <string name="glia_call_chat_zero_content_description">@string/glia_chat_title</string>
+    <string name="glia_call_chat_button_label">@string/glia_chat_title</string>
+    <string name="message_center_confirmation_screen_check_messages_btn">@string/message_center_check_messages_btn</string>
+    <string name="glia_dialog_overlay_permissions_ok">@string/glia_dialog_ok</string>
+    <string name="glia_dialog_overlay_permissions_no">@string/glia_dialog_no</string>
+    <string name="glia_dialog_upgrade_accept">@string/glia_dialog_accept</string>
+    <string name="glia_dialog_upgrade_decline">@string/glia_dialog_decline</string>
+    <string name="glia_dialog_screen_sharing_offer_accept">@string/glia_dialog_accept</string>
+    <string name="glia_dialog_screen_sharing_offer_decline">@string/glia_dialog_decline</string>
+    <string name="glia_dialog_engagement_ended_action_ok">@string/glia_dialog_ok</string>
+    <string name="glia_dialog_allow_notifications_yes">@string/glia_dialog_yes</string>
+    <string name="glia_dialog_allow_notifications_no">@string/glia_dialog_no</string>
+    <string name="glia_dialog_end_engagement_yes">@string/glia_dialog_yes</string>
+    <string name="glia_dialog_end_engagement_no">@string/glia_dialog_no</string>
+    <string name="glia_dialog_screen_sharing_offer_enable_notifications_yes">@string/glia_dialog_yes</string>
+    <string name="glia_dialog_screen_sharing_offer_enable_notifications_no">@string/glia_dialog_no</string>
+    <string name="glia_chat_alert_dialog_close_content_description">@string/glia_top_app_bar_close</string>
+    <string name="glia_dialog_leave_queue_yes">@string/glia_dialog_yes</string>
+    <string name="glia_dialog_leave_queue_no">@string/glia_dialog_no</string>
     <string name="glia_notification_screen_sharing_channel_name">Screen sharing notification channel</string>
     <string name="glia_notification_screen_sharing_title">Screen Sharing Started</string>
     <string name="glia_notification_screen_sharing_message">You are currently sharing your screen.\nSelect \'End Sharing\' to stop.</string>
@@ -174,89 +193,214 @@
     <string name="glia_notification_one_way_video_call_message_no_audio">The operator’s camera is on. You can now see them.</string>
     <string name="glia_notification_action_end_sharing">End Sharing</string>
 
-    <string name="glia_chat_attachment_upload_checking_file">Checking file…</string>
-    <string name="glia_chat_attachment_upload_ready_to_send">Ready to send</string>
-    <string name="glia_chat_attachment_upload_failed_upload">Could not upload the file.</string>
-    <string name="glia_chat_attachment_upload_uploading">Uploading file…</string>
-    <string name="glia_chat_attachment_upload_error_network_time_out">Network timed out.</string>
-    <string name="glia_chat_attachment_upload_error_invalid_input">Invalid input</string>
-    <string name="glia_chat_attachment_upload_error_read_access_permissions_denied">File read access permission denied</string>
-    <string name="glia_chat_attachment_upload_error_file_type_invalid">This file type is not supported.</string>
-    <string name="glia_chat_attachment_upload_error_file_size_over_limit">The file is larger than the 25 MB limit.</string>
-    <string name="glia_chat_attachment_upload_error_engagement_missing">Engagement missing</string>
-    <string name="glia_chat_attachment_upload_error_file_count_limit_reached">Cannot upload more than 25 files</string>
-    <string name="glia_chat_attachment_upload_error_internal_error">Internal error</string>
-    <string name="glia_chat_attachment_upload_error_failed_to_check_safety">The safety of the file could not be confirmed.</string>
-    <string name="glia_chat_attachment_upload_error_file_upload_forbidden">File uploading disabled</string>
-    <string name="glia_chat_attachment_upload_menu_browse">Browse</string>
-    <string name="glia_chat_attachment_upload_menu_take_photo">Take photo</string>
-    <string name="glia_chat_attachment_upload_menu_gallery">Photo library</string>
-    <string name="glia_chat_attachment_download_button_label">Download</string>
-    <string name="glia_chat_attachment_open_button_label">Open</string>
-    <string name="glia_chat_attachment_downloading_label">Downloading file…</string>
-    <string name="glia_chat_select_picture_title">Select Picture</string>
-    <string name="glia_chat_select_file_title">Select file</string>
 
-    <!--    FilePreviewActivity-->
-    <string name="glia_preview_activity_preview_failed_msg">Could not load the image preview. Please try again.</string>
-    <string name="glia_preview_activity_image_save_success_msg">The image was saved successfully.</string>
-    <string name="glia_preview_activity_image_save_fail_msg">Could not save the image.</string>
-    <string name="glia_preview_activity_image_share_fail_msg">Could not share the image. Please try again.</string>
-    <string name="glia_preview_activity_image_share_title">Share Image</string>
-    <string name="glia_preview_activity_toolbar_title">Preview</string>
-    <string name="glia_preview_activity_img_fetch_fail_msg">Could not fetch the image. Please try again.</string>
-    <string name="glia_preview_activity_menu_save_button">Save</string>
-    <string name="glia_preview_activity_menu_share_button">Share</string>
-    <string name="glia_preview_activity_image_content_description">Preview content</string>
-
-    <!-- Survey -->
-    <string name="glia_survey_cancel_label">Cancel</string>
-    <string name="glia_survey_submit_label">Submit</string>
-    <string name="glia_survey_open_text_item_title">Additional thoughts?</string>
-    <string name="glia_survey_open_text_item_edit_hint">Comment</string>
-    <string name="glia_survey_scale_item_title">How would you rate this interaction? (1 - Bad, 5 - Good)</string>
-    <string name="glia_survey_scale_item_1">1</string>
-    <string name="glia_survey_scale_item_2">2</string>
-    <string name="glia_survey_scale_item_3">3</string>
-    <string name="glia_survey_scale_item_4">4</string>
-    <string name="glia_survey_scale_item_5">5</string>
-    <string name="glia_survey_single_choice_item_title">If you hadn\'t chatted with us today, what would you have done?</string>
-    <string name="glia_survey_yes_no_item_title">Would you use our chat again?</string>
-    <string name="glia_survey_yes_no_item_yes">Yes</string>
-    <string name="glia_survey_yes_no_item_no">No</string>
-    <string name="glia_survey_require_label"><![CDATA[%1$s\u00A0<font color=#%2$s>*</font>]]></string>
-    <string name="glia_survey_required_error_message">Please provide an answer.</string>
-    <string name="glia_survey_require_label_content_description">%1$s. Required.</string>
-    <string name="glia_survey_network_unavailable">The survey could not be submitted due to a network error. Please try again.</string>
-
-    <!-- ChatHeadView -->
-    <string name="glia_chat_head_view_content_description">Back to the Engagement. Floating Button.</string>
-
-    <!-- Message Center -->
-    <string name="message_center_screen_title">Messaging</string>
-    <string name="message_center_title">Welcome to Message Center</string>
-    <string name="message_center_description">Send a message and we\'ll get back to you \nwithin 48 hours</string>
-    <string name="message_center_message_title">Your message</string>
-    <string name="message_center_message_edit_text_hint">Enter your message</string>
-    <string name="message_center_check_messages_btn">Check messages</string>
-    <string name="message_center_send_message_btn">Send</string>
-    <string name="message_center_message_limit_error_message">The message cannot exceed 10000 characters.</string>
-    <string name="message_center_confirmation_screen_title">Thank you!</string>
-    <string name="message_center_confirmation_screen_message">Your message has been sent.\nWe will get back to you within 48 hours.</string>
-    <string name="message_center_confirmation_screen_check_messages_btn">Check messages</string>
-    <string name="message_center_progress_bar_content_description">Sending</string>
-
-    <!-- Call Visualizer -->
-    <string name="call_visualizer_screen_sharing_title">Screen Sharing</string>
-    <string name="call_visualizer_label">Your Screen is Being Shared</string>
-    <string name="call_visualizer_button">End Screen Sharing</string>
-
-    <!-- Visitor Code View -->
-    <string name="glia_visitor_code_view_title">Your Visitor Code</string>
-    <string name="glia_visitor_code_content_description">Your visitor code is %1$s</string>
-    <string name="glia_visitor_code_loading">Loading your visitor code</string>
-    <string name="glia_visitor_code_error_title">Could not load the visitor code. Please try refreshing.</string>
-    <string name="glia_visitor_code_refresh_button">Refresh</string>
+    <!-- NEW REFERENCES -->
+    <!-- NEW REFERENCES -->
+    <!-- NEW REFERENCES -->
+    <string name="alert_action_settings">Settings</string><!-- TODO UNUSED IN ANDROID -->
+    <string name="android_app_bar_end_engagement_accessibility_label">@string/glia_top_app_bar_chat_end_content_description</string>
+    <string name="android_app_bar_nav_up_accessibility">@string/glia_top_app_bar_navigate_up_content_description</string>
+    <string name="android_bubble_accessibility">@string/glia_chat_head_view_content_description</string>
+    <string name="android_call_mute_accessibility">@string/glia_call_mute_content_description</string>
+    <string name="android_call_on_hold_accessibility">@string/glia_call_operator_status_on_hold_description</string>
+    <string name="android_call_speaker_off_accessibility">@string/glia_call_speaker_off_content_description</string>
+    <string name="android_call_speaker_on_accessibility">@string/glia_call_speaker_on_content_description</string>
+    <string name="android_call_unmute_accessibility">@string/glia_call_unmute_content_description</string>
+    <string name="android_call_video_off_accessibility">@string/glia_call_video_off_content_description</string>
+    <string name="android_call_video_on_accessibility">@string/glia_call_video_on_content_description</string>
+    <string name="android_call_queue_message">@string/glia_call_in_queue_message</string>
+    <string name="android_chat_audio_accessibility_icon">@string/glia_chat_audio_icon_content_description</string>
+    <string name="android_chat_file_accessibility">@string/glia_chat_attachment_item_content_description</string>
+    <string name="android_chat_file_operator_accessibility">@string/glia_chat_operator_file_content_description</string>
+    <string name="android_chat_file_visitor_accessibility">@string/glia_chat_visitor_file_content_description</string>
+    <string name="android_chat_file_visitor_delivered_accessibility">@string/glia_chat_visitor_file_delivered_content_description</string>
+    <string name="android_chat_accessibility_message">@string/glia_chat_operator_message_content_description</string>
+    <string name="android_chat_operator_accessibility_image">@string/glia_chat_operator_image_content_description</string>
+    <string name="android_chat_operator_name_accessibility_message">@string/glia_chat_operator_name_message_content_description</string>
+    <string name="android_chat_queue_accessibility_label">@string/glia_chat_in_queue_message_content_description</string>
+    <string name="android_chat_video_accessibility_icon">@string/glia_chat_video_icon_content_description</string>
+    <string name="android_chat_visitor_accessibility_image">@string/glia_chat_visitor_image_content_description</string>
+    <string name="android_chat_visitor_delivered_accessibility_image">@string/glia_chat_visitor_image_delivered_content_description</string>
+    <string name="android_chat_visitor_accessibility_message">@string/glia_chat_visitor_message_content_description</string>
+    <string name="android_chat_visitor_delivered_accessibility_message">@string/glia_chat_visitor_message_delivered_content_description</string>
+    <string name="android_chat_download_complete">@string/glia_chat_file_download_success_message</string>
+    <string name="android_chat_download_failed">@string/glia_chat_file_download_failed_msg</string>
+    <string name="android_file_not_ready_for_preview">@string/glia_view_file_not_ready_for_preview</string>
+    <string name="android_file_select_title">@string/glia_chat_select_file_title</string>
+    <string name="android_file_view_error">@string/glia_view_file_error_message</string>
+    <string name="android_notification_audio_call_channel_name">@string/glia_notification_call_channel_name</string>
+    <string name="android_notification_audio_call_message">@string/glia_notification_audio_call_message</string>
+    <string name="android_notification_audio_call_title">@string/glia_notification_audio_call_title</string>
+    <string name="android_notification_end_sharing">@string/glia_notification_action_end_sharing</string>
+    <string name="android_notification_one_way_video_call_message">@string/glia_notification_one_way_video_call_message</string>
+    <string name="android_notification_one_way_video_call_title">@string/glia_notification_one_way_video_call_title</string>
+    <string name="android_notification_one_way_video_no_audio">@string/glia_notification_one_way_video_call_message_no_audio</string>
+    <string name="android_notification_screen_sharing_channel_name">@string/glia_notification_screen_sharing_channel_name</string>
+    <string name="android_notification_screen_sharing_message">@string/glia_notification_screen_sharing_message</string>
+    <string name="android_notification_screen_sharing_title">@string/glia_notification_screen_sharing_title</string>
+    <string name="android_notification_two_way_video_call_message">@string/glia_notification_two_way_video_call_message</string>
+    <string name="android_notification_two_way_video_call_title">@string/glia_notification_two_way_video_call_title</string>
+    <string name="android_notification_two_way_video_no_audio">@string/glia_notification_two_way_video_call_message_no_audio</string>
+    <string name="android_notifications_allow_message">@string/glia_dialog_allow_notifications_message</string>
+    <string name="android_notifications_allow_title">@string/glia_dialog_allow_notifications_title</string>
+    <string name="android_overlay_message">@string/glia_dialog_overlay_permissions_message</string>
+    <string name="android_overlay_title">@string/glia_dialog_overlay_permissions_title</string>
+    <string name="android_permissions_message">@string/glia_dialog_permission_error_message</string>
+    <string name="android_permissions_title">@string/glia_dialog_permission_error_title</string>
+    <string name="android_preview_accessibility_image">@string/glia_preview_activity_image_content_description</string>
+    <string name="android_preview_error_fetch">@string/glia_preview_activity_img_fetch_fail_msg</string>
+    <string name="android_preview_failed_message">@string/glia_preview_activity_preview_failed_msg</string>
+    <string name="android_preview_menu_save">@string/glia_preview_activity_menu_save_button</string>
+    <string name="android_preview_menu_share">@string/glia_preview_activity_menu_share_button</string>
+    <string name="android_preview_save_error_message">@string/glia_preview_activity_image_save_fail_msg</string>
+    <string name="android_preview_save_success_message">@string/glia_preview_activity_image_save_success_msg</string>
+    <string name="android_preview_share_error_message">@string/glia_preview_activity_image_share_fail_msg</string>
+    <string name="android_preview_share_title">@string/glia_preview_activity_image_share_title</string>
+    <string name="android_preview_title">@string/glia_preview_activity_toolbar_title</string>
+    <string name="android_screen_sharing_accessibility_icon">@string/glia_screensharing_dialog_icon_content_description</string>
+    <string name="android_screen_sharing_offer_with_notifications_message">@string/glia_dialog_screen_sharing_offer_enable_notifications_message</string>
+    <string name="android_screen_sharing_offer_with_notifications_title">@string/glia_dialog_screen_sharing_offer_enable_notifications_title</string>
+    <string name="android_survey_error_network">@string/glia_survey_network_unavailable</string>
+    <string name="android_upload_error_engagement_missing">@string/glia_chat_attachment_upload_error_engagement_missing</string>
+    <string name="android_upload_error_file_limit">@string/glia_chat_attachment_upload_error_file_count_limit_reached</string>
+    <string name="android_upload_error_forbidden">@string/glia_chat_attachment_upload_error_file_upload_forbidden</string>
+    <string name="android_upload_error_invalid_input">@string/glia_chat_attachment_upload_error_invalid_input</string>
+    <string name="android_upload_error_network">@string/glia_chat_attachment_upload_error_network_time_out</string>
+    <string name="android_upload_error_permissions">@string/glia_chat_attachment_upload_error_read_access_permissions_denied</string>
+    <string name="android_upload_menu_take_photo">@string/glia_chat_attachment_upload_menu_take_photo</string>
+    <string name="android_visitor_code_loading">@string/glia_visitor_code_loading</string>
+    <string name="android_visitor_code_refresh">@string/glia_visitor_code_refresh_button</string>
+    <string name="call_bubble_accessibility_hint">Deactivates minimize.</string><!-- TODO ADA NEW IN ANDROID -->
+    <string name="call_bubble_accessibility_label">@string/glia_call_operator_profile_picture_content_description</string>
+    <string name="call_button_mute">@string/glia_call_mute_button_mute</string>
+    <string name="call_button_speaker">@string/glia_call_speaker_button_label</string>
+    <string name="call_button_unmute">@string/glia_call_mute_button_unmute</string>
+    <string name="call_buttons_chat_badge_value_multiple_items_accessibility_label">@string/glia_call_chat_other_content_description</string>
+    <string name="call_buttons_chat_badge_value_single_item_accessibility_label">@string/glia_call_chat_one_content_description</string>
+    <string name="call_connect_first_text_accessibility_hint">Displays operator name.</string><!-- TODO ADA NEW IN ANDROID -->
+    <string name="call_connect_second_text_accessibility_hint">Displays call duration.</string><!-- TODO ADA NEW IN ANDROID -->
+    <string name="call_header_close_button_accessibility_hint">Activates minimize.</string><!-- TODO ADA NEW IN ANDROID -->
+    <string name="call_on_hold_bottom_text">@string/glia_call_continue_browsing_on_hold</string>
+    <string name="call_on_hold">@string/glia_call_on_hold</string>
+    <string name="call_operator_avatar_accessibility_hint">Displays operator avatar or placeholder.</string><!-- TODO ADA NEW IN ANDROID -->
+    <string name="call_operator_avatar_accessibility_label">@string/glia_call_operator_profile_picture_content_description</string>
+    <string name="call_operator_name_accessibility_hint">Displays operator name.</string><!-- TODO ADA NEW IN ANDROID -->
+    <string name="call_video_operator_accessibility_label">@string/glia_call_operator_video_content_description</string>
+    <string name="call_video_visitor_accessibility_label">@string/glia_call_visitor_video_content_description</string>
+    <string name="call_visualizer_screen_sharing_message">@string/call_visualizer_label</string>
+    <string name="call_visualizer_screen_sharing_message_accessibility_hint">Message label</string><!-- Is it needed?-->
+    <string name="call_visualizer_screen_sharing_view_title">@string/call_visualizer_screen_sharing_title</string>
+    <string name="call_visualizer_visitor_code_action_close">@string/glia_top_app_bar_close</string><!-- Just use glia top app bar?-->
+    <string name="call_visualizer_visitor_code_action_refresh">@string/glia_visitor_code_refresh_button</string>
+    <string name="call_visualizer_visitor_code_close_accessibility_hint">Closes visitor code</string><!-- TODO ADA NEW IN ANDROID, UNIFY WITH CLOSE?-->
+    <string name="call_visualizer_visitor_code_close_accessibility_label">Close Button</string><!-- TODO ADA NEW IN ANDROID, UNIFY WITH CLOSE?-->
+    <string name="call_visualizer_visitor_code_refresh_accessibility_hint">Generates new visitor code</string><!-- TODO ADA NEW IN ANDROID-->
+    <string name="call_visualizer_visitor_code_refresh_accessibility_label">Refresh Button</string><!-- TODO ADA NEW IN ANDROID-->
+    <string name="call_visualizer_visitor_code_title">@string/glia_visitor_code_view_title</string>
+    <string name="call_visualizer_visitor_code_title_accessibility_hint">@string/glia_visitor_code_content_description</string>
+    <string name="chat_duration_accessibility_label">@string/glia_call_call_duration_hint</string>
+    <string name="chat_attach_files">@string/glia_chat_add_attachment_description</string>
+    <string name="chat_attachement_photo_library">@string/glia_chat_attachment_upload_menu_gallery</string>
+    <string name="chat_attachement_take_photo">@string/glia_chat_attachment_upload_menu_take_photo</string>
+    <string name="chat_attachement_upload_unsupported_file">@string/glia_chat_attachment_upload_error_file_type_invalid</string>
+    <string name="chat_download_downloading">@string/glia_chat_attachment_downloading_label</string>
+    <string name="chat_file_infected_error">@string/glia_chat_attachment_upload_error_failed_to_check_safety</string>
+    <string name="chat_file_too_large_error">@string/glia_chat_attachment_upload_error_file_size_over_limit</string>
+    <string name="chat_file_upload_failed">@string/glia_chat_attachment_upload_failed_upload</string>
+    <string name="chat_file_upload_in_progress">@string/glia_chat_attachment_upload_uploading</string>
+    <string name="chat_file_upload_scanning">@string/glia_chat_attachment_upload_checking_file</string>
+    <string name="chat_file_upload_success">@string/glia_chat_attachment_upload_ready_to_send</string>
+    <string name="chat_input_placeholder">@string/glia_chat_enter_message</string>
+    <string name="chat_input_send">@string/message_center_send_message_btn</string>
+    <plurals name="chat_message_unread_accessibility_label"><item quantity="one">@string/glia_call_chat_one_content_description</item><item quantity="other">@string/glia_call_chat_other_content_description</item></plurals>
+    <string name="chat_message_start_engagement_placeholder">@string/glia_chat_not_started_hint</string>
+    <string name="chat_operator_avatar_accessibility_label">@string/glia_call_operator_profile_picture_content_description</string>
+    <string name="chat_operator_name_accessibility_label">@string/glia_call_operator_name_hint</string>
+    <string name="chat_operator_joined">@string/glia_chat_operator_has_joined</string>
+    <string name="chat_status_delivered">@string/glia_chat_delivered</string>
+    <string name="chat_status_typing">Operator typing</string>
+    <string name="chat_unread_message_divider">@string/glia_chat_new_messages</string>
+    <string name="chat_upgrade_audio_text">@string/glia_chat_upgraded_to_audio_call</string>
+    <string name="chat_upgrade_video_text">@string/glia_chat_upgraded_to_video_call</string>
+    <string name="chat_upload_remove_accessibility_label">@string/glia_chat_attachment_remove_item_content_description</string>
+    <string name="engagement_connect_with">@string/glia_call_connecting_with</string>
+    <string name="engagement_connect_placeholder">@string/glia_chat_in_queue_message</string>
+    <string name="engagement_default_operator_name">Operator</string> <!-- TODO NEW TO ANDROID -->
+    <string name="engagement_end_confirmation_header">@string/glia_dialog_end_engagement_title</string>
+    <string name="engagement_end_message">@string/glia_dialog_end_engagement_message</string>
+    <string name="engagement_ended_header">@string/glia_dialog_engagement_ended_title</string>
+    <string name="engagement_ended_message">@string/glia_dialog_engagement_ended_message</string>
+    <string name="engagement_minimize_video_button">@string/glia_call_minimize_button_label</string>
+    <string name="engagement_offer_upgrade">{operatorName} has offered you to upgrade</string> <!-- TODO NEW -->
+    <string name="engagement_queue_closed_header">@string/glia_dialog_operators_unavailable_title</string>
+    <string name="engagement_queue_closed_message">@string/glia_dialog_operators_unavailable_message</string>
+    <string name="engagement_queue_leave_header">@string/glia_dialog_leave_queue_title</string>
+    <string name="engagement_queue_leave_message">@string/glia_dialog_leave_queue_message</string>
+    <string name="engagement_queue_reconnection_failed_try_again">@string/glia_dialog_unexpected_error_message</string>
+    <string name="engagement_queue_transferring_message">@string/glia_chat_visitor_status_transferring</string>
+    <string name="engagement_queue_wait_message">@string/glia_call_continue_browsing</string>
+    <string name="engagement_secure_messaging_title">@string/message_center_screen_title</string>
+    <string name="error_internal">@string/glia_chat_attachment_upload_error_internal_error</string>
+    <string name="error_general">@string/glia_dialog_unexpected_error_title</string>
+    <string name="error_unexpected_title">We\'re sorry, there has been an unexpected error.</string> <!-- TODO NEW -->
+    <string name="general_accept">@string/glia_dialog_accept</string>
+    <string name="general_back">Back</string> <!-- TODO NEW -->
+    <string name="general_browse">@string/glia_chat_attachment_upload_menu_take_photo</string>
+    <string name="general_cancel">@string/glia_dialog_cancel</string>
+    <string name="general_close">@string/glia_top_app_bar_close</string>
+    <string name="general_comment">@string/glia_survey_open_text_item_edit_hint</string>
+    <string name="general_company_name">@string/glia_call_company_name_hint</string>
+    <string name="general_decline">@string/glia_dialog_decline</string>
+    <string name="general_download">@string/glia_chat_attachment_download_button_label</string>
+    <string name="general_end">@string/glia_top_app_bar_chat_end</string>
+    <string name="general_message">Message</string> <!-- TODO NEW -->
+    <string name="general_no">@string/glia_dialog_no</string>
+    <string name="general_ok">@string/glia_dialog_ok</string>
+    <string name="general_open">@string/glia_chat_attachment_open_button_label</string>
+    <string name="general_powered_by">@string/glia_chat_glia_logo_content_description</string> <!-- TODO remove Glia -->
+    <string name="general_retry">Retry</string><!-- TODO NEW -->
+    <string name="general_selected">Selected</string><!-- TODO NEW, maybe unify? -->
+    <string name="general_submit">@string/glia_survey_submit_label</string>
+    <string name="general_tank_you">@string/message_center_confirmation_screen_title</string>
+    <string name="general_yes">@string/glia_dialog_yes</string>
+    <string name="general_you">@string/glia_call_visitor_video_on_hold_text</string>
+    <string name="gva_error_unsupported">@string/gva_not_supported</string>
+    <string name="media_messaging_description">@string/message_center_description</string>
+    <string name="media_audio_name">@string/glia_call_audio_app_bar_title</string>
+    <string name="media_phone_name">Phone</string> <!-- TODO NEW -->
+    <string name="media_text_name">@string/glia_chat_title</string>
+    <string name="media_video_name">@string/glia_call_video_app_bar_title</string>
+    <string name="message_center_check_messages">@string/message_center_check_messages_btn</string>
+    <string name="message_center_confirmation_check_messages_accessibility_hint">Navigates you to the chat transcript.</string><!-- TODO NEW-->
+    <string name="message_center_confirmation_check_messages_accessibility_label">Checks messages</string><!-- TODO NEW-->
+    <string name="message_center_confirmation_subtitle">@string/message_center_confirmation_screen_message</string><!-- Removed newline -->
+    <string name="message_center_header">@string/glia_messaging_title</string>
+    <string name="message_center_not_authenticated_message">@string/glia_dialog_message_center_unauthorized_message</string>
+    <string name="message_center_unavailable_message">@string/glia_dialog_message_center_unavailable_message</string>
+    <string name="message_center_unavailable_title">@string/glia_dialog_message_center_unavailable_title</string>
+    <string name="message_center_welcome_check_messages_accessibility_hint">Navigates you to the chat transcript.</string><!-- TODO NEW-->
+    <string name="message_center_welcome_file_picker_label_accessibility_hint">Navigates you to the chat transcript.</string><!-- TODO NEW-->
+    <string name="message_center_welcome_file_picker_label_accessibility_label">File picker</string><!-- TODO NEW-->
+    <string name="message_center_welcome_message_length_warning">@string/message_center_message_limit_error_message</string>
+    <string name="message_center_welcome_message_text_view_placeholder">@string/message_center_message_edit_text_hint</string>
+    <string name="message_center_welcome_message_title">@string/message_center_message_title</string>
+    <string name="message_center_welcome_send_accessibility_hint">Navigates you to the chat transcript.</string><!-- TODO NEW-->
+    <string name="message_center_welcome_title">@string/message_center_title</string>
+    <string name="screen_sharing_visitor_screen_disclaimer_title">@string/glia_dialog_screen_sharing_offer_title</string>
+    <string name="screen_sharing_visitor_screen_end">@string/call_visualizer_button</string>
+    <string name="screensharing_visitor_screen_disclaimer_info">@string/glia_dialog_screen_sharing_offer_message</string>
+    <string name="send_message_send">@string/glia_chat_send_content_description</string>
+    <string name="send_message_sending">@string/message_center_progress_bar_content_description</string>
+    <string name="survey_action_validation_error">@string/glia_survey_required_error_message</string>
+    <string name="survey_question_option_button_selected_accessibility_label">Selected: {buttonTitle}</string><!-- TODO NEW-->
+    <string name="survey_question_option_button_unselected_accessibility_label">Unselected: {buttonTitle}</string><!-- TODO NEW-->
+    <string name="survey_question_text_field_accessibility_hint">Enter the answer</string><!-- TODO NEW -->
+    <string name="survey_question_title_accessibility_label">@string/glia_survey_require_label_content_description</string>
+    <string name="survey_validation_title_accessibility_label">Please provide an answer for question above</string><!-- TODO NEW-->
+    <string name="upgrade_audio_title">@string/glia_dialog_upgrade_audio_title</string>
+    <string name="upgrade_video_one_way_title">@string/glia_dialog_upgrade_video_1_way_title</string>
+    <string name="upgrade_video_two_way_title">@string/glia_dialog_upgrade_video_2_way_title</string>
+    <string name="visitor_code_failed">@string/glia_visitor_code_error_title</string>
 
     <!--    GVA -->
     <string name="gva_not_supported">This action is not currently supported on mobile.</string>


### PR DESCRIPTION
MOB-2346

Created and unified new string keys in a backwards compatible manner. The only exception was made for the plurals key, where the override should be for the individual values, not the plural itself.

In minor places, trimmed down reference links in string values, still some TODO-s left in the strings.xml file but vast majority of them is about ADA witch is yet to be unified and will be done in MOB-2280

Decided it is probably be for the best to go with a feature branch approach for this, because we will probably start breaking things otherwise until main functionality is there. Should not cause many conflicts by the end though.
