### PR TITLE
Extend project setting with region value

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,7 @@ android {
         p.each { name, value -> ext[name] = value }
     }
 
+    initEnvProperty('GLIA_REGION', "beta")
     initEnvProperty('GLIA_API_KEY_SECRET')
     initEnvProperty('GLIA_API_KEY_ID')
     initEnvProperty('GLIA_SITE_ID')
@@ -47,11 +48,12 @@ android {
     initEnvProperty('GLIA_JWT', "")
     initEnvProperty('FIREBASE_PROJECT_ID')
     initEnvProperty('FIREBASE_API_KEY')
-    initEnvProperty('FIREBASE_APP_ID')
-    initEnvProperty('FIREBASE_APP_ID_DEBUG')
+    initEnvProperty('FIREBASE_APP_ID', "")
+    initEnvProperty('FIREBASE_APP_ID_DEBUG', "")
 
     buildTypes {
         all {
+            resValue("string", "environment", GLIA_REGION)
             resValue("string", "site_id", GLIA_SITE_ID)
             resValue("string", "glia_api_key_id", GLIA_API_KEY_ID)
             resValue("string", "glia_api_key_secret", GLIA_API_KEY_SECRET)
@@ -63,12 +65,12 @@ android {
         debug {
             signingConfig signingConfigs.debug
             applicationIdSuffix '.debug'
-            resValue("string", "firebase_app_id", FIREBASE_APP_ID_DEBUG ?: "")
+            resValue("string", "firebase_app_id", FIREBASE_APP_ID_DEBUG)
         }
         release {
             initWith debug
             applicationIdSuffix ''
-            resValue("string", "firebase_app_id", FIREBASE_APP_ID ?: "")
+            resValue("string", "firebase_app_id", FIREBASE_APP_ID)
         }
     }
     lint {

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -380,8 +380,7 @@ class MainFragment : Fragment() {
             createDefaultConfig(
                 context = requireActivity().applicationContext,
                 /*uiJsonRemoteConfig = UnifiedUiConfigurationLoader.fetchLocalGlobalColors(requireContext()),*/
-                /*runtimeConfig = createSampleRuntimeConfig(),*/
-                /*region = "us"*/
+                /*runtimeConfig = createSampleRuntimeConfig()*/
             )
         )
         prepareAuthentication()

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -29,6 +29,7 @@
     <string name="pref_auth_token">auth_token</string>
     <string name="pref_queue_id">queue_id</string>
     <string name="pref_context_asset_id">context_asset_id</string>
+    <string name="pref_environment">environment</string>
     <string name="pref_white_label">white_label_toggle</string>
     <string name="pref_use_overlay">use_overlay</string>
     <string name="pref_remote_theme">remote_theme_toggle</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="settings_site_api_key_id">Site Api Key id</string>
     <string name="settings_site_api_key_secret">Site Api Key Secret</string>
     <string name="settings_site_id">Site id (needs restart)</string>
+    <string name="settings_environment">Region (needs restart)</string>
     <string name="settings_chat_background_color">Background color</string>
     <string name="settings_chat_negative_color">Negative color</string>
     <string name="settings_chat_visitor_message_bg_color">Visitor message bg color</string>

--- a/app/src/main/res/xml/sdk_basic_prefs.xml
+++ b/app/src/main/res/xml/sdk_basic_prefs.xml
@@ -22,6 +22,12 @@
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
+            app:defaultValue="@string/environment"
+            app:key="@string/pref_environment"
+            app:title="@string/settings_environment"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
             app:defaultValue="@string/settings_value_default_company_name"
             app:key="@string/pref_company_name"
             app:title="@string/settings_company_name"


### PR DESCRIPTION
The region was added to the testing app settings.

Region value can be used in the `local.properties`. 
```
GLIA_REGION=us
```

Also, the value can be changed in the application settings.
