### PR TITLE
Improve solution for opening dialogs on top of CallVisualizerSupportActivity instead of integrator's Activity

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -96,13 +96,19 @@ internal class ActivityWatcherForCallVisualizer(
 
     override fun requestCameraPermission() {
         if (resumedActivity.get() is ComponentActivity) {
-            cameraPermissionLauncher?.run { this.launch(Manifest.permission.CAMERA) }
+            cameraPermissionLauncher?.run {
+                controller.setIsWaitingMediaProjectionResult(true)
+                this.launch(Manifest.permission.CAMERA)
+            }
         }
     }
 
     override fun requestOverlayPermission() {
         if (resumedActivity.get() is ComponentActivity) {
-            overlayPermissionLauncher?.run { this.launch(Settings.ACTION_MANAGE_OVERLAY_PERMISSION) }
+            overlayPermissionLauncher?.run {
+                controller.setIsWaitingMediaProjectionResult(true)
+                this.launch(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
+            }
         }
     }
 
@@ -120,6 +126,7 @@ internal class ActivityWatcherForCallVisualizer(
         (activity as? ComponentActivity?)?.let { componentActivity ->
             cameraPermissionLauncher = componentActivity.registerForActivityResult(RequestPermission()) {
                     isGranted: Boolean ->
+                controller.setIsWaitingMediaProjectionResult(false)
                 controller.onRequestedCameraPermissionResult(isGranted)
             }
         }
@@ -133,6 +140,7 @@ internal class ActivityWatcherForCallVisualizer(
         (activity as? ComponentActivity?)?.let { componentActivity ->
             overlayPermissionLauncher = componentActivity.registerForActivityResult(RequestPermission()) {
                     isGranted: Boolean ->
+                controller.setIsWaitingMediaProjectionResult(false)
                 controller.onMediaProjectionPermissionResult(isGranted, componentActivity)
             }
         }
@@ -341,8 +349,8 @@ internal class ActivityWatcherForCallVisualizer(
             val contextWithStyle = activity.wrapWithMaterialThemeOverlay()
 
             alertDialog = Dialogs.showUpgradeDialog(contextWithStyle, theme, mediaUpgrade, {
-                dialogController.dismissCurrentDialog()
                 controller.onMediaUpgradeReceived(mediaUpgrade.mediaUpgradeOffer)
+                dialogController.dismissCurrentDialog()
             }) {
                 controller.onNegativeDialogButtonClicked()
             }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
@@ -130,11 +130,7 @@ internal class ActivityWatcherForCallVisualizerController(
         when (currentDialogMode) {
             MODE_NONE -> Logger.e(TAG, "$currentDialogMode should not have a dialog to click")
             MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING -> watcher.openNotificationChannelScreen()
-            MODE_START_SCREEN_SHARING ->
-                activity?.run {
-                    setIsWaitingMediaProjectionResult(true)
-                    startScreenSharing(this)
-                }
+            MODE_START_SCREEN_SHARING -> activity?.run { startScreenSharing(this) }
             MODE_MEDIA_UPGRADE -> watcher.openCallActivity()
             MODE_ENABLE_NOTIFICATION_CHANNEL -> watcher.openNotificationChannelScreen()
             MODE_OVERLAY_PERMISSION -> {
@@ -196,6 +192,7 @@ internal class ActivityWatcherForCallVisualizerController(
         startMediaProjectionLaunchers[activity::class.simpleName].let { startMediaProjection ->
             activity.getSystemService(MediaProjectionManager::class.java)
                 ?.let { mediaProjectionManager ->
+                    setIsWaitingMediaProjectionResult(true)
                     startMediaProjection?.launch(mediaProjectionManager.createScreenCaptureIntent())
                     Logger.d(TAG, "Acquire a media projection token: launching permission request")
                 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
@@ -116,7 +116,7 @@ public class DialogController {
     }
 
     public void dismissOverlayPermissionsDialog() {
-        Logger.d(TAG, "Dismiss Visitor Code Dialog");
+        Logger.d(TAG, "Dismiss Overlay Permissions Dialog");
         dialogManager.remove(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -22,11 +22,13 @@ import androidx.core.view.isVisible
 import com.glia.widgets.GliaWidgets
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
+import com.glia.widgets.callvisualizer.CallVisualizerSupportActivity
 import com.glia.widgets.core.dialog.model.DialogState.MediaUpgrade
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.applyButtonTheme
 import com.glia.widgets.helper.applyImageColorTheme
 import com.glia.widgets.helper.applyTextTheme
+import com.glia.widgets.helper.asActivity
 import com.glia.widgets.helper.isAlertDialogButtonUseVerticalAlignment
 import com.glia.widgets.view.button.BaseConfigurableButton
 import com.glia.widgets.view.button.GliaPositiveButton
@@ -91,13 +93,23 @@ object Dialogs {
         horizontalInset: Int = 0,
         cancelable: Boolean = true
     ): AlertDialog {
-        return MaterialAlertDialogBuilder(context)
+        val dialog = MaterialAlertDialogBuilder(context)
             .setView(view)
             .setBackgroundInsetStart(horizontalInset)
             .setBackgroundInsetEnd(horizontalInset)
             .setCancelable(cancelable)
+            .setOnCancelListener {
+                Dependencies.getControllerFactory().dialogController.dismissVisitorCodeDialog()
+                context.asActivity()?.let {
+                    if (it is CallVisualizerSupportActivity) {
+                        it.overridePendingTransition(0, 0)
+                        it.finish()
+                    }
+                }
+            }
             .show()
             .also { setDialogBackground(it, theme.gliaChatBackgroundColor) }
+        return dialog
     }
 
     private fun showDialog(


### PR DESCRIPTION
You can check ticket description to find the scenarios, which these changes are to solving:
[Integrators want to use Android Widgets SDK without a need to use Material Theme in their projects](https://glia.atlassian.net/browse/MOB-2515)

There are two scenarios that are not solved yet, but their reason is different and I'm working on them separately.

@DavDo FYI, I decided not to move the logic from `ActivityWatcherForCallVisualizer` to `CallVisualizerSupportActivity` because:
- I'm not completely sure that this logic is only needed for `CallVisualizerSupportActivity`
- I've spent a good deal of time already, on this solution and don't want to spend more
- this change is, actually, refactoring and it doesn't solve the initial bugs
