### PR TITLE
Enable chat input after engagement transfer (operator connected) (master hotfix)

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.java
@@ -226,7 +226,7 @@ public class ChatState {
                 .copyFrom(this)
                 .setFormattedOperatorName(formattedOperatorName)
                 .setOperatorProfileImgUrl(operatorProfileImgUrl)
-//                .enableChatPanel() // Why is this here?
+                .enableChatPanel()
                 .createChatState();
     }
 


### PR DESCRIPTION
[Input field is disabled after transfer from Bot to Queue](https://glia.atlassian.net/browse/MOB-2493)

Steps to reproduce:
Use “Bot only” queue to start with bot, then post the message “Transfer to Queueu {queue_id}”

Backport PR: https://github.com/salemove/android-sdk-widgets/pull/699
