### PR TITLE
Send logs through Core SDK logger

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
@@ -74,11 +74,11 @@ object Logger {
                     Throwable::class.java
                 )
             } catch (e: IllegalAccessException) {
-                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+                Log.d(TAG, "Unable to access Core SDK logger function $e")
             } catch (e: InvocationTargetException) {
-                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+                Log.d(TAG, "Unable to invoke Core SDK logger function $e")
             } catch (e: NoSuchMethodException) {
-                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+                Log.d(TAG, "Unable to find Core SDK logger function $e")
             }
         }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
@@ -50,11 +50,11 @@ object Logger {
                     String::class.java
                 )
             } catch (e: IllegalAccessException) {
-                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+                Log.d(TAG, "Unable to access Core SDK logger function $e")
             } catch (e: InvocationTargetException) {
-                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+                Log.d(TAG, "Unable to invoke Core SDK logger function $e")
             } catch (e: NoSuchMethodException) {
-                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+                Log.d(TAG, "Unable to find Core SDK logger function $e")
             }
         }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
@@ -1,23 +1,88 @@
 package com.glia.widgets.helper
 
 import android.util.Log
+import com.glia.androidsdk.Glia
 import com.glia.widgets.BuildConfig
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
 
 object Logger {
+
+    private var coreSdkLogger: com.glia.androidsdk.internal.logger.Logger? = null
+    private var coreSdkLogDFunction: Method? = null
+    private var coreSDKLogEFunction: Method? = null
+
+    @Suppress("unused")
+    @JvmStatic
+    fun setCoreSdkLogger(coreSdkLogger: com.glia.androidsdk.internal.logger.Logger) {
+        d(TAG, "Core SDK logger set successfully")
+        this.coreSdkLogger = coreSdkLogger
+    }
+
+    @JvmStatic
+    fun getCoreSdkLogger() : com.glia.androidsdk.internal.logger.Logger? = coreSdkLogger
+
     @JvmStatic
     fun d(tag: String, message: String?) {
         if (BuildConfig.DEBUG) {
             // No need to log an empty message
-            Log.d(tag, message ?: return)
+            logDToCoreSdk(tag, message ?: return)
         }
     }
 
     @JvmStatic
     fun e(tag: String, message: String?) {
         if (BuildConfig.DEBUG) {
-            // //No need to log an empty message
-            Log.e(tag, message ?: return)
+            //No need to log an empty message
+            logEToCoreSdk(tag, message ?: return)
         }
+    }
+
+    private fun logDToCoreSdk(tag: String, message: String?) {
+        if (!Glia.isInitialized()) return
+        if (message == null) return
+
+        if (coreSdkLogDFunction == null) {
+            try {
+                coreSdkLogDFunction = getCoreSdkLogger()?.javaClass?.getDeclaredMethod(
+                    "d",
+                    String::class.java,
+                    String::class.java
+                )
+            } catch (e: IllegalAccessException) {
+                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+            } catch (e: InvocationTargetException) {
+                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+            } catch (e: NoSuchMethodException) {
+                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+            }
+        }
+
+        coreSdkLogDFunction?.invoke(null, tag, message)
+    }
+
+    private fun logEToCoreSdk(tag: String, message: String?, throwable: Throwable? = null) {
+        if (!Glia.isInitialized()) return
+        if (message == null) return
+
+        if (coreSDKLogEFunction == null) {
+            try {
+                coreSDKLogEFunction = getCoreSdkLogger()?.javaClass?.getDeclaredMethod(
+                    "e",
+                    String::class.java,
+                    String::class.java,
+                    Throwable::class.java
+                )
+            } catch (e: IllegalAccessException) {
+                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+            } catch (e: InvocationTargetException) {
+                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+            } catch (e: NoSuchMethodException) {
+                Log.d(TAG, "Unable to log message using Core SDK logger $e")
+            }
+        }
+
+        coreSDKLogEFunction?.invoke(null, tag, message, throwable)
     }
 
     @JvmStatic
@@ -25,7 +90,7 @@ object Logger {
         if (BuildConfig.DEBUG) {
             // No problem with lint in here
             if (message.isNullOrBlank() && tr == null) return
-            Log.e(tag, message, tr)
+            logEToCoreSdk(tag, message, tr)
         }
     }
 }


### PR DESCRIPTION
**Jira issue:**
[Developers want to be able to send logs from Widgets SDK](https://glia.atlassian.net/browse/MOB-2789)

**What was solved?**
These changes work based on the [Inject Core SDK Logger to Widgets SDK](https://github.com/salemove/android-sdk/pull/586) changes suggested for Core SDK.

So all logs will go through Core SDK logger and as a result will be sent to LogCat and to the backend.

**Release notes:**
This change is for internal logging. I think there is no need to mention it in the release notes.

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

