### PR TITLE
Hotfix/0/notifications removal web view card adapter default end engagement dialog preventing

### DIFF
--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -69,6 +69,8 @@
             android:name=".core.screensharing.MediaProjectionService"
             android:foregroundServiceType="mediaProjection" />
 
+        <service android:name=".core.notification.NotificationRemovalService" />
+
         <receiver
             android:name=".core.notification.NotificationActionReceiver"
             android:exported="false">

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -117,7 +117,7 @@ public class GliaWidgets {
     public static final String CHAT_TYPE = "chat_type";
 
     @Nullable
-    private static CustomCardAdapter customCardAdapter;
+    private static CustomCardAdapter customCardAdapter = new WebViewCardAdapter();
 
     /**
      * Should be called when the application is starting in {@link Application}.onCreate()
@@ -274,8 +274,12 @@ public class GliaWidgets {
 
     /**
      * Allows configuring custom response cards based on metadata.
+     * <p>
+     * Glia SDK uses {@link WebViewCardAdapter} by default.
+     * This method allows setting the custom implementation of {@link CustomCardAdapter}.
      *
-     * @param customCardAdapter an instance of {@link CustomCardAdapter}.
+     * @param customCardAdapter an instance of {@link CustomCardAdapter}
+     *                          or {@code null} for the default, not Custom Card, Glia message implementation.
      * @see CustomCardAdapter
      * @see WebViewCardAdapter
      */

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/WebViewCardAdapter.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/WebViewCardAdapter.java
@@ -7,20 +7,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.glia.androidsdk.chat.ChatMessage;
-import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.chat.adapter.holder.CustomCardViewHolder;
 import com.glia.widgets.chat.adapter.holder.WebViewViewHolder;
 
 /**
  * The implementation of {@link CustomCardAdapter} allows displaying all card messages in WebViews.
- * <p>
- * It provides a simple way to set up {@link GliaWidgets#setCustomCardAdapter(CustomCardAdapter)}.
- * <p>
- * <b>Usage example:</b>
- * <pre>{@code
- * GliaWidgets.setCustomCardAdapter(new WebViewCardAdapter());
- * }<pre/>
  * @see CustomCardAdapter
  * @see WebViewViewHolder
  */

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationRemovalService.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationRemovalService.kt
@@ -1,0 +1,16 @@
+package com.glia.widgets.core.notification
+
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class NotificationRemovalService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        notificationManager.cancel(NotificationFactory.CALL_NOTIFICATION_ID)
+        super.onTaskRemoved(rootIntent)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import com.glia.widgets.R
 import com.glia.widgets.core.notification.NotificationFactory
+import com.glia.widgets.core.notification.NotificationRemovalService
 import com.glia.widgets.core.notification.areNotificationsEnabledForChannel
 import com.glia.widgets.core.screensharing.MediaProjectionService
 
@@ -60,6 +61,7 @@ internal class NotificationManager(private val applicationContext: Application) 
                 NotificationFactory.CALL_NOTIFICATION_ID,
                 NotificationFactory.createAudioCallNotification(applicationContext)
             )
+            startNotificationRemovalService()
         }
     }
 
@@ -69,11 +71,21 @@ internal class NotificationManager(private val applicationContext: Application) 
                 NotificationFactory.CALL_NOTIFICATION_ID,
                 NotificationFactory.createVideoCallNotification(applicationContext, isTwoWayVideo, hasAudio)
             )
+            startNotificationRemovalService()
         }
+    }
+
+    private fun startNotificationRemovalService() {
+        applicationContext.startService(
+            Intent(applicationContext, NotificationRemovalService::class.java)
+        )
     }
 
     override fun removeCallNotification() {
         notificationManager.cancel(NotificationFactory.CALL_NOTIFICATION_ID)
+        applicationContext.stopService(
+            Intent(applicationContext, NotificationRemovalService::class.java)
+        )
     }
 
     /**


### PR DESCRIPTION
Mikk asked to include several commits from development branch into hotfix release.
Additionally to what we were planning to include into hotfix release.

They are:

- Notifications about an active audio or video call were not removed from the screen after the application crash or force quit.
- WebViewCardAdapter is now the default renderer option for custom cards.

This PR cherry-picks them.