### PR TITLE
Replace PagerSnapHelper to LinearSnapHelper for Gallery list

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaGalleryViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaGalleryViewHolder.kt
@@ -2,7 +2,7 @@ package com.glia.widgets.chat.adapter.holder
 
 import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.PagerSnapHelper
+import androidx.recyclerview.widget.LinearSnapHelper
 import com.glia.widgets.UiTheme
 import com.glia.widgets.chat.adapter.ChatAdapter
 import com.glia.widgets.chat.adapter.GvaGalleryAdapter
@@ -24,7 +24,7 @@ internal class GvaGalleryViewHolder(
             LinearLayoutManager.HORIZONTAL,
             false
         )
-        PagerSnapHelper().attachToRecyclerView(contentBinding.cardRecyclerView)
+        LinearSnapHelper().attachToRecyclerView(contentBinding.cardRecyclerView)
     }
 
     fun bind(item: GvaGalleryCards, measuredHeight: Int?) {


### PR DESCRIPTION
The purpose of `SnapHelper` is to snap gallery items to the center. `PagerSnapHelper` scrolls one by one, which is not desired. We replaced it with `LinearSnapHelper` for center snapping only.