### PR TITLE
Apply company name from custom locales

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/Activity.java
+++ b/app/src/main/java/com/glia/exampleapp/Activity.java
@@ -23,7 +23,7 @@ public class Activity extends AppCompatActivity {
     private void initGliaWidgetsWithDeepLink() {
         Uri uri = getIntent().getData();
         if (!Glia.isInitialized() && uri != null) {
-            GliaWidgets.init(GliaWidgetsConfigManager.obtainConfigFromDeepLink(uri, getApplicationContext()));
+            GliaWidgets.init(ExampleAppConfigManager.obtainConfigFromDeepLink(uri, getApplicationContext()));
         }
     }
 

--- a/app/src/main/java/com/glia/exampleapp/Application.java
+++ b/app/src/main/java/com/glia/exampleapp/Application.java
@@ -51,7 +51,7 @@ public class Application extends android.app.Application {
                 if (activity.getClass() != com.glia.exampleapp.Activity.class) {
                     if (Glia.isInitialized()) return;
 
-                    GliaWidgets.init(GliaWidgetsConfigManager.createDefaultConfig(getApplicationContext()));
+                    GliaWidgets.init(ExampleAppConfigManager.createDefaultConfig(getApplicationContext()));
                 }
             }
 

--- a/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
+++ b/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
@@ -16,7 +16,7 @@ import com.glia.widgets.UiTheme
  * glia://widgets/secret?site_id={site_id}&api_key_secret={api_key_secret}&api_key_id={api_key_id}&queue_id={queue_id}&visitor_context_asset_id={visitor_context_asset_id}
  * where all query params are mandatory except visitor_context_asset_id
  */
-object GliaWidgetsConfigManager {
+object ExampleAppConfigManager {
     private const val SECRET_KEY = "secret"
     private const val SITE_ID_KEY = "site_id"
     private const val API_KEY_SECRET_KEY = "api_key_secret"

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -26,7 +26,7 @@ import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.fcm.GliaPushMessage
 import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.androidsdk.visitor.Authentication
-import com.glia.exampleapp.GliaWidgetsConfigManager.createDefaultConfig
+import com.glia.exampleapp.ExampleAppConfigManager.createDefaultConfig
 import com.glia.widgets.GliaWidgets
 import com.glia.widgets.UiTheme
 import com.glia.widgets.call.CallActivity
@@ -218,8 +218,7 @@ class MainFragment : Fragment() {
 
     private fun setNavigationIntentData(intent: Intent) {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
-        intent.putExtra(GliaWidgets.COMPANY_NAME, getCompanyNameFromPrefs(sharedPreferences))
-            .putExtra(GliaWidgets.QUEUE_ID, getQueueIdFromPrefs(sharedPreferences))
+        intent.putExtra(GliaWidgets.QUEUE_ID, getQueueIdFromPrefs(sharedPreferences))
             .putExtra(GliaWidgets.CONTEXT_ASSET_ID, getContextAssetIdFromPrefs(sharedPreferences))
             .putExtra(GliaWidgets.UI_THEME, getRuntimeThemeFromPrefs(sharedPreferences))
             .putExtra(GliaWidgets.USE_OVERLAY, getUseOverlay(sharedPreferences))

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -39,6 +39,9 @@ public class GliaWidgets {
     /**
      * Use with {@link android.os.Bundle} to pass in the name of your company as a navigation
      * argument when navigating to {@link com.glia.widgets.chat.ChatActivity}
+     *
+     * @deprecated Use {@link com.glia.widgets.GliaWidgetsConfig.Builder#companyName}
+     * or customize the strings from GliaHub
      */
     public static final String COMPANY_NAME = "company_name";
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
@@ -134,7 +134,6 @@ public class CallActivity extends AppCompatActivity {
         Logger.d(TAG, "navigateToChat");
         GliaSdkConfiguration sdkConfiguration = configuration.getSdkConfiguration();
         Intent newIntent = new Intent(getApplicationContext(), ChatActivity.class)
-                .putExtra(GliaWidgets.COMPANY_NAME, sdkConfiguration.getCompanyName())
                 .putExtra(GliaWidgets.QUEUE_ID, sdkConfiguration.getQueueId())
                 .putExtra(GliaWidgets.CONTEXT_ASSET_ID, sdkConfiguration.getContextAssetId())
                 .putExtra(GliaWidgets.UI_THEME, sdkConfiguration.getRunTimeTheme())

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentBuilder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallIntentBuilder.java
@@ -30,7 +30,6 @@ class CallIntentBuilder {
         validateWidgetsSdkConfiguration();
         GliaSdkConfiguration sdkConfiguration = configuration.getSdkConfiguration();
         return new Intent(context, CallActivity.class)
-                .putExtra(GliaWidgets.COMPANY_NAME, sdkConfiguration.getCompanyName())
                 .putExtra(GliaWidgets.QUEUE_ID, sdkConfiguration.getQueueId())
                 .putExtra(GliaWidgets.CONTEXT_ASSET_ID, sdkConfiguration.getContextAssetId())
                 .putExtra(GliaWidgets.UI_THEME, sdkConfiguration.getRunTimeTheme())

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -304,7 +304,7 @@ internal class CallView(
             operatorStatusView.showTransferring()
             operatorNameView.text = (stringProvider.getRemoteString(R.string.engagement_queue_transferring_message))
         } else {
-            operatorNameView.text = stringProvider.getRemoteString(R.string.general_company_name)
+            operatorNameView.text = Dependencies.getSdkConfigurationManager().companyName
             operatorNameView.hint = stringProvider.getRemoteString(R.string.chat_operator_name_accessibility_label)
             handleOperatorStatusViewOperatorImage(state)
         }
@@ -559,7 +559,7 @@ internal class CallView(
         chatButtonLabel.text = stringProvider.getRemoteString(R.string.media_text_name)
         speakerButtonLabel.text = stringProvider.getRemoteString(R.string.call_button_speaker)
         minimizeButtonLabel.text = stringProvider.getRemoteString(R.string.engagement_minimize_video_button)
-        companyNameView.text = stringProvider.getRemoteString(R.string.general_company_name)
+        companyNameView.text = Dependencies.getSdkConfigurationManager().companyName
         videoButtonLabel.text = stringProvider.getRemoteString(R.string.media_video_name)
         callTheme?.topText.also(onHoldTextView::applyThemeAsDefault)
         callTheme?.duration.also(callTimerView::applyThemeAsDefault)
@@ -974,9 +974,9 @@ internal class CallView(
                 callState.callStatus.formattedOperatorName,
                 ""
             )
-            if (callState.companyName != null) { // TODO FIXME Make CompanyName configurable from remote strings
+            if (callState.companyName != null) {
                 companyNameView.text = callState.companyName
-                companyNameView.hint = stringProvider.getRemoteString(R.string.general_company_name)
+                companyNameView.hint = callState.companyName
                 msrView.text = stringProvider.getRemoteString(
                     R.string.android_call_queue_message
                 )

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.java
@@ -1,7 +1,6 @@
 package com.glia.widgets.core.configuration;
 
 import android.content.Intent;
-import android.text.TextUtils;
 
 import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.widgets.GliaWidgets;
@@ -101,8 +100,7 @@ public class GliaSdkConfiguration {
         }
 
         public Builder intent(Intent intent) {
-            String tempCompanyName = intent.getStringExtra(GliaWidgets.COMPANY_NAME);
-            this.companyName = !TextUtils.isEmpty(tempCompanyName) ? tempCompanyName : Dependencies.getSdkConfigurationManager().getCompanyName();
+            this.companyName = Dependencies.getSdkConfigurationManager().getCompanyName();
             this.queueId = intent.getStringExtra(GliaWidgets.QUEUE_ID);
             UiTheme tempTheme = intent.getParcelableExtra(GliaWidgets.UI_THEME);
             this.runTimeTheme = tempTheme != null ? tempTheme : Dependencies.getSdkConfigurationManager().getUiTheme();

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
@@ -1,11 +1,15 @@
 package com.glia.widgets.core.configuration;
 
 import com.glia.androidsdk.screensharing.ScreenSharing;
+import com.glia.widgets.R;
+import com.glia.widgets.StringProvider;
 import com.glia.widgets.UiTheme;
 
 import org.jetbrains.annotations.Nullable;
 
 public class GliaSdkConfigurationManager {
+
+    StringProvider stringProvider;
 
     private boolean useOverlay = false;
     private ScreenSharing.Mode screenSharingMode = null;
@@ -22,7 +26,18 @@ public class GliaSdkConfigurationManager {
     }
 
     public String getCompanyName() {
+        fetchRemoteCompanyName();
         return companyName;
+    }
+
+    private void fetchRemoteCompanyName() {
+        if (stringProvider == null) {
+            return;
+        }
+        String remoteCompanyName = stringProvider.getRemoteString(R.string.general_company_name);
+        if (remoteCompanyName != null && !remoteCompanyName.isEmpty()) {
+            companyName = remoteCompanyName;
+        }
     }
 
     public void setCompanyName(String companyName) {
@@ -53,5 +68,9 @@ public class GliaSdkConfigurationManager {
                 .useOverlay(useOverlay)
                 .runTimeTheme(uiTheme)
                 .build();
+    }
+
+    public void setStringProvider(StringProvider stringProvider) {
+        this.stringProvider = stringProvider;
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -8,7 +8,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import androidx.lifecycle.Lifecycle;
 
-import com.glia.androidsdk.Glia;
 import com.glia.widgets.GliaWidgetsConfig;
 import com.glia.widgets.StringProvider;
 import com.glia.widgets.StringProviderImpl;
@@ -52,6 +51,7 @@ public class Dependencies {
     public static void onAppCreate(Application application) {
         resourceProvider = new ResourceProvider(application.getBaseContext());
         stringProvider = new StringProviderImpl(resourceProvider);
+        sdkConfigurationManager.setStringProvider(stringProvider);
         notificationManager = new NotificationManager(application, stringProvider);
         DownloadsFolderDataSource downloadsFolderDataSource = new DownloadsFolderDataSource(application);
         RepositoryFactory repositoryFactory = new RepositoryFactory(gliaCore, downloadsFolderDataSource);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
@@ -317,7 +317,6 @@ class ChatHeadView @JvmOverloads constructor(
             cls: Class<*>,
             sdkConfiguration: GliaSdkConfiguration
         ): Intent = Intent(context, cls)
-            .putExtra(GliaWidgets.COMPANY_NAME, sdkConfiguration.companyName)
             .putExtra(GliaWidgets.QUEUE_ID, sdkConfiguration.queueId)
             .putExtra(GliaWidgets.CONTEXT_ASSET_ID, sdkConfiguration.contextAssetId)
             .putExtra(GliaWidgets.UI_THEME, sdkConfiguration.runTimeTheme)


### PR DESCRIPTION
[Implement Company name from custom locales](https://glia.atlassian.net/browse/MOB-2685)

**Changes overview**
- Company name can now be taken from a single source of truth: `Dependencies.getSdkConfigurationManager().companyName`
- Dropped a way to specify company name through `Intent` (see migration guide)
- Company name priority setup for Android is going to be: custom locales (highest priority) => SDK configuration => default value, which is "Company Name".
- Renamed GliaWidgetsConfigManager to ExampleAppConfigManager to cross it out from the number of classes related to configuration.


[Additional details](https://salemove.slack.com/archives/C04JS5GH6AD/p1695891888361899) on taken decisions.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [x] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Migration guide:** _If you were specifying the company name by intent.putExtra(GliaWidgets.COMPANY_NAME, “Some value”) please specify it with Glia Widgets SDK initialization (set GliaWidgetsConfig.Builder#companyName) or customize the strings from GliaHub._
