### PR TITLE
Fixed overlay dialog being dismissed by ENGAGEMENT_ENDED at start of …

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -231,7 +231,7 @@ public class CallController implements
     public void engagementEnded() {
         Logger.d(TAG, "engagementEndedByOperator");
         stop();
-        if (!Glia.getCurrentEngagement().isPresent()) {
+        if (!Dependencies.getUseCaseFactory().createIsOngoingEngagementUseCase().invoke()) {
             dialogController.dismissDialogs();
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -231,7 +231,9 @@ public class CallController implements
     public void engagementEnded() {
         Logger.d(TAG, "engagementEndedByOperator");
         stop();
-        dialogController.dismissDialogs();
+        if (!Glia.getCurrentEngagement().isPresent()) {
+            dialogController.dismissDialogs();
+        }
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -231,9 +231,12 @@ public class CallController implements
     public void engagementEnded() {
         Logger.d(TAG, "engagementEndedByOperator");
         stop();
-        if (!Dependencies.getUseCaseFactory().createIsOngoingEngagementUseCase().invoke()) {
-            dialogController.dismissDialogs();
+        // TODO re-enable during MOB-2523
+        /*
+        if (!isOngoingEngagementUseCase.invoke()) {
+            dialogController.dismissDialogs()
         }
+        */
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -676,9 +676,12 @@ internal class ChatController(
 
             EngagementStateEvent.Type.ENGAGEMENT_ENDED -> {
                 Logger.d(TAG, "Engagement Ended")
-                if (!Dependencies.getUseCaseFactory().createIsOngoingEngagementUseCase().invoke()) {
+                // TODO re-enable during MOB-2523
+                /*
+                if (!isOngoingEngagementUseCase.invoke()) {
                     dialogController.dismissDialogs()
                 }
+                */
             }
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -676,7 +676,7 @@ internal class ChatController(
 
             EngagementStateEvent.Type.ENGAGEMENT_ENDED -> {
                 Logger.d(TAG, "Engagement Ended")
-                if (!Glia.getCurrentEngagement().isPresent) {
+                if (!Dependencies.getUseCaseFactory().createIsOngoingEngagementUseCase().invoke()) {
                     dialogController.dismissDialogs()
                 }
             }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.text.format.DateUtils
 import android.view.View
 import androidx.annotation.VisibleForTesting
+import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.chat.AttachmentFile
@@ -675,7 +676,9 @@ internal class ChatController(
 
             EngagementStateEvent.Type.ENGAGEMENT_ENDED -> {
                 Logger.d(TAG, "Engagement Ended")
-                dialogController.dismissDialogs()
+                if (!Glia.getCurrentEngagement().isPresent) {
+                    dialogController.dismissDialogs()
+                }
             }
         }
     }


### PR DESCRIPTION
…engagement

END_ENGAGEMENT being called at the beginning of the engagement dismisses overlay dialog and breaks acceptance tests
