### PR TITLE
Improve line break replacement logic

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -41,9 +41,9 @@ internal fun UiTheme?.isAlertDialogButtonUseVerticalAlignment(): Boolean = this?
 internal fun UiTheme?.getFullHybridTheme(newTheme: UiTheme?): UiTheme = deepMerge(newTheme) ?: UiTheme.UiThemeBuilder().build()
 
 /**
- * Returns styled text from the provided HTML string. Replaces \n to <br> tag.
+ * Returns styled text from the provided HTML string. Replaces \n to <br> regardless of the operating system where the string was created.
  */
-internal fun String.fromHtml(flags: Int = Html.FROM_HTML_MODE_COMPACT): Spanned = Html.fromHtml(replace("\n", "<br>"), flags)
+internal fun String.fromHtml(flags: Int = Html.FROM_HTML_MODE_COMPACT): Spanned = Html.fromHtml(replace("(\r\n|\n)".toRegex(), "<br>"), flags)
 
 internal val AttachmentFile.isImage: Boolean get() = contentType.startsWith("image")
 


### PR DESCRIPTION
Improved according to [suggested](https://github.com/salemove/android-sdk-widgets/pull/719#discussion_r1299156114) by @AndriiHorishniiMOC regex.

Here is a detailed explanation of the characters:

- `\r\n` is a line break in Windows.
- `\n` is a line break in Unix (macOS, Linux, etc.).

The regular expression (`\r\n|\n`) is saying that it should match either a Windows line break `\r\n` OR a Unix line break `\n`. Therefore, this is a way of matching a line break in a text file regardless of the operating system where the file was created.


