### PR TITLE
Fix screen sharing dialog displaying on a Chat Screen although screen-sharing request was accepted from Call screen

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -826,7 +826,9 @@ public class CallController implements
                         break;
                 }
             });
-            omnibrowseEngagement.on(Engagement.Events.END, engagementState -> viewCallback.destroyView());
+            omnibrowseEngagement.on(Engagement.Events.END, engagementState -> {
+                if (viewCallback != null) viewCallback.destroyView();
+            });
         });
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/ScreenSharingController.kt
@@ -3,7 +3,6 @@ package com.glia.widgets.core.screensharing
 import android.app.Activity
 import androidx.annotation.VisibleForTesting
 import com.glia.androidsdk.GliaException
-import com.glia.widgets.callvisualizer.domain.IsCallOrChatScreenActiveUseCase
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager
 import com.glia.widgets.core.dialog.DialogController
 import com.glia.widgets.core.notification.domain.RemoveScreenSharingNotificationUseCase
@@ -99,6 +98,7 @@ internal class ScreenSharingController(
 
     fun onScreenSharingAccepted(activity: Activity) {
         Logger.d(TAG, "onScreenSharingAccepted")
+        dialogController.dismissCurrentDialog()
         showScreenSharingEnabledNotification()
         repository.onScreenSharingAccepted(
             activity,
@@ -109,6 +109,7 @@ internal class ScreenSharingController(
 
     fun onScreenSharingAcceptedAndPermissionAsked(activity: Activity) {
         Logger.d(TAG, "onScreenSharingAcceptedAndPermissionAsked")
+        dialogController.dismissCurrentDialog()
         showScreenSharingEnabledNotification()
         repository.onScreenSharingAcceptedAndPermissionAsked(
             activity,
@@ -119,6 +120,7 @@ internal class ScreenSharingController(
 
     fun onScreenSharingDeclined() {
         Logger.d(TAG, "onScreenSharingDeclined")
+        dialogController.dismissCurrentDialog()
         repository.onScreenSharingDeclined()
         hasPendingScreenSharingRequest = false
         hideScreenSharingEnabledNotification()


### PR DESCRIPTION
This case has been detected by the 'Screensharing on the audio engagement' acceptance [test](https://app-automate.browserstack.com/dashboard/v2/builds/d3f1c67c149f01d8238d3d62108cf74d67bfc825/sessions/cea0ec953faab749948a4a62ebfda137ea5d145e?overallStatus=error&projectIds=250430).

I've tested scenarios from the [Dialogs doc](https://glia.atlassian.net/wiki/spaces/ENG/pages/3486842894/Dialogs) and [Fix the dialog display logic PR](https://github.com/salemove/android-sdk-widgets/pull/754#issue-1884404350) (which basically fails acceptance tests) - they are working fine.
