### PR TITLE
Feature/mob 2732 company name ignores remote base locals value

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
@@ -1,15 +1,15 @@
 package com.glia.widgets.core.configuration;
 
+import com.glia.androidsdk.Glia;
 import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.widgets.R;
 import com.glia.widgets.StringProvider;
 import com.glia.widgets.UiTheme;
+import com.glia.widgets.di.Dependencies;
 
 import org.jetbrains.annotations.Nullable;
 
 public class GliaSdkConfigurationManager {
-
-    StringProvider stringProvider;
 
     private boolean useOverlay = false;
     private ScreenSharing.Mode screenSharingMode = null;
@@ -27,15 +27,15 @@ public class GliaSdkConfigurationManager {
 
     public String getCompanyName() {
         fetchRemoteCompanyName();
+        if (companyName == null) {
+            Dependencies.getResourceProvider().getString(R.string.general_company_name);
+        }
         return companyName;
     }
 
     private void fetchRemoteCompanyName() {
-        if (stringProvider == null) {
-            return;
-        }
-        String remoteCompanyName = stringProvider.getRemoteString(R.string.general_company_name);
-        if (remoteCompanyName != null && !remoteCompanyName.isEmpty()) {
+        String remoteCompanyName = Glia.getRemoteString(Dependencies.getResourceProvider().getResourceKey(R.string.general_company_name));
+        if (remoteCompanyName != null && !remoteCompanyName.trim().isEmpty()) {
             companyName = remoteCompanyName;
         }
     }
@@ -68,9 +68,5 @@ public class GliaSdkConfigurationManager {
                 .useOverlay(useOverlay)
                 .runTimeTheme(uiTheme)
                 .build();
-    }
-
-    public void setStringProvider(StringProvider stringProvider) {
-        this.stringProvider = stringProvider;
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -51,7 +51,6 @@ public class Dependencies {
     public static void onAppCreate(Application application) {
         resourceProvider = new ResourceProvider(application.getBaseContext());
         stringProvider = new StringProviderImpl(resourceProvider);
-        sdkConfigurationManager.setStringProvider(stringProvider);
         notificationManager = new NotificationManager(application, stringProvider);
         DownloadsFolderDataSource downloadsFolderDataSource = new DownloadsFolderDataSource(application);
         RepositoryFactory repositoryFactory = new RepositoryFactory(gliaCore, downloadsFolderDataSource);


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2732

**What was solved?**
BaseLocale value of general.company_name is an empty string and this should be skipped.

This way the Company name fetch priority order becomes the following:
1. Custom locales
2. Local SDK configuration
3. Hardcoded string resource from local strings.xml

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)