### PR TITLE
Improve chat flow to handle sent message responses

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -125,7 +125,9 @@ internal class ChatManager constructor(
 
     @VisibleForTesting
     fun checkUnsentMessages(state: State) {
-        sendUnsentMessagesUseCase(state.unsentItems.firstOrNull() ?: return) {}
+        sendUnsentMessagesUseCase(state.unsentItems.firstOrNull() ?: return) {
+            onChatAction(Action.MessageSent(it))
+        }
     }
 
     @VisibleForTesting
@@ -187,9 +189,12 @@ internal class ChatManager constructor(
             is Action.OnMediaUpgradeTimerUpdated -> mapMediaUpgradeTimerUpdated(action.formattedValue, state)
             is Action.CustomCardClicked -> mapCustomCardClicked(action, state)
             Action.ChatRestored -> state
+            is Action.MessageSent -> mapMessageSent(action.message, state)
         }
     }
 
+    @VisibleForTesting
+    fun mapMessageSent(message: VisitorMessage, state: State): State = mapNewMessage(ChatMessageInternal(message), state)
 
     @VisibleForTesting
     fun mapCustomCardClicked(action: Action.CustomCardClicked, state: State): State = action.run {
@@ -359,5 +364,6 @@ internal class ChatManager constructor(
         object OnMediaUpgradeCanceled : Action
         data class CustomCardClicked(val customCard: CustomCardChatItem, val attachment: SingleChoiceAttachment) : Action
         object ChatRestored : Action
+        data class MessageSent(val message: VisitorMessage) : Action
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapter.kt
@@ -215,8 +215,11 @@ internal class ChatAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: MutableList<Any>) {
-        val isHandled: Boolean = when (val item: ChatItem = differ.currentList[position]) {
-            is MediaUpgradeStartedTimerItem -> updateMediaUpgradeTimer(payloads, holder as MediaUpgradeStartedViewHolder)
+        val isHandled: Boolean = when (holder) {
+            is MediaUpgradeStartedViewHolder -> updateMediaUpgradeTimer(payloads, holder)
+            is VisitorMessageViewHolder -> updateDeliveredState(payloads, holder)
+            is VisitorFileAttachmentViewHolder -> updateDeliveredState(payloads, holder)
+            is VisitorImageAttachmentViewHolder -> updateDeliveredState(payloads, holder)
             else -> false
         }
 
@@ -224,6 +227,24 @@ internal class ChatAdapter(
             super.onBindViewHolder(holder, position, payloads)
         }
     }
+
+    private fun updateDeliveredState(payloads: MutableList<Any>, holder: VisitorMessageViewHolder): Boolean =
+        payloads.lastOrNull { it is Boolean }?.let {
+            holder.updateDelivered(it as Boolean)
+            true
+        } ?: false
+
+    private fun updateDeliveredState(payloads: MutableList<Any>, holder: VisitorFileAttachmentViewHolder): Boolean =
+        payloads.lastOrNull { it is Boolean }?.let {
+            holder.updateDelivered(it as Boolean)
+            true
+        } ?: false
+
+    private fun updateDeliveredState(payloads: MutableList<Any>, holder: VisitorImageAttachmentViewHolder): Boolean =
+        payloads.lastOrNull { it is Boolean }?.let {
+            holder.updateDelivered(it as Boolean)
+            true
+        } ?: false
 
     private fun updateMediaUpgradeTimer(payloads: MutableList<Any>, viewHolder: MediaUpgradeStartedViewHolder): Boolean = payloads.run {
         firstOrNull() as? String

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapterDiffCallback.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapterDiffCallback.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.chat.adapter
 import androidx.recyclerview.widget.DiffUtil
 import com.glia.widgets.chat.model.ChatItem
 import com.glia.widgets.chat.model.MediaUpgradeStartedTimerItem
+import com.glia.widgets.chat.model.VisitorChatItem
 
 internal class ChatAdapterDiffCallback : DiffUtil.ItemCallback<ChatItem>() {
     override fun areItemsTheSame(oldItem: ChatItem, newItem: ChatItem): Boolean = oldItem.id == newItem.id
@@ -11,6 +12,7 @@ internal class ChatAdapterDiffCallback : DiffUtil.ItemCallback<ChatItem>() {
     override fun getChangePayload(oldItem: ChatItem, newItem: ChatItem): Any? = when {
         oldItem is MediaUpgradeStartedTimerItem.Audio && newItem is MediaUpgradeStartedTimerItem.Audio -> newItem.time
         oldItem is MediaUpgradeStartedTimerItem.Video && newItem is MediaUpgradeStartedTimerItem.Video -> newItem.time
+        oldItem is VisitorChatItem && newItem is VisitorChatItem -> newItem.showDelivered
         else -> null
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolder.kt
@@ -57,4 +57,8 @@ internal class VisitorMessageViewHolder(
         )
         itemView.contentDescription = contentDescription
     }
+
+    fun updateDelivered(delivered: Boolean) {
+        binding.deliveredView.isVisible = delivered
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/fileattachment/VisitorFileAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/fileattachment/VisitorFileAttachmentViewHolder.java
@@ -70,4 +70,8 @@ public class VisitorFileAttachmentViewHolder extends FileAttachmentViewHolder {
             }
         });
     }
+
+    public void updateDelivered(boolean delivered) {
+        deliveredView.setVisibility(delivered ? View.VISIBLE : View.GONE);
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/VisitorImageAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/VisitorImageAttachmentViewHolder.java
@@ -20,11 +20,11 @@ public class VisitorImageAttachmentViewHolder extends ImageAttachmentViewHolder 
     private final TextView deliveredView;
 
     public VisitorImageAttachmentViewHolder(
-            @NonNull View itemView,
-            UiTheme uiTheme,
-            GetImageFileFromCacheUseCase getImageFileFromCacheUseCase,
-            GetImageFileFromDownloadsUseCase getImageFileFromDownloadsUseCase,
-            GetImageFileFromNetworkUseCase getImageFileFromNetworkUseCase
+        @NonNull View itemView,
+        UiTheme uiTheme,
+        GetImageFileFromCacheUseCase getImageFileFromCacheUseCase,
+        GetImageFileFromDownloadsUseCase getImageFileFromDownloadsUseCase,
+        GetImageFileFromNetworkUseCase getImageFileFromNetworkUseCase
     ) {
         super(itemView, getImageFileFromCacheUseCase, getImageFileFromDownloadsUseCase, getImageFileFromNetworkUseCase);
         deliveredView = itemView.findViewById(R.id.delivered_view);
@@ -41,10 +41,10 @@ public class VisitorImageAttachmentViewHolder extends ImageAttachmentViewHolder 
     private void setAccessibilityLabels(boolean showDelivered) {
         if (showDelivered) {
             itemView.setContentDescription(itemView.getResources().getString(
-                    R.string.glia_chat_visitor_image_delivered_content_description));
+                R.string.glia_chat_visitor_image_delivered_content_description));
         } else {
             itemView.setContentDescription(itemView.getResources().getString(
-                    R.string.glia_chat_visitor_image_content_description));
+                R.string.glia_chat_visitor_image_content_description));
         }
     }
 
@@ -58,5 +58,9 @@ public class VisitorImageAttachmentViewHolder extends ImageAttachmentViewHolder 
             deliveredView.setTypeface(fontFamily);
         }
         deliveredView.setTextColor(ContextCompat.getColor(context, uiTheme.getBaseNormalColor()));
+    }
+
+    public void updateDelivered(boolean delivered) {
+        deliveredView.setVisibility(delivered ? View.VISIBLE : View.GONE);
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -158,6 +158,7 @@ internal class ChatController(
         object : GliaSendMessageUseCase.Listener {
             override fun messageSent(message: VisitorMessage?) {
                 Logger.d(TAG, "messageSent: $message, id: ${message?.id}")
+                message?.also { chatManager.onChatAction(ChatManager.Action.MessageSent(it)) }
                 scrollChatToBottom()
             }
 
@@ -519,6 +520,7 @@ internal class ChatController(
                     dialogController.dismissDialogs()
                 }
             }
+
             EngagementStateEvent.Type.NO_ENGAGEMENT -> {
                 Logger.d(TAG, "NoEngagement")
             }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendHistoryChatItemUseCases.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendHistoryChatItemUseCases.kt
@@ -98,7 +98,7 @@ internal class AppendHistoryVisitorChatItemUseCase(
             }
 
             if (content.isNotBlank()) {
-                chatItems += VisitorMessageItem.History(id, timestamp, content)
+                chatItems += VisitorMessageItem(content, id, timestamp)
             }
         }
 
@@ -131,7 +131,7 @@ internal class AppendHistoryCustomCardItemUseCase(
         message.attachment?.asSingleChoice()?.selectedOptionText?.takeIf {
             it.isNotBlank()
         }?.let {
-            VisitorMessageItem.History(message.id, message.timestamp, it)
+            VisitorMessageItem(it, message.id, message.timestamp)
         }?.also {
             chatItems.add(it)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
@@ -149,7 +149,7 @@ internal class AppendNewVisitorMessageUseCase(
             }
 
             state.chatItems[index] = message.run {
-                lastDeliveredItem = VisitorMessageItem.Delivered(id, timestamp, content)
+                lastDeliveredItem = VisitorMessageItem(content, id, timestamp, true)
                 lastDeliveredItem!!
             }
 
@@ -168,11 +168,7 @@ internal class AppendNewVisitorMessageUseCase(
                 val hasFiles = !files.isNullOrEmpty()
 
                 if (content.isNotBlank()) {
-                    if (hasFiles) {
-                        state.chatItems += VisitorMessageItem.New(id, timestamp, content)
-                    } else {
-                        state.chatItems += VisitorMessageItem.Delivered(id, timestamp, content)
-                    }
+                    state.chatItems += VisitorMessageItem(content, id, timestamp, !hasFiles)
                 }
 
                 files?.forEachIndexed { index, attachmentFile ->

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/SendUnsentMessagesUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/SendUnsentMessagesUseCase.kt
@@ -1,30 +1,31 @@
 package com.glia.widgets.chat.domain
 
 import com.glia.androidsdk.chat.SingleChoiceAttachment
+import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.data.GliaChatRepository
 import com.glia.widgets.chat.model.Unsent
 
 
 internal class SendUnsentMessagesUseCase(private val chatRepository: GliaChatRepository) {
-    operator fun invoke(message: Unsent, onSuccess: () -> Unit) {
+    operator fun invoke(message: Unsent, onSuccess: (VisitorMessage) -> Unit) {
         when (message) {
             is Unsent.Attachment -> sendAttachment(message.attachment, onSuccess)
             is Unsent.Message -> sendMessage(message.message, onSuccess)
         }
     }
 
-    private fun sendAttachment(attachment: SingleChoiceAttachment, onSuccess: () -> Unit) {
+    private fun sendAttachment(attachment: SingleChoiceAttachment, onSuccess: (VisitorMessage) -> Unit) {
         chatRepository.sendResponse(attachment) { response, exception ->
             if (exception == null && response != null) {
-                onSuccess()
+                onSuccess(response)
             }
         }
     }
 
-    private fun sendMessage(message: String, onSuccess: () -> Unit) {
+    private fun sendMessage(message: String, onSuccess: (VisitorMessage) -> Unit) {
         chatRepository.sendMessage(message) { response, exception ->
             if (exception == null && response != null) {
-                onSuccess()
+                onSuccess(response)
             }
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatItems.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatItems.kt
@@ -8,6 +8,7 @@ import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.androidsdk.chat.SingleChoiceOption
 import com.glia.widgets.chat.adapter.ChatAdapter
 import com.glia.widgets.helper.isDownloaded
+import java.util.UUID
 
 internal abstract class ChatItem(@ChatAdapter.Type val viewType: Int) {
     abstract val id: String
@@ -231,44 +232,21 @@ internal sealed class VisitorAttachmentItem(@ChatAdapter.Type viewType: Int) : V
     }
 }
 
-internal sealed class VisitorMessageItem : VisitorChatItem(ChatAdapter.VISITOR_MESSAGE_TYPE) {
-    override val showDelivered: Boolean
-        get() = this is Delivered
-
-    abstract val message: String
+internal data class VisitorMessageItem(
+    val message: String,
+    override val id: String = UUID.randomUUID().toString(),
+    override val timestamp: Long = System.currentTimeMillis(),
+    override val showDelivered: Boolean = false
+) : VisitorChatItem(ChatAdapter.VISITOR_MESSAGE_TYPE) {
 
     override fun withDeliveredStatus(delivered: Boolean): VisitorChatItem {
         check(!delivered) { "The method should be called only with false value, to hide delivered status" }
-        return New(id, timestamp, message)
+        return copy(showDelivered = delivered)
     }
-
-    data class New(
-        override val id: String,
-        override val timestamp: Long,
-        override val message: String
-    ) : VisitorMessageItem()
-
-    data class History(
-        override val id: String,
-        override val timestamp: Long,
-        override val message: String
-    ) : VisitorMessageItem()
-
-    data class Unsent(
-        override val id: String = "",
-        override val timestamp: Long = System.currentTimeMillis(),
-        override val message: String
-    ) : VisitorMessageItem()
-
-    data class Delivered(
-        override val id: String,
-        override val timestamp: Long,
-        override val message: String
-    ) : VisitorMessageItem()
 }
 
 internal sealed class Unsent(val content: String) {
-    val chatMessage: VisitorMessageItem.Unsent = VisitorMessageItem.Unsent(message = content)
+    val chatMessage: VisitorMessageItem = VisitorMessageItem(message = content)
 
     data class Message(val message: String) : Unsent(message)
     data class Attachment(val attachment: SingleChoiceAttachment) : Unsent(attachment.selectedOptionText)

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -297,6 +297,16 @@ class ChatManagerTest {
     }
 
     @Test
+    fun `mapMessageSent adds new Message`() {
+        val action: ChatManager.Action.MessageSent = mock {
+            on { message } doReturn mock()
+        }
+
+        subjectUnderTest.mapMessageSent(action.message, state)
+        verify(subjectUnderTest).mapNewMessage(any(), eq(state))
+    }
+
+    @Test
     fun `mapCustomCardClicked updates Custom Card`() {
         val action: ChatManager.Action.CustomCardClicked = mock {
             on { customCard } doReturn mock()
@@ -481,11 +491,16 @@ class ChatManagerTest {
         val mockUnsentMessage: Unsent.Message = mock {
             on { message } doReturn "message"
         }
+
+        whenever(sendUnsentMessagesUseCase(any(), any())).thenAnswer {
+            (it.getArgument(1) as ((VisitorMessage) -> Unit)).invoke(mock())
+        }
+
         state.unsentItems.add(mockUnsentMessage)
 
         subjectUnderTest.checkUnsentMessages(state)
-
         verify(sendUnsentMessagesUseCase).invoke(any(), any())
+        verify(subjectUnderTest).onChatAction(any())
     }
 
     @Test

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendHistoryCustomCardItemUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendHistoryCustomCardItemUseCaseTest.kt
@@ -63,6 +63,6 @@ class AppendHistoryCustomCardItemUseCaseTest {
 
         assertTrue(items.isNotEmpty())
         assertTrue(items.first() is CustomCardChatItem)
-        assertTrue(items[1] is VisitorMessageItem.History)
+        assertTrue(items[1] is VisitorMessageItem)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendHistoryVisitorChatItemUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendHistoryVisitorChatItemUseCaseTest.kt
@@ -45,7 +45,7 @@ class AppendHistoryVisitorChatItemUseCaseTest {
         useCase(items, visitorMessage)
 
         assertTrue(items.count() == 1)
-        assertTrue(items.last() is VisitorMessageItem.History)
+        assertTrue(items.last() is VisitorMessageItem)
     }
 
     @Test
@@ -75,7 +75,7 @@ class AppendHistoryVisitorChatItemUseCaseTest {
 
         assertTrue(items.count() == 2)
         assertTrue(items.first() is VisitorAttachmentItem.File)
-        assertTrue(items[1] is VisitorMessageItem.History)
+        assertTrue(items[1] is VisitorMessageItem)
     }
 
     @Test
@@ -101,6 +101,6 @@ class AppendHistoryVisitorChatItemUseCaseTest {
         assertTrue(items.count() == 3)
         assertTrue(items.first() is VisitorAttachmentItem.File)
         assertTrue(items[1] is VisitorAttachmentItem.Image)
-        assertTrue(items[2] is VisitorMessageItem.History)
+        assertTrue(items[2] is VisitorMessageItem)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewOperatorMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewOperatorMessageUseCaseTest.kt
@@ -102,7 +102,7 @@ class AppendNewOperatorMessageUseCaseTest {
         whenever(isGvaUseCase(any())) doReturn false
         doAnswer {
             state.chatItems.add(mock())
-            state.chatItems.add(mock<VisitorMessageItem.New>())
+            state.chatItems.add(mock<VisitorMessageItem>())
         }.whenever(appendNewResponseCardOrTextItemUseCase).invoke(any(), any())
 
         useCase(state, chatMessageInternal)

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
@@ -65,7 +65,7 @@ class AppendNewVisitorMessageUseCaseTest {
 
     @Test
     fun `addUnsentItem returns true when unsentItems and chatItems contain received message`() {
-        val lastDelivered: VisitorChatItem = VisitorMessageItem.Delivered("id", 1, "message")
+        val lastDelivered: VisitorChatItem = VisitorMessageItem("message", "id", 1, true)
 
         useCase.lastDeliveredItem = lastDelivered
         state.chatItems.add(lastDelivered)
@@ -81,8 +81,8 @@ class AppendNewVisitorMessageUseCaseTest {
 
         assertTrue(useCase.addUnsentItem(state, visitorMessage))
         assertTrue(state.unsentItems.isEmpty())
-        assertTrue(state.chatItems.last() is VisitorMessageItem.Delivered)
-        assertTrue(state.chatItems.first() is VisitorMessageItem.New)
+        assertTrue(state.chatItems.last() is VisitorMessageItem)
+        assertTrue(state.chatItems.first() is VisitorMessageItem)
     }
 
     @Test
@@ -106,7 +106,7 @@ class AppendNewVisitorMessageUseCaseTest {
         useCase(state, chatMessageInternal)
 
         assertTrue(state.chatItems.count() == 1)
-        assertTrue(state.chatItems.first() is VisitorMessageItem.Delivered)
+        assertTrue(state.chatItems.first() is VisitorMessageItem)
     }
 
     @Test
@@ -131,7 +131,7 @@ class AppendNewVisitorMessageUseCaseTest {
         useCase(state, chatMessageInternal)
 
         assertTrue(state.chatItems.count() == 2)
-        assertTrue(state.chatItems.first() is VisitorMessageItem.New)
+        assertTrue(state.chatItems.first() is VisitorMessageItem)
         assertTrue(state.chatItems.last() is VisitorAttachmentItem.File)
         assertTrue((state.chatItems.last() as VisitorChatItem).showDelivered)
         assertTrue(useCase.lastDeliveredItem is VisitorAttachmentItem.File)


### PR DESCRIPTION
Previously, the chat flow only rendered visitor messages from the chat messages socket and ignored responses from the send message endpoint. However, these messages were not rendered during socket reconnection, leading to user confusion.

***Changes:***
- Add functions to handle send message response
- Remove redundant sealed classes from the Visitor message
- Optimize ChatAdapter for delivered status update

MOB 2603
