### PR TITLE
Open dialogs on top of CallVisualizerSupportActivity instead of integrator's Activity

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
@@ -24,6 +24,8 @@ class ActivityWatcherForCallVisualizerContract {
         fun onRequestedCameraPermissionResult(isGranted: Boolean)
         fun onMediaProjectionPermissionResult(isGranted: Boolean, activity: Activity)
         fun onMediaProjectionRejected()
+        fun isWaitingMediaProjectionResult(): Boolean
+        fun setIsWaitingMediaProjectionResult(isWaiting: Boolean)
     }
 
     interface Watcher {
@@ -48,5 +50,6 @@ class ActivityWatcherForCallVisualizerContract {
         fun checkInitialCameraPermission()
         fun callOverlayDialog()
         fun dismissOverlayDialog()
+        fun isSupportActivityOpen(): Boolean
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
@@ -15,3 +15,4 @@ class CallVisualizerSupportActivity : AppCompatActivity() {
 sealed class PermissionType : Parcelable
 object ScreenSharing : PermissionType()
 object Camera : PermissionType()
+object None : PermissionType()

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerControllerTest.kt
@@ -138,6 +138,7 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         verify(watcher).removeDialogFromStack()
         verify(watcher).dismissOverlayDialog()
         verify(watcher).openOverlayPermissionView()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -146,6 +147,7 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         resetMocks()
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -158,6 +160,7 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
 
     @Test
     fun `onPositiveDialogButtonClicked notification channel dialog is shown when MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(
             DialogState(
                 MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING
@@ -167,10 +170,13 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(watcher).openNotificationChannelScreen()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
     fun `onNegativeDialogButtonClicked decline is sent and dialog is dismissed when MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(
             DialogState(
                 MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING
@@ -178,92 +184,141 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         )
         verify(watcher).showAllowScreenSharingNotificationsAndStartSharingDialog()
         controller.onNegativeDialogButtonClicked()
+        verify(watcher).isSupportActivityOpen()
         verify(watcher).removeDialogFromStack()
         verify(screenSharingController).onScreenSharingDeclined()
     }
 
     @Test
     fun `onPositiveDialogButtonClicked call activity is called when MODE_MEDIA_UPGRADE`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         prepareMediaUpgradeApplicationState()
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(watcher).openCallActivity()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
     fun `onNegativeDialogButtonClicked dialog is dismissed when MODE_MEDIA_UPGRADE`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         prepareMediaUpgradeApplicationState()
         controller.onNegativeDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
+        verify(watcher).isSupportActivityOpen()
     }
 
     @Test
     fun `onPositiveDialogButtonClicked overlay permissions are called when MODE_OVERLAY_PERMISSIONS`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_OVERLAY_PERMISSION))
         verify(watcher).showOverlayPermissionsDialog()
         controller.onPositiveDialogButtonClicked()
         verify(watcher).dismissOverlayDialog()
         verify(watcher).removeDialogFromStack()
         verify(watcher).openOverlayPermissionView()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
     fun `onNegativeDialogButtonClicked dialog is dismissed when MODE_OVERLAY_PERMISSIONS`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_OVERLAY_PERMISSION))
         verify(watcher).showOverlayPermissionsDialog()
         controller.onNegativeDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(watcher).dismissOverlayDialog()
+        verify(watcher).isSupportActivityOpen()
     }
 
     @Test
     fun `onPositiveDialogButtonClicked notification channel is shown when MODE_ENABLE_NOTIFICAIONTS_CHANNEL`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_ENABLE_NOTIFICATION_CHANNEL))
         verify(watcher).showAllowNotificationsDialog()
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(watcher).openNotificationChannelScreen()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
     fun `onNegativeDialogButtonClicked dialog is dismissed when MODE_ENABLE_NOTIFICATIONS_CHANNEL`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_ENABLE_NOTIFICATION_CHANNEL))
         verify(watcher).showAllowNotificationsDialog()
         controller.onNegativeDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
+        verify(watcher).isSupportActivityOpen()
+    }
+
+    @Test
+    fun `onPositiveDialogButtonClicked openSupportActivity called when isSupportActivityOpen false and MODE_VISITOR_CODE`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(false)
+        controller.onDialogControllerCallback(DialogState(MODE_VISITOR_CODE))
+        verify(watcher, never()).showVisitorCodeDialog()
+        controller.onPositiveDialogButtonClicked()
+        verify(watcher).removeDialogFromStack()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).openSupportActivity(any())
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
     fun `onPositiveDialogButtonClicked dialog is dismissed when MODE_VISITOR_CODE`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_VISITOR_CODE))
         verify(watcher).showVisitorCodeDialog()
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
     fun `onNegativeDialogButtonClicked dialog is dismissed when MODE_VISITOR_CODE`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_VISITOR_CODE))
         verify(watcher).showVisitorCodeDialog()
         controller.onNegativeDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
+        verify(watcher).isSupportActivityOpen()
     }
 
     @Test
+    fun `onPositiveDialogButtonClicked openSupportActivity called when isSupportActivityOpen false and MODE_SCREEN_SHARING`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(false)
+        controller.onDialogControllerCallback(DialogState(MODE_START_SCREEN_SHARING))
+        verify(watcher, never()).showScreenSharingDialog()
+        controller.onPositiveDialogButtonClicked()
+        verify(watcher).removeDialogFromStack()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).destroySupportActivityIfExists()
+        verify(watcher).openSupportActivity(any())
+    }
+    @Test
     fun `onPositiveDialogButtonClicked dialog is dismissed when MODE_SCREEN_SHARING`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_START_SCREEN_SHARING))
         verify(watcher).showScreenSharingDialog()
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
+        verify(watcher).isSupportActivityOpen()
+        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
     fun `onNegativeDialogButtonClicked dialog is dismissed when MODE_SCREEN_SHARING`() {
+        whenever(watcher.isSupportActivityOpen()).thenReturn(true)
         controller.onDialogControllerCallback(DialogState(MODE_START_SCREEN_SHARING))
         verify(watcher).showScreenSharingDialog()
         controller.onNegativeDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(screenSharingController).onScreenSharingDeclined()
+        verify(watcher).isSupportActivityOpen()
     }
 
     @Test


### PR DESCRIPTION
This prevents the `java.lang.IllegalArgumentException: The style on this component requires your app theme to be Theme.MaterialComponents (or a descendant)` crash even if integrator's activity style is not Material.

ℹ️ I have not found a straightforward way to detect if Activity style is Material, so decided to use this solution regardless of Activity style.

ℹ️ This pull request is based on the [feature/fix_dialogs_crash](https://github.com/salemove/android-sdk-widgets/compare/development...feature/fix_dialogs_crash?expand=1) branch developed by Alexander. I created a separate branch because I came to the conclusion that additional ActivityWatcher `SupportActivityWatcher` is not needed. Instead, the code should be organized a bit differently.

ℹ️ I commented in the code the most non-obvious part, where `watcher.openSupportActivity(None)` is called. I spent a lot of time trying to make it more obvious, however, I see only one way - create separate components (Controller, Contract, etc.) for 'CallVisualizerSupportActivity' and move all the code related to dialog callback and dialog buttons there. Tried it, however, it requires a lot of changes and introduces big risks of new bugs. So I refused this approach.

[MOB-2515](https://glia.atlassian.net/browse/MOB-2446)


[MOB-2515]: https://glia.atlassian.net/browse/MOB-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ