### PR TITLE
MOB-2498 fixed reversed button dialog

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -169,7 +169,7 @@ object Dialogs {
                 text = negativeButtonText
                 setOnClickListener(negativeButtonClickListener)
                 applyButtonTheme(
-                    backgroundColor = systemNegativeColor,
+                    backgroundColor = if (isButtonsColorsReversed) { brandPrimaryColor } else { systemNegativeColor },
                     textColor = baseLightColor,
                     textFont = fontFamily
                 )
@@ -179,7 +179,7 @@ object Dialogs {
                 text = positiveButtonText
                 setOnClickListener(positiveButtonClickListener)
                 applyButtonTheme(
-                    backgroundColor = brandPrimaryColor,
+                    backgroundColor = if (isButtonsColorsReversed) { systemNegativeColor } else { brandPrimaryColor },
                     textColor = baseLightColor,
                     textFont = fontFamily
                 )


### PR DESCRIPTION
Reversed dialog button changes were overridden.

![reversed dialog](https://github.com/salemove/android-sdk-widgets/assets/9782505/833a7d18-d2ea-4e8c-80df-57f32e6edb6e)
