### PR TITLE
Account for the "Always Use the Default Operator Picture" Glia Hub setting

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaOperatorRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaOperatorRepository.kt
@@ -14,6 +14,9 @@ internal class GliaOperatorRepository(private val gliaCore: GliaCore) {
     @VisibleForTesting
     var operatorDefaultImageUrl: String? = null
 
+    @VisibleForTesting
+    var isAlwaysUseDefaultOperatorPicture: Boolean = false
+
     fun getOperatorById(operatorId: String, callback: Consumer<LocalOperator?>) {
         val cachedOperator = cachedOperators[operatorId]
         if (cachedOperator != null) {
@@ -28,7 +31,13 @@ internal class GliaOperatorRepository(private val gliaCore: GliaCore) {
     fun emit(operator: Operator) = putOperator(mapOperator(operator))
 
     @VisibleForTesting
-    fun mapOperator(operator: Operator): LocalOperator = operator.run { LocalOperator(id, name, imageUrl ?: operatorDefaultImageUrl) }
+    fun mapOperator(operator: Operator): LocalOperator = operator.run { LocalOperator(id, name, getOperatorImage(operator.imageUrl)) }
+
+    @VisibleForTesting
+    fun getOperatorImage(imageUrl: String?): String? {
+        return if (isAlwaysUseDefaultOperatorPicture || imageUrl == null) operatorDefaultImageUrl
+        else imageUrl
+    }
 
     @VisibleForTesting
     fun putOperator(operator: LocalOperator) {
@@ -39,4 +48,7 @@ internal class GliaOperatorRepository(private val gliaCore: GliaCore) {
         operatorDefaultImageUrl = imageUrl
     }
 
+    fun setIsAlwaysUseDefaultOperatorPicture(isAlwaysUseDefaultOperatorPicture: Boolean?) {
+        this.isAlwaysUseDefaultOperatorPicture = isAlwaysUseDefaultOperatorPicture ?: false
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/MapOperatorUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/MapOperatorUseCase.kt
@@ -4,7 +4,6 @@ import com.glia.androidsdk.chat.Chat
 import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.chat.OperatorMessage
 import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
-import com.glia.widgets.helper.toChatMessageInternal
 import io.reactivex.Single
 import kotlin.jvm.optionals.getOrNull
 
@@ -15,9 +14,8 @@ internal class MapOperatorUseCase(private val getOperatorUseCase: GetOperatorUse
             else -> processVisitorMessage(chatMessage)
         }
 
-    private fun processOperatorMessage(chatMessage: OperatorMessage): Single<ChatMessageInternal> = chatMessage
-        .takeIf { it.operatorImageUrl != null }?.toChatMessageInternal()?.let { Single.just(it) }
-        ?: getOperatorUseCase.execute(chatMessage.operatorId!!).map { ChatMessageInternal(chatMessage, it.getOrNull()) }
+    private fun processOperatorMessage(chatMessage: OperatorMessage): Single<ChatMessageInternal> =
+        getOperatorUseCase.execute(chatMessage.operatorId!!).map { ChatMessageInternal(chatMessage, it.getOrNull()) }
 
     private fun processVisitorMessage(chatMessage: ChatMessage): Single<ChatMessageInternal> = Single.just(ChatMessageInternal(chatMessage))
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/UpdateOperatorDefaultImageUrlUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/UpdateOperatorDefaultImageUrlUseCase.kt
@@ -9,6 +9,7 @@ internal class UpdateOperatorDefaultImageUrlUseCase(
     private val siteInfoUseCase: SiteInfoUseCase
 ) {
     operator fun invoke() = siteInfoUseCase.execute { response, _ ->
+        operatorRepository.setIsAlwaysUseDefaultOperatorPicture(response.isAlwaysUseDefaultOperatorPicture)
         response.defaultOperatorPicture?.url?.getOrNull()?.also(operatorRepository::updateOperatorDefaultImageUrl)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/engagement/GliaOperatorRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/engagement/GliaOperatorRepositoryTest.kt
@@ -96,6 +96,38 @@ class GliaOperatorRepositoryTest {
         verify(callback).accept(null)
     }
 
+    @Test
+    fun `getOperatorImage returns default image url when operator image null and isAlwaysUseDefaultOperatorPicture true`() {
+        repository.operatorDefaultImageUrl = "default"
+        repository.isAlwaysUseDefaultOperatorPicture = true
+
+        assertEquals("default", repository.getOperatorImage(null))
+    }
+
+    @Test
+    fun `getOperatorImage returns default image url when operator image null and isAlwaysUseDefaultOperatorPicture false`() {
+        repository.operatorDefaultImageUrl = "default"
+        repository.isAlwaysUseDefaultOperatorPicture = false
+
+        assertEquals("default", repository.getOperatorImage(null))
+    }
+
+    @Test
+    fun `getOperatorImage returns default image url when operator image exists and isAlwaysUseDefaultOperatorPicture true`() {
+        repository.operatorDefaultImageUrl = "default"
+        repository.isAlwaysUseDefaultOperatorPicture = true
+
+        assertEquals("default", repository.getOperatorImage(null))
+    }
+
+    @Test
+    fun `getOperatorImage returns image Url when operator image exists and isAlwaysUseDefaultOperatorPicture false`() {
+        repository.operatorDefaultImageUrl = "default"
+        repository.isAlwaysUseDefaultOperatorPicture = false
+
+        assertEquals("imageUrl", repository.getOperatorImage("imageUrl"))
+    }
+
     private fun stubGetOperatorResponse(operator: Operator?, exception: GliaException?) {
         doAnswer { invocation: InvocationOnMock ->
             invocation.getArgument<RequestCallback<Operator?>>(1).apply { onResult(operator, exception) }


### PR DESCRIPTION
[Operator avatar image does not respect the "Always Use the Default Operator Picture" Glia Hub setting](https://glia.atlassian.net/browse/MOB-2690)

[Test scenarios](https://glia.atlassian.net/wiki/spaces/ENG/pages/3504668722/Operator+image)

R (release notes) - Changes that the integrator may be interested in.


