### PR TITLE
Fix the dialog display logic

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -220,10 +220,10 @@ internal class CallView(
         floatingVisitorVideoContainer.onResume()
         callController?.onResume()
         operatorVideoView?.resumeRendering()
+        dialogController?.addCallback(dialogCallback)
         screenSharingController?.setViewCallback(screenSharingViewCallback)
         screenSharingController?.onResume(context.requireActivity())
         serviceChatHeadController?.onResume(this)
-        dialogController?.addCallback(dialogCallback)
     }
 
     fun onPause() {
@@ -390,17 +390,14 @@ internal class CallView(
                 positiveButtonText = resources.getString(R.string.glia_dialog_screen_sharing_offer_enable_notifications_yes),
                 negativeButtonText = resources.getString(R.string.glia_dialog_screen_sharing_offer_enable_notifications_no),
                 positiveButtonClickListener = {
-                    dismissAlertDialog()
                     callController?.notificationsDialogDismissed()
                     this.context.openNotificationChannelScreen()
                 },
                 negativeButtonClickListener = {
-                    dismissAlertDialog()
                     callController?.notificationsDialogDismissed()
                     screenSharingController?.onScreenSharingDeclined()
                 },
                 cancelListener = {
-                    it.dismiss()
                     callController?.notificationsDialogDismissed()
                     screenSharingController?.onScreenSharingDeclined()
                 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
@@ -141,12 +141,10 @@ internal class ActivityWatcherForCallVisualizerController(
         }
         watcher.removeDialogFromStack()
         currentDialogMode = MODE_NONE
-        watcher.destroySupportActivityIfExists()
     }
 
     override fun onNegativeDialogButtonClicked() {
         Logger.d(TAG, "onNegativeButtonDialogButtonClicked() - $currentDialogMode")
-        watcher.removeDialogFromStack()
         when (currentDialogMode) {
             MODE_NONE -> Logger.e(TAG, "$currentDialogMode should not have a dialog to click")
             MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING,
@@ -162,6 +160,7 @@ internal class ActivityWatcherForCallVisualizerController(
             MODE_VISITOR_CODE,
             MODE_ENABLE_NOTIFICATION_CHANNEL -> Logger.d(TAG, "$currentDialogMode no operation")
         }
+        watcher.removeDialogFromStack()
         currentDialogMode = MODE_NONE
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
@@ -164,6 +164,10 @@ public class DialogController {
         viewCallbacks.remove(callback);
     }
 
+    public boolean isEnableScreenSharingNotificationsAndStartSharingDialogShown() {
+        return Dialog.MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING == dialogManager.getCurrentMode();
+    }
+
     private boolean isOverlayDialogShown() {
         return Dialog.MODE_OVERLAY_PERMISSION == dialogManager.getCurrentMode();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
@@ -70,6 +70,13 @@ internal class ScreenSharingController(
         // spam all the time otherwise no way to end screen sharing
         if (hasPendingScreenSharingRequest) {
             if (!hasScreenSharingNotificationChannelEnabledUseCase.invoke()) {
+                if (dialogController.isEnableScreenSharingNotificationsAndStartSharingDialogShown) {
+                    // Do not need to request dialog again if this dialog is already shown.
+                    //
+                    // It prevents the infinity cycle of trying to display
+                    // this dialog if the CallVisualizerSupportActivity is used for it.
+                    return
+                }
                 dialogController.showEnableScreenSharingNotificationsAndStartSharingDialog()
             } else {
                 onScreenSharingAccepted(activity)
@@ -87,7 +94,6 @@ internal class ScreenSharingController(
 
     fun onScreenSharingAccepted(activity: Activity) {
         Logger.d(TAG, "onScreenSharingAccepted")
-        dialogController.dismissCurrentDialog()
         showScreenSharingEnabledNotification()
         repository.onScreenSharingAccepted(
             activity,
@@ -98,7 +104,6 @@ internal class ScreenSharingController(
 
     fun onScreenSharingAcceptedAndPermissionAsked(activity: Activity) {
         Logger.d(TAG, "onScreenSharingAcceptedAndPermissionAsked")
-        dialogController.dismissCurrentDialog()
         showScreenSharingEnabledNotification()
         repository.onScreenSharingAcceptedAndPermissionAsked(
             activity,
@@ -109,7 +114,6 @@ internal class ScreenSharingController(
 
     fun onScreenSharingDeclined() {
         Logger.d(TAG, "onScreenSharingDeclined")
-        dialogController.dismissCurrentDialog()
         repository.onScreenSharingDeclined()
         hasPendingScreenSharingRequest = false
         hideScreenSharingEnabledNotification()

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerControllerTest.kt
@@ -141,7 +141,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         verify(watcher).removeDialogFromStack()
         verify(watcher).dismissOverlayDialog()
         verify(watcher).openOverlayPermissionView()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -150,7 +149,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         resetMocks()
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -174,7 +172,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         verify(watcher).removeDialogFromStack()
         verify(watcher).openNotificationChannelScreen()
         verify(watcher).isSupportActivityOpen()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -200,7 +197,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         verify(watcher).removeDialogFromStack()
         verify(watcher).openCallActivity()
         verify(watcher).isSupportActivityOpen()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -222,7 +218,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         verify(watcher).removeDialogFromStack()
         verify(watcher).openOverlayPermissionView()
         verify(watcher).isSupportActivityOpen()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -245,7 +240,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         verify(watcher).removeDialogFromStack()
         verify(watcher).openNotificationChannelScreen()
         verify(watcher).isSupportActivityOpen()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -267,7 +261,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         verify(watcher).removeDialogFromStack()
         verify(watcher).isSupportActivityOpen()
         verify(watcher).openSupportActivity(any())
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -278,7 +271,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(watcher).isSupportActivityOpen()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test
@@ -299,7 +291,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(watcher).isSupportActivityOpen()
-        verify(watcher).destroySupportActivityIfExists()
         verify(watcher).openSupportActivity(any())
     }
     @Test
@@ -310,7 +301,6 @@ internal class ActivityWatcherForCallVisualizerControllerTest {
         controller.onPositiveDialogButtonClicked()
         verify(watcher).removeDialogFromStack()
         verify(watcher).isSupportActivityOpen()
-        verify(watcher).destroySupportActivityIfExists()
     }
 
     @Test

--- a/widgetssdk/src/test/java/com/glia/widgets/core/screensharing/ScreenSharingControllerTest.java
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/screensharing/ScreenSharingControllerTest.java
@@ -2,6 +2,7 @@ package com.glia.widgets.core.screensharing;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -93,14 +94,13 @@ public class ScreenSharingControllerTest {
     }
 
     @Test
-    public void onResume_hidesDialogShowsNotificationAcceptsScreenSharing_whenNotificationChannelEnabled() {
+    public void onResume_acceptsScreenSharing_whenNotificationChannelEnabled() {
         subjectUnderTest.hasPendingScreenSharingRequest = true;
         when(hasScreenSharingNotificationChannelEnabledUseCase.invoke())
                 .thenReturn(true);
 
         subjectUnderTest.onResume(mock(Activity.class));
 
-        verify(dialogController).dismissCurrentDialog();
         verify(showScreenSharingNotificationUseCase).invoke();
         verify(gliaScreenSharingRepository).onScreenSharingAccepted(any(), any());
     }
@@ -117,19 +117,29 @@ public class ScreenSharingControllerTest {
     }
 
     @Test
-    public void onScreenSharingAccepted_hidesDialogShowsNotificationAcceptsScreenSharing() {
+    public void onResume_doNothing_whenEnableScreenSharingNotificationsAndStartSharingDialogShown() {
+        subjectUnderTest.hasPendingScreenSharingRequest = true;
+        when(hasScreenSharingNotificationChannelEnabledUseCase.invoke())
+            .thenReturn(false);
+        when(dialogController.isEnableScreenSharingNotificationsAndStartSharingDialogShown()).thenReturn(true);
+
+        subjectUnderTest.onResume(mock(Activity.class));
+
+        verify(dialogController, never()).showEnableScreenSharingNotificationsAndStartSharingDialog();
+    }
+
+    @Test
+    public void onScreenSharingAccepted_acceptsScreenSharing() {
         subjectUnderTest.onScreenSharingAccepted(mock(Activity.class));
 
-        verify(dialogController).dismissCurrentDialog();
         verify(showScreenSharingNotificationUseCase).invoke();
         verify(gliaScreenSharingRepository).onScreenSharingAccepted(any(), any());
     }
 
     @Test
-    public void onScreenSharingDeclined_hidesDialogShowsNotificationAcceptsScreenSharing() {
+    public void onScreenSharingDeclined_declinesScreenSharing() {
         subjectUnderTest.onScreenSharingDeclined();
 
-        verify(dialogController).dismissCurrentDialog();
         verify(gliaScreenSharingRepository).onScreenSharingDeclined();
     }
 


### PR DESCRIPTION
Made changes to dialog logic to solve race conditions and fix the dialogs queue.

In a nutshell, a dialog should be dismissed once, using the `Dialog.MODE_NONE` state. SupportActivity also should be destroyed by the `Dialog.MODE_NONE` state. The dialog `stateDeque` should be changed and all actions should be done before destroying the SupportActivity if it is used.

Demonstration:
1. The operator asks for screen-sharing
2. The user answers NO
3. The operator asks one-way video
4. The operator asks for screen-sharing
5. The user answers NO to screen-sharing
6. The user ACCEPTS one-way video
7. The operator asks two-way video
8. The operator asks for screen-sharing
9. The user answers YES to screen-sharing but does not allow notifications in the settings screen
10. The user answers NO to screen-sharing
11. The user DECLINES one-way video
12. The operator asks two-way video
13. The operator asks for screen-sharing
14. The user answers YES to screen-sharing and allows notifications in the settings screen
15. The user starts screen-sharing
16. The user ACCEPTS one-way video

https://github.com/salemove/android-sdk-widgets/assets/79906470/2af6eed7-2127-4c97-a47f-dedd04f253c7

[MOB-2589](https://glia.atlassian.net/browse/MOB-2589)


[MOB-2589]: https://glia.atlassian.net/browse/MOB-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ