### PR TITLE
Do not unsubscribe from engagement events for Call Visualizer

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -328,7 +328,7 @@ public class CallController implements
         viewCallback = null;
 
         if (!retain) {
-            disposable.dispose();
+            disposable.clear();
             mediaUpgradeOfferRepository.stopAll();
             mediaUpgradeOfferRepositoryCallback = null;
             if (callTimerStatusListener != null) {
@@ -823,10 +823,7 @@ public class CallController implements
                         break;
                 }
             });
-            omnibrowseEngagement.on(Engagement.Events.END, engagementState -> {
-                Glia.omnibrowse.off(Omnibrowse.Events.ENGAGEMENT);
-                viewCallback.destroyView();
-            });
+            omnibrowseEngagement.on(Engagement.Events.END, engagementState -> viewCallback.destroyView());
         });
     }
 


### PR DESCRIPTION
Some listeners subscribe only once in Call Visualizer, so we shouldn't unsubscribe

[SDK should receive and handle subsequent 2-way video and screen-sharing requests](https://glia.atlassian.net/browse/MOB-2556)
