### PR TITLE
Display bubble right after Glia init if engagement is present

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
@@ -1,6 +1,8 @@
 package com.glia.widgets.view.head.controller
 
+import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Glia
+import com.glia.androidsdk.engagement.EngagementState
 import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase
@@ -26,7 +28,15 @@ internal class ActivityWatcherForChatHeadController(
     internal var screenSharingViewCallback: ScreenSharingController.ViewCallback? = null
 
     override fun init() {
-        gliaOnEngagementUseCase.execute { watcher.addChatHeadLayoutIfAbsent() }
+        gliaOnEngagementUseCase.execute { engagement ->
+            showBubble()
+
+            engagement.on(
+                Engagement.Events.STATE_UPDATE
+            ) { engagementState: EngagementState? ->
+                showBubble()
+            }
+        }
     }
 
     override fun shouldShowBubble(gliaOrRootView: String?): Boolean {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.java
@@ -22,6 +22,7 @@ import com.glia.widgets.core.engagement.domain.GliaOnEngagementUseCase;
 import com.glia.widgets.core.visitor.VisitorMediaUpdatesListener;
 import com.glia.widgets.core.visitor.domain.AddVisitorMediaStateListenerUseCase;
 import com.glia.widgets.core.visitor.domain.RemoveVisitorMediaStateListenerUseCase;
+import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.CommonExtensionsKt;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.view.MessagesNotSeenHandler;
@@ -177,7 +178,7 @@ public class ServiceChatHeadController
 
     public void init() {
         gliaOnEngagementUseCase.execute(this::newEngagementLoaded);
-        gliaOnCallVisualizerUseCase.invoke(this::newEngagementLoaded);
+        gliaOnCallVisualizerUseCase.invoke(this::newCallVisualizerEngagementLoaded);
         messagesNotSeenHandler.addListener(this::onUnreadMessageCountChange);
         addVisitorMediaStateListenerUseCase.execute(this);
     }
@@ -221,10 +222,11 @@ public class ServiceChatHeadController
         engagementDisposables.add(operatorDisposable);
         gliaOnEngagementEndUseCase.execute(this);
         toggleChatHeadServiceUseCase.invoke(resumedViewName);
+        if (sdkConfiguration == null) setSdkConfiguration(Dependencies.getSdkConfigurationManager().createWidgetsConfiguration());
         updateChatHeadView();
     }
 
-    private void newEngagementLoaded(OmnibrowseEngagement engagement) {
+    private void newCallVisualizerEngagementLoaded(OmnibrowseEngagement engagement) {
         state = State.ENGAGEMENT;
         if (operatorDisposable != null) operatorDisposable.dispose();
         operatorDisposable = getOperatorFlowableUseCase.execute()
@@ -235,6 +237,7 @@ public class ServiceChatHeadController
         engagementDisposables.add(operatorDisposable);
         // To recieve callback to engagementEnded() after Call Visualizer engagement ends
         gliaOnCallVisualizerEndUseCase.execute(this);
+        if (sdkConfiguration == null) setSdkConfiguration(Dependencies.getSdkConfigurationManager().createWidgetsConfiguration());
         updateChatHeadView();
     }
 


### PR DESCRIPTION
[Bubble is not displayed after Glia is initialized and engagement is restored](https://glia.atlassian.net/browse/MOB-2626)

**Steps to reproduce:**

Prerequisites: There is ongoing chat engagement.

1. Close the app
3. Open the app
5. Init Glia

**Expected result:** bubble is displayed for both cases: when screen overlay permission is/isn’t granted. Bubble displays operator avatar (if any). Bubble displays person icon if there is no avatar. Bubble tap navigates to chat screen.

**Actual result:** 

1) If overlay permission isn’t granted - bubble is not displayed. Although if visitor minimizes the app and maximizes again, bubble is displayed as per expected result. 

2) If if overlay permission is granted - bubble is not displayed. If visitor minimizes the app, bubble is displayed but person icon is displayed instead of the operator avatar. Bubble tap doesn’t navigate anywhere.

**This was happening because:**
1. There was no trigger to start ChatHeadService on Engagement start and on Engagement state update.
2. SDK hasn't yet been configured for the use case from steps to reproduce.
