### PR TITLE
Prevented unread indicator to be shown during call visualizer engagement

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
@@ -94,7 +94,9 @@ class ChatHeadView @JvmOverloads constructor(
 
     override fun showUnreadMessageCount(unreadMessageCount: Int) {
         post {
-            if (!isCallVisualizerUseCase.invoke()) {
+            if (isCallVisualizerUseCase.invoke()) {
+                binding.chatBubbleBadge.isVisible = false
+            } else {
                 binding.chatBubbleBadge.apply {
                     text = unreadMessageCount.toString()
                     isVisible = isDisplayUnreadMessageBadge(unreadMessageCount)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
@@ -21,6 +21,7 @@ import com.glia.widgets.call.Configuration
 import com.glia.widgets.callvisualizer.EndScreenSharingActivity
 import com.glia.widgets.chat.ChatActivity
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
+import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerUseCase
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.databinding.ChatHeadViewBinding
 import com.glia.widgets.di.Dependencies
@@ -66,11 +67,13 @@ class ChatHeadView @JvmOverloads constructor(
     @Suppress("JoinDeclarationAndAssignment")
     private var serviceChatHeadController: ServiceChatHeadController
     private var isCallVisualizerScreenSharingUseCase: IsCallVisualizerScreenSharingUseCase
+    private var isCallVisualizerUseCase: IsCallVisualizerUseCase
     private var theme: UiTheme? = null
 
     init {
         serviceChatHeadController = Dependencies.getControllerFactory().chatHeadController
         isCallVisualizerScreenSharingUseCase = Dependencies.getUseCaseFactory().createIsCallVisualizerScreenSharingUseCase()
+        isCallVisualizerUseCase = Dependencies.getUseCaseFactory().createIsCallVisualizerUseCase()
         setAccessibilityLabels()
         readTypedArray()
     }
@@ -91,9 +94,11 @@ class ChatHeadView @JvmOverloads constructor(
 
     override fun showUnreadMessageCount(unreadMessageCount: Int) {
         post {
-            binding.chatBubbleBadge.apply {
-                text = unreadMessageCount.toString()
-                isVisible = isDisplayUnreadMessageBadge(unreadMessageCount)
+            if (!isCallVisualizerUseCase.invoke()) {
+                binding.chatBubbleBadge.apply {
+                    text = unreadMessageCount.toString()
+                    isVisible = isDisplayUnreadMessageBadge(unreadMessageCount)
+                }
             }
         }
     }


### PR DESCRIPTION
MOB-2681

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2681

**What was solved?**
Fixed unread message indicator being shown on the bubble during Call Visualiser engagement

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [X] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)