### PR TITLE
Enable chat input after engagement transfer (operator connected) (development)

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.kt
@@ -88,7 +88,8 @@ internal data class ChatState(
         operatorProfileImgUrl: String?
     ): ChatState = copy(
         formattedOperatorName = formattedOperatorName,
-        operatorProfileImgUrl = operatorProfileImgUrl
+        operatorProfileImgUrl = operatorProfileImgUrl,
+        chatInputMode = ChatInputMode.ENABLED,
     )
 
     fun historyLoaded(chatItems: List<ChatItem>): ChatState = copy(


### PR DESCRIPTION
[Input field is disabled after transfer from Bot to Queue](https://glia.atlassian.net/browse/MOB-2493)

Steps to reproduce:
Use “Bot only” queue to start with bot, then post the message “Transfer to Queueu {queue_id}”

This PR is a backport for hotfix: https://github.com/salemove/android-sdk-widgets/pull/700