### PR TITLE
Bugfix/mob 2523 investigate engagement state

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -231,12 +231,9 @@ public class CallController implements
     public void engagementEnded() {
         Logger.d(TAG, "engagementEndedByOperator");
         stop();
-        // TODO re-enable during MOB-2523
-        /*
         if (!isOngoingEngagementUseCase.invoke()) {
-            dialogController.dismissDialogs()
+            dialogController.dismissDialogs();
         }
-        */
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -519,12 +519,12 @@ internal class ChatController(
 
             EngagementStateEvent.Type.ENGAGEMENT_ENDED -> {
                 Logger.d(TAG, "Engagement Ended")
-                // TODO re-enable during MOB-2523
-                /*
                 if (!isOngoingEngagementUseCase.invoke()) {
                     dialogController.dismissDialogs()
                 }
-                */
+            }
+            EngagementStateEvent.Type.NO_ENGAGEMENT -> {
+                Logger.d(TAG, "NoEngagement")
             }
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementStateRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementStateRepository.java
@@ -97,16 +97,10 @@ public class GliaEngagementStateRepository {
             .orElse(null);
     }
 
-<<<<<<< HEAD
-    private EngagementStateEvent mapToEngagementStateChangeEvent(
-        EngagementState engagementState,
-        @Nullable Operator operator
-=======
     @VisibleForTesting
     protected EngagementStateEvent mapToEngagementStateChangeEvent(
             EngagementState engagementState,
             @Nullable Operator operator
->>>>>>> 87dfc69a (Added test coverage)
     ) {
         if (engagementState == null && isOngoingEngagement) {
             isOngoingEngagement = false;

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/model/EngagementStateEvent.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/model/EngagementStateEvent.java
@@ -9,6 +9,7 @@ public interface EngagementStateEvent {
         ENGAGEMENT_ONGOING,
         ENGAGEMENT_OPERATOR_CONNECTED,
         ENGAGEMENT_OPERATOR_CHANGED,
+        NO_ENGAGEMENT
     }
 
     Type getType();
@@ -94,9 +95,23 @@ public interface EngagementStateEvent {
     }
 
     class EngagementEndedEvent implements EngagementStateEvent {
+
         @Override
         public Type getType() {
             return Type.ENGAGEMENT_ENDED;
+        }
+
+        @Override
+        public <T> T accept(EngagementStateEventVisitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    class NoEngagementEvent implements EngagementStateEvent {
+
+        @Override
+        public Type getType() {
+            return Type.NO_ENGAGEMENT;
         }
 
         @Override

--- a/widgetssdk/src/test/java/com/glia/widgets/core/engagement/GliaEngagementStateRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/engagement/GliaEngagementStateRepositoryTest.kt
@@ -1,0 +1,54 @@
+package com.glia.widgets.core.engagement
+
+import com.glia.androidsdk.Operator
+import com.glia.androidsdk.engagement.EngagementState
+import com.glia.widgets.core.engagement.domain.model.EngagementStateEvent
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class GliaEngagementStateRepositoryTest {
+
+    private val engagement: EngagementState = mock()
+    private val operator1: Operator = mock()
+    private val operator2: Operator = mock()
+    private val operatorRepo: GliaOperatorRepository = mock()
+    private val repo = GliaEngagementStateRepository(operatorRepo)
+    private val ID1 = "1"
+    private val ID2 = "2"
+
+
+    @Test
+    fun `mapToEngagementStateChangeEvent returns NoEngagement when engagementState null and is not ongoing engagement`() {
+        assertTrue(repo.mapToEngagementStateChangeEvent(null, null) is EngagementStateEvent.NoEngagementEvent)
+    }
+
+    @Test
+    fun `mapToEngagementStateChangeEvent returns NoEngagement when engagementState null and is ongoing engagement`() {
+        assertTrue(repo.mapToEngagementStateChangeEvent(engagement, null) is EngagementStateEvent.EngagementOperatorConnectedEvent)
+        assertTrue(repo.mapToEngagementStateChangeEvent(null, null) is EngagementStateEvent.EngagementEndedEvent)
+    }
+
+    @Test
+    fun `mapToEngagementStateChangeEvent returns EngagementOngoingEvent when operator ids equal`() {
+        whenever(engagement.operator).thenReturn(operator1)
+        whenever(operator1.id).thenReturn(ID1)
+        whenever(operator2.id).thenReturn(ID1)
+        assertTrue(repo.mapToEngagementStateChangeEvent(engagement, operator2) is EngagementStateEvent.EngagementOngoingEvent)
+    }
+
+    @Test
+    fun `mapToEngagementStateChangeEvent returns EngagementOperatorChangedEvent when operator ids are different`() {
+        whenever(engagement.operator).thenReturn(operator1)
+        whenever(operator1.id).thenReturn(ID1)
+        whenever(operator2.id).thenReturn(ID2)
+        assertTrue(repo.mapToEngagementStateChangeEvent(engagement, operator2) is EngagementStateEvent.EngagementOperatorChangedEvent)
+    }
+
+    @Test
+    fun `mapToEngagementStateChangeEvent returns EngagementTransferringEvent when operator ids equal`() {
+        whenever(engagement.visitorStatus).thenReturn(EngagementState.VisitorStatus.TRANSFERRING)
+        assertTrue(repo.mapToEngagementStateChangeEvent(engagement, null) is EngagementStateEvent.EngagementTransferringEvent)
+    }
+}


### PR DESCRIPTION
Initial problem was "End engagement" dialog could persist from one session to another.

The fix for this raised acceptance test issue where ENGAGEMENT_ENDED was called any time that Engagement was not ongoing.

Adding new type to engagement state NO_ENGAGEMENT to clear ambiguity and ENGAGEMENT_ENDED is only sent when engagement ends.

Original issue is https://glia.atlassian.net/browse/MOB-2503
