### PR TITLE
GVA: Use RecyclerView for the Persistent button options

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
@@ -178,6 +178,7 @@ internal class ChatAdapter(
                         operatorMessageBinding.contentLayout,
                         true
                     ),
+                    onGvaButtonsClickListener,
                     uiTheme
                 )
             }
@@ -249,7 +250,7 @@ internal class ChatAdapter(
 
             is SystemChatItem -> (holder as SystemMessageViewHolder).bind(chatItem.message)
             is GvaResponseText -> (holder as GvaResponseTextViewHolder).bind(chatItem)
-            is GvaPersistentButtons -> (holder as GvaPersistentButtonsViewHolder).bind(chatItem, onGvaButtonsClickListener)
+            is GvaPersistentButtons -> (holder as GvaPersistentButtonsViewHolder).bind(chatItem)
             is GvaGalleryCards -> (holder as GvaGalleryViewHolder).bind(chatItem, chatItemHeightManager.getMeasuredHeight(chatItem))
             is CustomCardChatItem -> {
                 (holder as CustomCardViewHolder).bind(chatItem.message) { text: String, value: String ->

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/GvaButtonsAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/GvaButtonsAdapter.kt
@@ -1,0 +1,58 @@
+package com.glia.widgets.chat.adapter
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.view.ContextThemeWrapper
+import androidx.appcompat.widget.LinearLayoutCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.glia.widgets.R
+import com.glia.widgets.UiTheme
+import com.glia.widgets.chat.model.GvaButton
+import com.glia.widgets.helper.Utils
+import com.glia.widgets.helper.getFontCompat
+import com.glia.widgets.view.unifiedui.applyButtonTheme
+import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
+import com.google.android.material.button.MaterialButton
+
+internal class GvaButtonsAdapter(
+    private val buttonsClickListener: ChatAdapter.OnGvaButtonsClickListener,
+    private val uiTheme: UiTheme,
+    private val buttonTheme: ButtonTheme?
+) : RecyclerView.Adapter<GvaButtonsAdapter.ButtonViewHolder>() {
+    private var options: List<GvaButton>? = null
+
+    fun setOptions(options: List<GvaButton>) {
+        this.options = options
+        notifyDataSetChanged()
+    }
+
+    class ButtonViewHolder(
+        private val buttonView: MaterialButton
+    ) : RecyclerView.ViewHolder(buttonView) {
+        fun bind(button: GvaButton, buttonsClickListener: ChatAdapter.OnGvaButtonsClickListener) {
+            buttonView.text = button.text
+            buttonView.setOnClickListener {
+                buttonsClickListener.onGvaButtonClicked(button)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ButtonViewHolder {
+        val styleResId = Utils.getAttrResourceId(parent.context, R.attr.gvaOptionButtonStyle)
+        val button = MaterialButton(ContextThemeWrapper(parent.context, styleResId), null, 0).also {
+            it.id = View.generateViewId()
+
+            uiTheme.fontRes?.let(parent::getFontCompat)?.also(it::setTypeface)
+
+            buttonTheme?.also(it::applyButtonTheme)
+        }
+        button.layoutParams = LinearLayoutCompat.LayoutParams(LinearLayoutCompat.LayoutParams.MATCH_PARENT, LinearLayoutCompat.LayoutParams.WRAP_CONTENT)
+        return ButtonViewHolder(button)
+    }
+
+    override fun getItemCount(): Int = options?.size ?: 0
+
+    override fun onBindViewHolder(holder: ButtonViewHolder, position: Int) {
+        options?.get(position)?.let { holder.bind(it, buttonsClickListener) }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaGalleryItemViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaGalleryItemViewHolder.kt
@@ -1,32 +1,23 @@
 package com.glia.widgets.chat.adapter.holder
 
 import android.view.View
-import android.view.ViewGroup
-import androidx.appcompat.view.ContextThemeWrapper
-import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.view.isVisible
-import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.glia.widgets.chat.adapter.ChatAdapter
-import com.glia.widgets.chat.model.GvaButton
+import com.glia.widgets.chat.adapter.GvaButtonsAdapter
 import com.glia.widgets.chat.model.GvaGalleryCard
 import com.glia.widgets.databinding.ChatGvaGalleryItemBinding
 import com.glia.widgets.di.Dependencies
-import com.glia.widgets.helper.Utils
 import com.glia.widgets.helper.fromHtml
 import com.glia.widgets.helper.getColorCompat
 import com.glia.widgets.helper.getColorStateListCompat
 import com.glia.widgets.helper.getFontCompat
 import com.glia.widgets.helper.load
-import com.glia.widgets.view.unifiedui.applyButtonTheme
 import com.glia.widgets.view.unifiedui.applyLayerTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
-import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.chat.MessageBalloonTheme
 import com.glia.widgets.view.unifiedui.theme.gva.GvaGalleryCardTheme
-import com.google.android.material.button.MaterialButton
 import kotlin.properties.Delegates
 
 internal class GvaGalleryItemViewHolder(
@@ -35,7 +26,7 @@ internal class GvaGalleryItemViewHolder(
     private val uiTheme: UiTheme
 ) : ViewHolder(binding.root) {
 
-    private var adapter: ButtonsAdapter by Delegates.notNull()
+    private var adapter: GvaButtonsAdapter by Delegates.notNull()
 
     private val operatorTheme: MessageBalloonTheme? by lazy {
         Dependencies.getGliaThemeManager().theme?.chatTheme?.operatorMessage
@@ -46,7 +37,7 @@ internal class GvaGalleryItemViewHolder(
     }
 
     init {
-        adapter = ButtonsAdapter(buttonsClickListener, uiTheme, galleryCardTheme?.button)
+        adapter = GvaButtonsAdapter(buttonsClickListener, uiTheme, galleryCardTheme?.button)
         binding.buttonsRecyclerView.adapter = adapter
         binding.item.apply {
             uiTheme.operatorMessageBackgroundColor?.let(::getColorStateListCompat)?.also {
@@ -104,49 +95,5 @@ internal class GvaGalleryItemViewHolder(
         } ?: run {
             binding.image.isVisible = false
         }
-    }
-
-    private class ButtonsAdapter(
-        private val buttonsClickListener: ChatAdapter.OnGvaButtonsClickListener,
-        private val uiTheme: UiTheme,
-        private val buttonTheme: ButtonTheme?
-    ) : RecyclerView.Adapter<ButtonsAdapter.ButtonViewHolder>() {
-
-        private var options: List<GvaButton>? = null
-
-        fun setOptions(options: List<GvaButton>) {
-            this.options = options
-            notifyDataSetChanged()
-        }
-
-        class ButtonViewHolder(
-            private val buttonView: MaterialButton
-        ) : ViewHolder(buttonView) {
-            fun bind(button: GvaButton, buttonsClickListener: ChatAdapter.OnGvaButtonsClickListener) {
-                buttonView.text = button.text
-                buttonView.setOnClickListener {
-                    buttonsClickListener.onGvaButtonClicked(button)
-                }
-            }
-        }
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ButtonViewHolder {
-            val styleResId = Utils.getAttrResourceId(parent.context, R.attr.gvaOptionButtonStyle)
-            val button = MaterialButton(ContextThemeWrapper(parent.context, styleResId), null, 0).also {
-                it.id = View.generateViewId()
-
-                uiTheme.fontRes?.let(parent::getFontCompat)?.also(it::setTypeface)
-
-                buttonTheme?.also(it::applyButtonTheme)
-            }
-            button.layoutParams = LinearLayoutCompat.LayoutParams(LinearLayoutCompat.LayoutParams.MATCH_PARENT, LinearLayoutCompat.LayoutParams.WRAP_CONTENT)
-            return ButtonViewHolder(button)
-        }
-
-        override fun getItemCount(): Int = options?.size ?: 0
-
-        override fun onBindViewHolder(holder: ButtonViewHolder, position: Int) {
-            options?.get(position)?.let { holder.bind(it, buttonsClickListener) }
-        }
-
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaPersistentButtonsViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaPersistentButtonsViewHolder.kt
@@ -1,38 +1,38 @@
 package com.glia.widgets.chat.adapter.holder
 
 import android.view.View
-import android.view.ViewGroup
-import androidx.appcompat.view.ContextThemeWrapper
-import androidx.appcompat.widget.LinearLayoutCompat
-import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.glia.widgets.chat.adapter.ChatAdapter
+import com.glia.widgets.chat.adapter.GvaButtonsAdapter
 import com.glia.widgets.chat.model.GvaPersistentButtons
 import com.glia.widgets.databinding.ChatGvaPersistentButtonsContentBinding
 import com.glia.widgets.databinding.ChatOperatorMessageLayoutBinding
 import com.glia.widgets.di.Dependencies
-import com.glia.widgets.helper.Utils
 import com.glia.widgets.helper.fromHtml
 import com.glia.widgets.helper.getColorCompat
 import com.glia.widgets.helper.getColorStateListCompat
 import com.glia.widgets.helper.getFontCompat
-import com.glia.widgets.view.unifiedui.applyButtonTheme
 import com.glia.widgets.view.unifiedui.applyLayerTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.gva.GvaPersistentButtonTheme
-import com.google.android.material.button.MaterialButton
+import kotlin.properties.Delegates
 
 internal class GvaPersistentButtonsViewHolder(
     operatorMessageBinding: ChatOperatorMessageLayoutBinding,
     private val contentBinding: ChatGvaPersistentButtonsContentBinding,
+    buttonsClickListener: ChatAdapter.OnGvaButtonsClickListener,
     private val uiTheme: UiTheme
 ) : OperatorBaseViewHolder(operatorMessageBinding.root, operatorMessageBinding.chatHeadView, uiTheme) {
+
+    private var adapter: GvaButtonsAdapter by Delegates.notNull()
 
     private val persistentButtonTheme: GvaPersistentButtonTheme? by lazy {
         Dependencies.getGliaThemeManager().theme?.chatTheme?.gva?.persistentButtonTheme
     }
 
     init {
+        adapter = GvaButtonsAdapter(buttonsClickListener, uiTheme, persistentButtonTheme?.button)
+        contentBinding.buttonsRecyclerView.adapter = adapter
         contentBinding.root.apply {
             uiTheme.operatorMessageBackgroundColor?.let(::getColorStateListCompat)?.also {
                 backgroundTintList = it
@@ -56,55 +56,12 @@ internal class GvaPersistentButtonsViewHolder(
         }
     }
 
-    fun bind(item: GvaPersistentButtons, onGvaButtonsClickListener: ChatAdapter.OnGvaButtonsClickListener) {
+    fun bind(item: GvaPersistentButtons) {
         updateOperatorStatusView(item)
         updateItemContentDescription(item.operatorName, item.content)
 
         contentBinding.message.text = item.content.fromHtml()
-        setupButtons(item, contentBinding.container, onGvaButtonsClickListener)
-    }
 
-    private fun setupButtons(
-        item: GvaPersistentButtons,
-        container: ViewGroup,
-        onGvaButtonsClickListener: ChatAdapter.OnGvaButtonsClickListener
-    ) {
-        container.removeAllViews()
-        val horizontalMargin = container.resources.getDimensionPixelOffset(R.dimen.glia_large)
-        val verticalMargin = container.resources.getDimensionPixelOffset(R.dimen.glia_medium)
-        for (option in item.options) {
-            val onClickListener = onGvaButtonsClickListener.run {
-                View.OnClickListener { onGvaButtonClicked(option) }
-            }
-
-            val button = composeButton(
-                container = container,
-                text = option.text,
-                onClickListener = onClickListener
-            )
-
-            val params = LinearLayoutCompat.LayoutParams(LinearLayoutCompat.LayoutParams.MATCH_PARENT, LinearLayoutCompat.LayoutParams.WRAP_CONTENT)
-            val topMargin = if (item.options.first() == option) verticalMargin else 0
-            val bottomMargin = if (item.options.last() == option) verticalMargin else 0
-            params.setMargins(horizontalMargin, topMargin, horizontalMargin, bottomMargin)
-            container.addView(button, params)
-        }
-    }
-
-    private fun composeButton(
-        container: ViewGroup,
-        text: String,
-        onClickListener: View.OnClickListener
-    ): MaterialButton {
-        val styleResId = Utils.getAttrResourceId(container.context, R.attr.gvaOptionButtonStyle)
-        return MaterialButton(ContextThemeWrapper(container.context, styleResId), null, 0).also {
-            it.id = View.generateViewId()
-            it.text = text
-            it.setOnClickListener(onClickListener)
-
-            uiTheme.fontRes?.let(container::getFontCompat)?.also(it::setTypeface)
-
-            persistentButtonTheme?.button?.also(it::applyButtonTheme)
-        }
+        adapter.setOptions(item.options)
     }
 }

--- a/widgetssdk/src/main/res/layout/chat_gva_persistent_buttons_content.xml
+++ b/widgetssdk/src/main/res/layout/chat_gva_persistent_buttons_content.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_marginTop="@dimen/glia_medium"
     android:background="@drawable/bg_message">
@@ -20,10 +20,12 @@
         android:textIsSelectable="true"
         android:textColorLink="?attr/gliaBaseDarkColor" />
 
-    <LinearLayout
-        android:id="@+id/container"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/buttons_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical" />
+        android:paddingVertical="@dimen/glia_medium"
+        android:paddingHorizontal="@dimen/glia_large"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
 </LinearLayout>


### PR DESCRIPTION
The `ButtonAdapter` from the `GvaGalleryItemViewHolder` was extracted to a separate file. Now it is used for both `GvaGalleryItemViewHolder` and `GvaPersistentButtonsViewHolder`.

[MOB-2520](https://glia.atlassian.net/browse/MOB-2520)


[MOB-2520]: https://glia.atlassian.net/browse/MOB-2520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ