### PR TITLE
Fix The chat history is empty after restoring the chat.

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -795,6 +795,7 @@ internal class ChatController(
         addOperatorMediaStateListenerUseCase.execute(operatorMediaStateListener)
         mediaUpgradeOfferRepository.startListening()
         emitViewState { chatState.engagementStarted() }
+        chatManager.reloadHistoryIfNeeded()
     }
 
     private fun initChatManager() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
@@ -14,7 +14,8 @@ internal class ManagerFactory(private val useCaseFactory: UseCaseFactory) {
                 appendNewChatMessageUseCase = createAppendNewChatMessageUseCase(),
                 sendUnsentMessagesUseCase = createSendUnsentMessagesUseCase(),
                 handleCustomCardClickUseCase = createHandleCustomCardClickUseCase(),
-                isOngoingEngagementUseCase = createIsOngoingEngagementUseCase()
+                isOngoingEngagementUseCase = createIsOngoingEngagementUseCase(),
+                isAuthenticatedUseCase = createIsAuthenticatedUseCase()
             )
         }
 }


### PR DESCRIPTION
I forgot to add the chat history reload step during chat flow optimization when a new engagement is established.
So here I added those steps and tests.

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2585
