### PR TITLE
Do not unsubscribe from engagement events for Call Visualizer

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -331,7 +331,7 @@ public class CallController implements
         viewCallback = null;
 
         if (!retain) {
-            disposable.dispose();
+            disposable.clear();
             mediaUpgradeOfferRepository.stopAll();
             mediaUpgradeOfferRepositoryCallback = null;
             if (callTimerStatusListener != null) {
@@ -826,10 +826,7 @@ public class CallController implements
                         break;
                 }
             });
-            omnibrowseEngagement.on(Engagement.Events.END, engagementState -> {
-                Glia.omnibrowse.off(Omnibrowse.Events.ENGAGEMENT);
-                viewCallback.destroyView();
-            });
+            omnibrowseEngagement.on(Engagement.Events.END, engagementState -> viewCallback.destroyView());
         });
     }
 


### PR DESCRIPTION
This is a back-port commit for the [Do not unsubscribe from engagement events for Call Visualizer](https://github.com/salemove/android-sdk-widgets/pull/732) hotfix.
