### PR TITLE
Cover Response text with snapshot tests

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaResponseTextViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/GvaResponseTextViewHolder.kt
@@ -5,18 +5,21 @@ import com.glia.widgets.UiTheme
 import com.glia.widgets.chat.model.GvaResponseText
 import com.glia.widgets.databinding.ChatOperatorMessageLayoutBinding
 import com.glia.widgets.databinding.ChatReceiveMessageContentBinding
+import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.fromHtml
 import com.glia.widgets.helper.getColorCompat
 import com.glia.widgets.helper.getColorStateListCompat
 import com.glia.widgets.helper.getFontCompat
 import com.glia.widgets.view.unifiedui.applyLayerTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
+import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 
 internal class GvaResponseTextViewHolder(
     operatorMessageBinding: ChatOperatorMessageLayoutBinding,
     private val messageContentBinding: ChatReceiveMessageContentBinding,
-    private val uiTheme: UiTheme
-) : OperatorBaseViewHolder(operatorMessageBinding.root, operatorMessageBinding.chatHeadView, uiTheme)  {
+    private val uiTheme: UiTheme,
+    unifiedTheme: UnifiedTheme? = Dependencies.getGliaThemeManager().theme
+) : OperatorBaseViewHolder(operatorMessageBinding.root, operatorMessageBinding.chatHeadView, uiTheme, unifiedTheme)  {
 
     init {
         setupMessageContentView()

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHead.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHead.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64bb80818a30c995cb26dca3503adc0980c14314b4832f1760e6665aedaf803f
+size 77969

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHeadWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHeadWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d0e5f584796438f33ce56b1517812f46b8a08b34c46dedcf5fa19e8bad1eeb9
+size 69252

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHeadWithUiTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHeadWithUiTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6a0e343ed4894b03902daa760e64d570be927bc09108693a7d3e60d05ac12bf
+size 76486

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHeadWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withChatHeadWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48a76ed9c06ae5955a719432d0f3e050dc0e12a2c9c30c15b00eb5fecb433855
+size 72695

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHead.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHead.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:837d81cc9a5d27d08b59dc0b436e8405649dacb4b854a3d6922e18868f94dc33
+size 74942

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHeadWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHeadWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:562b3136193a81b2cc0737f3e5e200c575fdf0a4d8398329c65637008cffe767
+size 65418

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHeadWithUiTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHeadWithUiTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d36e7677f161d2e030f6ecac01953412653e891802c9f2701e63efa10364dae2
+size 72093

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHeadWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat.adapter.holder_GvaResponseTextViewHolderSnapshotTest_withoutChatHeadWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b3e6d568233d4cc8140cd5e2b6c520f023148060df2cda80bbda6eab173b83
+size 69171

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaResponseTextViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaResponseTextViewHolderSnapshotTest.kt
@@ -2,19 +2,17 @@ package com.glia.widgets.chat.adapter.holder
 
 import com.glia.widgets.SnapshotTest
 import com.glia.widgets.UiTheme
-import com.glia.widgets.chat.model.GvaButton
-import com.glia.widgets.chat.model.GvaPersistentButtons
-import com.glia.widgets.databinding.ChatGvaPersistentButtonsContentBinding
+import com.glia.widgets.chat.model.GvaResponseText
 import com.glia.widgets.databinding.ChatOperatorMessageLayoutBinding
+import com.glia.widgets.databinding.ChatReceiveMessageContentBinding
 import com.glia.widgets.snapshotutils.SnapshotGva
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
+class GvaResponseTextViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
 
-    private fun gvaPersistentButtons(showChatHead: Boolean = false) = GvaPersistentButtons(
+    private fun gvaResponseText(showChatHead: Boolean = false) = GvaResponseText(
         content = gvaLongSubtitle(),
-        options = mediumLengthTexts().map { GvaButton(it) },
         showChatHead = showChatHead
     )
 
@@ -24,7 +22,7 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withoutChatHead() {
         snapshot(
             setupView(
-                gvaPersistentButtons()
+                gvaResponseText()
             ).viewHolder.itemView
         )
     }
@@ -33,7 +31,7 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withoutChatHeadWithUiTheme() {
         snapshot(
             setupView(
-                gvaPersistentButtons(),
+                gvaResponseText(),
                 uiTheme = uiTheme()
             ).viewHolder.itemView
         )
@@ -43,7 +41,7 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withoutChatHeadWithGlobalColors() {
         snapshot(
             setupView(
-                gvaPersistentButtons(),
+                gvaResponseText(),
                 unifiedTheme = unifiedThemeWithGlobalColors()
             ).viewHolder.itemView
         )
@@ -53,18 +51,8 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withoutChatHeadWithUnifiedTheme() {
         snapshot(
             setupView(
-                gvaPersistentButtons(),
+                gvaResponseText(),
                 unifiedTheme = unifiedTheme()
-            ).viewHolder.itemView
-        )
-    }
-
-    @Test
-    fun withoutChatHeadUnifiedThemeWithoutGva() {
-        snapshot(
-            setupView(
-                gvaPersistentButtons(),
-                unifiedTheme = unifiedThemeWithoutGva()
             ).viewHolder.itemView
         )
     }
@@ -75,7 +63,7 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withChatHead() {
         snapshot(
             setupView(
-                gvaPersistentButtons(
+                gvaResponseText(
                     showChatHead = true
                 ),
             ).viewHolder.itemView
@@ -86,7 +74,7 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withChatHeadWithUiTheme() {
         snapshot(
             setupView(
-                gvaPersistentButtons(
+                gvaResponseText(
                     showChatHead = true
                 ),
                 uiTheme = uiTheme()
@@ -98,7 +86,7 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withChatHeadWithGlobalColors() {
         snapshot(
             setupView(
-                gvaPersistentButtons(
+                gvaResponseText(
                     showChatHead = true
                 ),
                 unifiedTheme = unifiedThemeWithGlobalColors()
@@ -110,22 +98,10 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
     fun withChatHeadWithUnifiedTheme() {
         snapshot(
             setupView(
-                gvaPersistentButtons(
+                gvaResponseText(
                     showChatHead = true
                 ),
                 unifiedTheme = unifiedTheme()
-            ).viewHolder.itemView
-        )
-    }
-
-    @Test
-    fun withChatHeadUnifiedThemeWithoutGva() {
-        snapshot(
-            setupView(
-                gvaPersistentButtons(
-                    showChatHead = true
-                ),
-                unifiedTheme = unifiedThemeWithoutGva()
             ).viewHolder.itemView
         )
     }
@@ -134,25 +110,24 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva {
 
     private data class ViewData(
         val chatOperatorMessageLayoutBinding: ChatOperatorMessageLayoutBinding,
-        val gvaPersistentButtonsContentBinding: ChatGvaPersistentButtonsContentBinding,
-        val viewHolder: GvaPersistentButtonsViewHolder
+        val gvaPersistentButtonsContentBinding: ChatReceiveMessageContentBinding,
+        val viewHolder: GvaResponseTextViewHolder
     )
 
     private fun setupView(
-        card: GvaPersistentButtons,
+        card: GvaResponseText,
         unifiedTheme: UnifiedTheme? = null,
         uiTheme: UiTheme = UiTheme()
     ): ViewData {
         val chatOperatorMessageLayoutBinding = ChatOperatorMessageLayoutBinding.inflate(layoutInflater)
-        val gvaPersistentButtonsContentBinding = ChatGvaPersistentButtonsContentBinding.inflate(
+        val gvaPersistentButtonsContentBinding = ChatReceiveMessageContentBinding.inflate(
             layoutInflater,
             chatOperatorMessageLayoutBinding.contentLayout,
             true
         )
-        val viewHolder = GvaPersistentButtonsViewHolder(
+        val viewHolder = GvaResponseTextViewHolder(
             chatOperatorMessageLayoutBinding,
             gvaPersistentButtonsContentBinding,
-            {},
             uiTheme,
             unifiedTheme
         )


### PR DESCRIPTION
Added snapshot tests for GVA Response text.

[MOB-2601](https://glia.atlassian.net/browse/MOB-2601)

[MOB-2601]: https://glia.atlassian.net/browse/MOB-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ