### PR TITLE
Remove LeakCanary for default builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 
 
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
+//    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$testLibraryVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"


### PR DESCRIPTION
Decided to make LeakCanary disabled by default. It is a great library, but it annoys me when I'm working on day-to-day tasks, so I think it is better to keep it disabled by default and enable it only when needed to check memory leaks. 