### PR TITLE
Increment Core SDK version to 1.0.3 - edit date

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
-#Fri Aug 04 13:07:13 UTC 2023
+#Thu Aug 10 15:36:20 UTC 2023
 dependency.coreSdk.version=1.0.3
 widgets.versionCode=66
 widgets.versionName=2.0.3


### PR DESCRIPTION
As Karl noticed, date should correspond to the release date
