### PR TITLE
Improve chat transcript quick reply button behaviour

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -759,6 +759,7 @@ internal class ChatController(
     }
 
     private fun sendGvaResponse(singleChoiceAttachment: SingleChoiceAttachment) {
+        addQuickReplyButtons(emptyList())
         sendMessageUseCase.execute(singleChoiceAttachment, sendMessageCallback)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
@@ -13,7 +13,8 @@ internal class ManagerFactory(private val useCaseFactory: UseCaseFactory) {
                 appendHistoryChatMessageUseCase = createAppendHistoryChatMessageUseCase(),
                 appendNewChatMessageUseCase = createAppendNewChatMessageUseCase(),
                 sendUnsentMessagesUseCase = createSendUnsentMessagesUseCase(),
-                handleCustomCardClickUseCase = createHandleCustomCardClickUseCase()
+                handleCustomCardClickUseCase = createHandleCustomCardClickUseCase(),
+                isOngoingEngagementUseCase = createIsOngoingEngagementUseCase()
             )
         }
 }


### PR DESCRIPTION
MOB 2535

**Additional info:**
We only show quick reply buttons for the latest item in the history. However, completed engagements render the button non-functional and could be outdated for future engagements. Therefore, we need to check if the engagement is ongoing before displaying quick reply buttons.
