### PR TITLE
Fix screen sharing request

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
@@ -169,7 +169,9 @@ internal class ActivityWatcherForCallVisualizerController(
         if (callVisualizerController.isCallOrChatScreenActiveUseCase(activity)) return
         setupScreenSharingViewCallback()
         screenSharingController.setViewCallback(screenSharingViewCallback)
-        screenSharingController.onResume(activity)
+        screenSharingController.onResume(activity) {
+            startScreenSharing(activity)
+        }
     }
 
     private fun removeScreenSharingCallback() {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.core.screensharing
 import android.app.Activity
 import androidx.annotation.VisibleForTesting
 import com.glia.androidsdk.GliaException
+import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager
 import com.glia.widgets.core.dialog.DialogController
 import com.glia.widgets.core.notification.domain.RemoveScreenSharingNotificationUseCase
@@ -66,7 +67,7 @@ internal class ScreenSharingController(
         viewCallbacks.forEach(Consumer { obj: ViewCallback -> obj.onScreenSharingRequestSuccess() })
     }
 
-    fun onResume(activity: Activity) {
+    fun onResume(activity: Activity, requestScreenSharingCallback: (() -> Unit)? = null) {
         // spam all the time otherwise no way to end screen sharing
         if (hasPendingScreenSharingRequest) {
             if (!hasScreenSharingNotificationChannelEnabledUseCase.invoke()) {
@@ -79,7 +80,11 @@ internal class ScreenSharingController(
                 }
                 dialogController.showEnableScreenSharingNotificationsAndStartSharingDialog()
             } else {
-                onScreenSharingAccepted(activity)
+                if (requestScreenSharingCallback != null) {
+                    requestScreenSharingCallback()
+                } else {
+                    onScreenSharingAccepted(activity)
+                }
             }
         }
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/screensharing/ScreenSharingControllerTest.java
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/screensharing/ScreenSharingControllerTest.java
@@ -22,6 +22,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
+
 @RunWith(RobolectricTestRunner.class)
 public class ScreenSharingControllerTest {
 
@@ -97,12 +100,26 @@ public class ScreenSharingControllerTest {
     public void onResume_acceptsScreenSharing_whenNotificationChannelEnabled() {
         subjectUnderTest.hasPendingScreenSharingRequest = true;
         when(hasScreenSharingNotificationChannelEnabledUseCase.invoke())
-                .thenReturn(true);
+            .thenReturn(true);
 
-        subjectUnderTest.onResume(mock(Activity.class));
+        subjectUnderTest.onResume(mock(Activity.class), null);
 
         verify(showScreenSharingNotificationUseCase).invoke();
         verify(gliaScreenSharingRepository).onScreenSharingAccepted(any(), any());
+    }
+
+    @Test
+    public void onResume_requestScreenSharingCallback_whenCallbackIsNotNull() {
+        Function0<Unit> requestScreenSharingCallback = mock(Function0.class);
+        subjectUnderTest.hasPendingScreenSharingRequest = true;
+        when(hasScreenSharingNotificationChannelEnabledUseCase.invoke())
+            .thenReturn(true);
+
+        subjectUnderTest.onResume(mock(Activity.class), requestScreenSharingCallback);
+
+        verify(requestScreenSharingCallback).invoke();
+        verify(showScreenSharingNotificationUseCase, never()).invoke();
+        verify(gliaScreenSharingRepository, never()).onScreenSharingAccepted(any(), any());
     }
 
     @Test
@@ -111,7 +128,7 @@ public class ScreenSharingControllerTest {
         when(hasScreenSharingNotificationChannelEnabledUseCase.invoke())
                 .thenReturn(false);
 
-        subjectUnderTest.onResume(mock(Activity.class));
+        subjectUnderTest.onResume(mock(Activity.class), null);
 
         verify(dialogController).showEnableScreenSharingNotificationsAndStartSharingDialog();
     }
@@ -123,7 +140,7 @@ public class ScreenSharingControllerTest {
             .thenReturn(false);
         when(dialogController.isEnableScreenSharingNotificationsAndStartSharingDialogShown()).thenReturn(true);
 
-        subjectUnderTest.onResume(mock(Activity.class));
+        subjectUnderTest.onResume(mock(Activity.class), null);
 
         verify(dialogController, never()).showEnableScreenSharingNotificationsAndStartSharingDialog();
     }


### PR DESCRIPTION
Start screen sharing using the `ActivityWatcherForCallVisualizer` if it is not the Call or Chat Activity

[MOB-2627](https://glia.atlassian.net/browse/MOB-2627)


[MOB-2627]: https://glia.atlassian.net/browse/MOB-2627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ