### PR TITLE
Handle connection issues

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -156,6 +156,9 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     private var onNavigateToCallListener: OnNavigateToCallListener? = null
     private var onNavigateToSurveyListener: OnNavigateToSurveyListener? = null
     private var onBackToCallListener: OnBackToCallListener? = null
+    private val onMessageClickListener = ChatAdapter.OnMessageClickListener { messageId: String ->
+        controller?.onMessageClicked(messageId)
+    }
     private val onOptionClickedListener = OnOptionClickedListener { item, selectedOption ->
         Logger.d(TAG, "singleChoiceCardClicked")
         controller?.singleChoiceOptionClicked(item, selectedOption)
@@ -748,6 +751,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     private fun setupViewAppearance() {
         adapter = ChatAdapter(
             theme,
+            onMessageClickListener,
             onOptionClickedListener,
             this,
             this,

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapterDiffCallback.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/ChatAdapterDiffCallback.kt
@@ -10,9 +10,20 @@ internal class ChatAdapterDiffCallback : DiffUtil.ItemCallback<ChatItem>() {
     override fun areContentsTheSame(oldItem: ChatItem, newItem: ChatItem): Boolean = oldItem.areContentsTheSame(newItem)
 
     override fun getChangePayload(oldItem: ChatItem, newItem: ChatItem): Any? = when {
-        oldItem is MediaUpgradeStartedTimerItem.Audio && newItem is MediaUpgradeStartedTimerItem.Audio -> newItem.time
-        oldItem is MediaUpgradeStartedTimerItem.Video && newItem is MediaUpgradeStartedTimerItem.Video -> newItem.time
-        oldItem is VisitorChatItem && newItem is VisitorChatItem -> newItem.showDelivered
+        oldItem is MediaUpgradeStartedTimerItem.Audio && newItem is MediaUpgradeStartedTimerItem.Audio -> ChatAdapterPayload.Time(newItem.time)
+        oldItem is MediaUpgradeStartedTimerItem.Video && newItem is MediaUpgradeStartedTimerItem.Video -> ChatAdapterPayload.Time(newItem.time)
+        oldItem is VisitorChatItem && newItem is VisitorChatItem ->
+            if (oldItem.showDelivered != newItem.showDelivered)
+                ChatAdapterPayload.ShowDelivered(newItem.showDelivered)
+            else if (oldItem.showError != newItem.showError)
+                ChatAdapterPayload.ShowError(newItem.showError)
+            else null
         else -> null
     }
+}
+
+internal sealed class ChatAdapterPayload {
+    internal data class Time(val time: String) : ChatAdapterPayload()
+    internal data class ShowDelivered(val showDelivered: Boolean) : ChatAdapterPayload()
+    internal data class ShowError(val showError: Boolean) : ChatAdapterPayload()
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/UploadAttachmentAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/UploadAttachmentAdapter.kt
@@ -115,7 +115,6 @@ class ViewHolder(
         val displayName = attachment?.displayName ?: return
 
         val size = Formatter.formatFileSize(context, attachment.size)
-        val mimeType = attachment.mimeType
 
         removeItemButton.setOnClickListener { callback?.onRemoveItemClicked(attachment) }
 
@@ -123,14 +122,13 @@ class ViewHolder(
 
         updateTitleAndStatusText(displayName, size, attachment.attachmentStatus)
 
-        updateExtensionType(attachment, mimeType, displayName)
+        updateExtensionType(attachment, displayName)
 
         updateContentDescription(displayName, size, attachment)
     }
 
     private fun updateExtensionType(
         attachment: FileAttachment,
-        mimeType: String,
         displayName: String
     ) {
         if (attachment.attachmentStatus.isError) {
@@ -150,7 +148,7 @@ class ViewHolder(
             extensionTypeImage.scaleType = ImageView.ScaleType.FIT_XY
             extensionTypeImage.imageTintList = null
 
-            if (mimeType.startsWith("image")) {
+            if (attachment.isImage) {
                 showExtensionTypeImage()
                 Picasso.get()
                     .load(attachment.uri)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolder.kt
@@ -1,11 +1,17 @@
 package com.glia.widgets.chat.adapter.holder
 
+import android.view.View
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.glia.widgets.R
 import com.glia.widgets.StringKey
 import com.glia.widgets.StringKeyPair
 import com.glia.widgets.UiTheme
+import com.glia.widgets.chat.adapter.ChatAdapter
 import com.glia.widgets.chat.model.VisitorMessageItem
 import com.glia.widgets.databinding.ChatVisitorMessageLayoutBinding
 import com.glia.widgets.di.Dependencies
@@ -18,6 +24,7 @@ import com.glia.widgets.view.unifiedui.theme.chat.MessageBalloonTheme
 
 internal class VisitorMessageViewHolder(
     private val binding: ChatVisitorMessageLayoutBinding,
+    private val onMessageClickListener: ChatAdapter.OnMessageClickListener,
     uiTheme: UiTheme
 ) : RecyclerView.ViewHolder(binding.root) {
 
@@ -25,6 +32,10 @@ internal class VisitorMessageViewHolder(
         Dependencies.getGliaThemeManager().theme?.chatTheme?.visitorMessage
     }
     private val stringProvider = Dependencies.getStringProvider()
+
+    private lateinit var id: String
+    private var showDelivered: Boolean = false
+    private var showError: Boolean = false
 
     init {
         uiTheme.visitorMessageBackgroundColor?.let(itemView::getColorStateListCompat)
@@ -37,32 +48,83 @@ internal class VisitorMessageViewHolder(
             val fontFamily = itemView.getFontCompat(uiTheme.fontRes)
             binding.content.typeface = fontFamily
             binding.deliveredView.typeface = fontFamily
+            binding.errorView.typeface = fontFamily
         }
         uiTheme.baseNormalColor?.let(itemView::getColorCompat)
             ?.also(binding.deliveredView::setTextColor)
+
+        uiTheme.systemNegativeColor?.let(itemView::getColorCompat)
+            ?.also(binding.errorView::setTextColor)
 
         // Unified Ui
         binding.content.applyLayerTheme(visitorTheme?.background)
         binding.content.applyTextTheme(visitorTheme?.text)
         binding.deliveredView.applyTextTheme(visitorTheme?.status)
         binding.deliveredView.text = stringProvider.getRemoteString(R.string.chat_message_delivered)
+        binding.errorView.text = stringProvider.getRemoteString(R.string.chat_message_delivery_failed_retry)
     }
 
     fun bind(item: VisitorMessageItem) {
+        this.id = item.id
+        this.showDelivered = item.showDelivered
+        this.showError = item.showError
+
         binding.content.text = item.message
-        binding.deliveredView.isVisible = item.showDelivered
-        val contentDescription = stringProvider.getRemoteString(
-            if (item.showDelivered) {
+
+        setShowError()
+        setShowDelivered()
+        setAccessibilityLabels()
+    }
+
+    private fun setShowDelivered() {
+        binding.deliveredView.isVisible = !showError && showDelivered
+    }
+
+    private fun setShowError() {
+        binding.errorView.isVisible = showError
+
+        if (showError) {
+            itemView.setOnClickListener { onMessageClickListener.onMessageClick(id) }
+            binding.content.setOnClickListener { onMessageClickListener.onMessageClick(id) }
+        } else {
+            itemView.setOnClickListener(null)
+            binding.content.setOnClickListener(null)
+        }
+    }
+
+    private fun setAccessibilityLabels() {
+        itemView.contentDescription = stringProvider.getRemoteString(
+            if (showError) {
+                R.string.android_chat_visitor_message_not_delivered_accessibility
+            } else if (showDelivered) {
                 R.string.android_chat_visitor_message_delivered_accessibility
             } else {
                 R.string.android_chat_visitor_message_accessibility
             },
-            StringKeyPair(StringKey.MESSAGE, item.message)
+            StringKeyPair(StringKey.MESSAGE, binding.content.text.toString())
         )
-        itemView.contentDescription = contentDescription
+
+        ViewCompat.setAccessibilityDelegate(itemView, object : AccessibilityDelegateCompat() {
+            override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+                super.onInitializeAccessibilityNodeInfo(host, info)
+                val actionLabel = stringProvider.getRemoteString(R.string.general_retry)
+                val actionClick = AccessibilityActionCompat(
+                    AccessibilityNodeInfoCompat.ACTION_CLICK, actionLabel
+                )
+                info.addAction(actionClick)
+            }
+        })
     }
 
     fun updateDelivered(delivered: Boolean) {
-        binding.deliveredView.isVisible = delivered
+        this.showDelivered = delivered
+        setShowDelivered()
+        setAccessibilityLabels()
+    }
+
+    fun updateError(showError: Boolean) {
+        this.showError = showError
+        setShowError()
+        setAccessibilityLabels()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/fileattachment/OperatorFileAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/fileattachment/OperatorFileAttachmentViewHolder.java
@@ -29,7 +29,7 @@ public class OperatorFileAttachmentViewHolder extends FileAttachmentViewHolder {
     }
 
     public void bind(OperatorAttachmentItem.File item, ChatAdapter.OnFileItemClickListener listener) {
-        super.setData(item.isFileExists(), item.isDownloading(), item.getAttachmentFile(), listener);
+        super.setData(item.isFileExists(), item.isDownloading(), item.getAttachment(), listener);
         updateOperatorStatusView(item);
     }
 
@@ -46,8 +46,9 @@ public class OperatorFileAttachmentViewHolder extends FileAttachmentViewHolder {
             operatorStatusView.showPlaceholder();
         }
 
-        String name = item.getAttachmentFile().getName();
-        String byteSize = Formatter.formatFileSize(itemView.getContext(), item.getAttachmentFile().getSize());
+        String name = getAttachmentName(item.getAttachment());
+        long size = getAttachmentSize(item.getAttachment());
+        String byteSize = Formatter.formatFileSize(itemView.getContext(), size);
         itemView.setContentDescription(
             stringProvider.getRemoteString(
                 R.string.android_chat_operator_file_accessibility,

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.java
@@ -11,12 +11,15 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.glia.androidsdk.chat.AttachmentFile;
 import com.glia.widgets.R;
+import com.glia.widgets.chat.model.Attachment;
+import com.glia.widgets.core.fileupload.model.FileAttachment;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromCacheUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromDownloadsUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromNetworkUseCase;
 import com.glia.widgets.helper.FileHelper;
 import com.glia.widgets.helper.Logger;
 import com.google.android.material.imageview.ShapeableImageView;
+import com.squareup.picasso.Picasso;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -47,7 +50,19 @@ public class ImageAttachmentViewHolder extends RecyclerView.ViewHolder {
         this.getImageFileFromNetworkUseCase = getImageFileFromNetworkUseCase;
     }
 
-    public void bind(AttachmentFile attachmentFile) {
+    public void bind(Attachment attachment) {
+        AttachmentFile attachmentFile = attachment.getRemoteAttachment();
+        if (attachmentFile != null) {
+            bind(attachmentFile);
+        }
+
+        FileAttachment fileAttachment = attachment.getLocalAttachment();
+        if (fileAttachment != null) {
+            bind(fileAttachment);
+        }
+    }
+
+    private void bind(AttachmentFile attachmentFile) {
         imageView.setImageResource(android.R.color.transparent); // clear the previous view state
 
         String imageName = FileHelper.getFileName(attachmentFile);
@@ -69,6 +84,12 @@ public class ImageAttachmentViewHolder extends RecyclerView.ViewHolder {
                 );
 
         setAccessibilityActions();
+    }
+
+    private void bind(FileAttachment fileAttachment) {
+        Picasso.get()
+            .load(fileAttachment.getUri())
+            .into(imageView);
     }
 
     private void setAccessibilityActions() {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/OperatorImageAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/OperatorImageAttachmentViewHolder.java
@@ -7,6 +7,7 @@ import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 
+import com.glia.androidsdk.chat.AttachmentFile;
 import com.glia.widgets.R;
 import com.glia.widgets.StringProvider;
 import com.glia.widgets.UiTheme;
@@ -40,8 +41,14 @@ public class OperatorImageAttachmentViewHolder extends ImageAttachmentViewHolder
     }
 
     public void bind(OperatorAttachmentItem.Image item, ChatAdapter.OnImageItemClickListener onImageItemClickListener) {
-        super.bind(item.getAttachmentFile());
-        itemView.setOnClickListener(v -> onImageItemClickListener.onImageItemClick(item.getAttachmentFile(), v));
+        super.bind(item.getAttachment());
+        AttachmentFile attachmentFile = item.getAttachment().getRemoteAttachment();
+        if (attachmentFile != null) {
+            itemView.setOnClickListener(v -> onImageItemClickListener.onImageItemClick(attachmentFile, v));
+        } else {
+            itemView.setOnClickListener(null);
+        }
+
         updateOperatorStatus(item);
 
         setAccessibilityLabels();

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/VisitorImageAttachmentViewHolder.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/VisitorImageAttachmentViewHolder.java
@@ -8,11 +8,16 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 
 import com.glia.androidsdk.chat.AttachmentFile;
 import com.glia.widgets.R;
 import com.glia.widgets.StringProvider;
 import com.glia.widgets.UiTheme;
+import com.glia.widgets.chat.adapter.ChatAdapter;
+import com.glia.widgets.chat.model.VisitorAttachmentItem;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromCacheUseCase;
 import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromDownloadsUseCase;
@@ -20,7 +25,9 @@ import com.glia.widgets.filepreview.domain.usecase.GetImageFileFromNetworkUseCas
 
 public class VisitorImageAttachmentViewHolder extends ImageAttachmentViewHolder {
     private final TextView deliveredView;
+    private final TextView errorView;
     private final StringProvider stringProvider = Dependencies.getStringProvider();
+    private VisitorAttachmentItem.Image item;
 
     public VisitorImageAttachmentViewHolder(
         @NonNull View itemView,
@@ -32,39 +39,90 @@ public class VisitorImageAttachmentViewHolder extends ImageAttachmentViewHolder 
         super(itemView, getImageFileFromCacheUseCase, getImageFileFromDownloadsUseCase, getImageFileFromNetworkUseCase);
         deliveredView = itemView.findViewById(R.id.delivered_view);
         deliveredView.setText(stringProvider.getRemoteString(R.string.chat_message_delivered));
-        setupDeliveredView(itemView.getContext(), uiTheme);
+        errorView = itemView.findViewById(R.id.error_view);
+        errorView.setText(stringProvider.getRemoteString(R.string.chat_message_delivery_failed_retry));
+        setupUiTheme(itemView.getContext(), uiTheme);
     }
 
-    public void bind(AttachmentFile attachmentFile, boolean showDelivered) {
-        super.bind(attachmentFile);
-        setShowDelivered(showDelivered);
+    public void bind(
+        VisitorAttachmentItem.Image item,
+        ChatAdapter.OnImageItemClickListener onImageItemClickListener,
+        ChatAdapter.OnMessageClickListener onMessageClickListener
+    ) {
+        this.item = item;
+        super.bind(item.getAttachment());
+        itemView.setOnClickListener(view -> {
+            AttachmentFile attachmentFile = item.getAttachment().getRemoteAttachment();
+            if (attachmentFile != null) {
+                onImageItemClickListener.onImageItemClick(attachmentFile, view);
+            } else {
+                onMessageClickListener.onMessageClick(item.getId());
+            }
+        });
 
-        setAccessibilityLabels(showDelivered);
+        setShowError(item.getShowError());
+        setShowDelivered(item.getShowDelivered());
+
+        setAccessibilityLabels(item.getShowError(), item.getShowDelivered());
     }
 
-    private void setAccessibilityLabels(boolean showDelivered) {
-        if (showDelivered) {
+    private void setAccessibilityLabels(boolean showError, boolean showDelivered) {
+        if (showError) {
+            itemView.setContentDescription(stringProvider.getRemoteString(
+                R.string.android_chat_visitor_image_attachment_not_delivered_accessibility));
+        } else if (showDelivered) {
             itemView.setContentDescription(stringProvider.getRemoteString(
                 R.string.android_chat_visitor_image_attachment_delivered_accessibility));
         } else {
             itemView.setContentDescription(stringProvider.getRemoteString(
                 R.string.android_chat_visitor_image_attachment_accessibility));
         }
+
+        ViewCompat.setAccessibilityDelegate(itemView, new AccessibilityDelegateCompat() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(@NonNull View host, @NonNull AccessibilityNodeInfoCompat info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+
+                String actionLabel = stringProvider.getRemoteString(
+                    showError
+                        ? R.string.general_retry
+                        : R.string.general_open
+                );
+
+                AccessibilityNodeInfoCompat.AccessibilityActionCompat actionClick
+                    = new AccessibilityNodeInfoCompat.AccessibilityActionCompat(
+                    AccessibilityNodeInfoCompat.ACTION_CLICK, actionLabel);
+                info.addAction(actionClick);
+            }
+        });
     }
 
     private void setShowDelivered(boolean showDelivered) {
-        deliveredView.setVisibility(showDelivered ? View.VISIBLE : View.GONE);
+        deliveredView.setVisibility(!item.getShowError() && showDelivered ? View.VISIBLE : View.GONE);
     }
 
-    private void setupDeliveredView(Context context, UiTheme uiTheme) {
+    private void setShowError(boolean showError) {
+        errorView.setVisibility(showError ? View.VISIBLE : View.GONE);
+    }
+
+    private void setupUiTheme(Context context, UiTheme uiTheme) {
         if (uiTheme.getFontRes() != null) {
             Typeface fontFamily = ResourcesCompat.getFont(context, uiTheme.getFontRes());
             deliveredView.setTypeface(fontFamily);
+            errorView.setTypeface(fontFamily);
         }
-        deliveredView.setTextColor(ContextCompat.getColor(context, uiTheme.getBaseNormalColor()));
+        Integer baseNormalColor = uiTheme.getBaseNormalColor();
+        if (baseNormalColor != null) {
+            deliveredView.setTextColor(ContextCompat.getColor(context, baseNormalColor));
+        }
+        Integer systemNegativeColor = uiTheme.getSystemNegativeColor();
+        if (systemNegativeColor != null) {
+            errorView.setTextColor(ContextCompat.getColor(context, systemNegativeColor));
+        }
     }
 
     public void updateDelivered(boolean delivered) {
-        deliveredView.setVisibility(delivered ? View.VISIBLE : View.GONE);
+        setShowDelivered(delivered);
+        setAccessibilityLabels(item.getShowError(), delivered);
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -173,8 +173,8 @@ internal class ChatController(
                 onSendMessageOperatorOffline(message)
             }
 
-            override fun error(ex: GliaException) {
-                onMessageSendError(ex)
+            override fun error(ex: GliaException, message: Unsent) {
+                onMessageSendError(ex, message)
             }
         }
     private var isVisitorEndEngagement = false
@@ -343,9 +343,11 @@ internal class ChatController(
         sendMessagePreview("")
     }
 
-    private fun onMessageSendError(exception: GliaException) {
+    private fun onMessageSendError(ignore: GliaException, message: Unsent) {
         Logger.d(TAG, "messageSent exception")
-        error(exception)
+
+        chatManager.onChatAction(ChatManager.Action.MessageSendError(message))
+        scrollChatToBottom()
     }
 
     private fun onSendMessageOperatorOffline(message: Unsent) {
@@ -997,6 +999,10 @@ internal class ChatController(
             is Gva.ButtonType.PostBack -> sendGvaResponse(buttonType.singleChoiceAttachment)
             is Gva.ButtonType.Url -> viewCallback?.requestOpenUri(buttonType.uri)
         }
+    }
+
+    fun onMessageClicked(messageId: String) {
+        chatManager.onChatAction(ChatManager.Action.MessageClicked(messageId))
     }
 
     private fun scrollChatToBottom() {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
@@ -134,11 +134,11 @@ internal class AppendNewVisitorMessageUseCase(
     fun addUnsentItem(state: ChatManager.State, message: VisitorMessage): Boolean {
         if (state.unsentItems.isEmpty()) return false
 
-        val unsentMessage = state.unsentItems.firstOrNull { it.content == message.content } ?: return false
+        val unsentMessage = state.unsentItems.firstOrNull { it.messageId == message.id } ?: return false
         state.unsentItems.remove(unsentMessage)
 
-        val index = state.chatItems.indexOf(unsentMessage.chatMessage)
-        if (index != -1) {
+        val index = unsentMessage.chatMessage?.let { state.chatItems.indexOf(it) }
+        if (index != null && index >= 0) {
             if (lastDeliveredItem != null) {
                 val lastDeliveredIndex = state.chatItems.indexOf(lastDeliveredItem!!)
                 state.chatItems[lastDeliveredIndex] = lastDeliveredItem!!.withDeliveredStatus(false)
@@ -154,10 +154,8 @@ internal class AppendNewVisitorMessageUseCase(
 
         return false
     }
-
     operator fun invoke(state: ChatManager.State, chatMessageInternal: ChatMessageInternal) {
         val message = chatMessageInternal.chatMessage as VisitorMessage
-
         if (!addUnsentItem(state, message)) {
             message.apply {
                 val files = (attachment as? FilesAttachment)?.files

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/MapChatItemUseCases.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/MapChatItemUseCases.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.chat.domain
 import com.glia.androidsdk.chat.AttachmentFile
 import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.androidsdk.chat.VisitorMessage
+import com.glia.widgets.chat.model.Attachment
 import com.glia.widgets.chat.model.OperatorAttachmentItem
 import com.glia.widgets.chat.model.OperatorMessageItem
 import com.glia.widgets.chat.model.VisitorAttachmentItem
@@ -15,7 +16,7 @@ internal class MapOperatorAttachmentUseCase {
     operator fun invoke(attachment: AttachmentFile, chatMessageInternal: ChatMessageInternal, showChatHead: Boolean) = chatMessageInternal.run {
         if (attachment.isImage) {
             OperatorAttachmentItem.Image(
-                attachmentFile = attachment,
+                attachment = Attachment.Remote(attachment),
                 id = chatMessage.id,
                 timestamp = chatMessage.timestamp,
                 showChatHead = showChatHead,
@@ -24,7 +25,7 @@ internal class MapOperatorAttachmentUseCase {
             )
         } else {
             OperatorAttachmentItem.File(
-                attachmentFile = attachment,
+                attachment = Attachment.Remote(attachment),
                 id = chatMessage.id,
                 timestamp = chatMessage.timestamp,
                 showChatHead = showChatHead,
@@ -38,9 +39,9 @@ internal class MapOperatorAttachmentUseCase {
 internal class MapVisitorAttachmentUseCase {
     operator fun invoke(attachmentFile: AttachmentFile, message: VisitorMessage, showDelivered: Boolean = false): VisitorChatItem = message.run {
         if (attachmentFile.isImage) {
-            VisitorAttachmentItem.Image(id, timestamp, attachmentFile, showDelivered = showDelivered)
+            VisitorAttachmentItem.Image(id, timestamp, Attachment.Remote(attachmentFile), showDelivered = showDelivered)
         } else {
-            VisitorAttachmentItem.File(id, timestamp, attachmentFile, showDelivered = showDelivered)
+            VisitorAttachmentItem.File(id, timestamp, Attachment.Remote(attachmentFile), showDelivered = showDelivered)
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/SendMessagePayload.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/SendMessagePayload.kt
@@ -1,0 +1,37 @@
+package com.glia.widgets.chat.model
+
+import com.glia.androidsdk.chat.FilesAttachment
+import com.glia.androidsdk.chat.SingleChoiceAttachment
+import com.glia.widgets.core.fileupload.model.FileAttachment
+
+class SendMessagePayload private constructor(
+    val content: String,
+    val fileAttachments: List<FileAttachment>?,
+    val payload: com.glia.androidsdk.chat.SendMessagePayload
+) {
+    constructor(content: String, fileAttachments: List<FileAttachment>?) : this(
+        content,
+        fileAttachments,
+        com.glia.androidsdk.chat.SendMessagePayload(
+            content,
+            fileAttachments
+                ?.map { it.engagementFile }
+                ?.toTypedArray()
+                ?.let { FilesAttachment.from(it) }
+        )
+    )
+
+    @JvmOverloads
+    constructor(content: String, attachment: SingleChoiceAttachment? = null) : this(
+        content,
+        null,
+        com.glia.androidsdk.chat.SendMessagePayload(content, attachment)
+    )
+
+    constructor(attachment: SingleChoiceAttachment) : this(
+        attachment.selectedOptionText ?: "option",
+        attachment
+    )
+
+    val messageId = payload.messageId
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/fileupload/model/FileAttachment.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/fileupload/model/FileAttachment.java
@@ -75,6 +75,10 @@ public class FileAttachment {
         return this.mimeType;
     }
 
+    public boolean isImage() {
+        return mimeType.startsWith("image");
+    }
+
     public enum Status {
         UPLOADING(false),
         SECURITY_SCAN(false),

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SendSecureMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SendSecureMessageUseCase.kt
@@ -1,9 +1,9 @@
 package com.glia.widgets.core.secureconversations.domain
 
 import com.glia.androidsdk.RequestCallback
-import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.data.GliaChatRepository
+import com.glia.widgets.chat.model.SendMessagePayload
 import com.glia.widgets.core.engagement.GliaEngagementRepository
 import com.glia.widgets.core.fileupload.SecureFileAttachmentRepository
 import com.glia.widgets.core.fileupload.model.FileAttachment
@@ -55,10 +55,12 @@ internal class SendSecureMessageUseCase(
         queueIds: Array<String>,
         callback: RequestCallback<VisitorMessage?>
     ) {
+        val payload = SendMessagePayload(content = message)
+
         if (hasOngoingEngagement) {
-            chatRepository.sendMessage(message, callback)
+            chatRepository.sendMessage(payload, callback)
         } else {
-            secureConversationsRepository.send(message, queueIds, callback)
+            secureConversationsRepository.send(payload, queueIds, callback)
         }
     }
 
@@ -68,15 +70,15 @@ internal class SendSecureMessageUseCase(
         fileAttachments: List<FileAttachment>,
         callback: RequestCallback<VisitorMessage?>
     ) {
-        val filesAttachment = fileAttachments
-            .map { it.engagementFile }
-            .toTypedArray()
-            .let { FilesAttachment.from(it) }
+        val payload = SendMessagePayload(
+            content = message,
+            fileAttachments = fileAttachments.ifEmpty { null }
+        )
 
         if (hasOngoingEngagement) {
-            chatRepository.sendMessageWithAttachment(message, filesAttachment, callback)
+            chatRepository.sendMessage(payload, callback)
         } else {
-            secureConversationsRepository.send(message, queueIds, filesAttachment, callback)
+            secureConversationsRepository.send(payload, queueIds, callback)
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -1027,7 +1027,12 @@ public class UseCaseFactory {
 
     @NonNull
     public SendUnsentMessagesUseCase createSendUnsentMessagesUseCase() {
-        return new SendUnsentMessagesUseCase(repositoryFactory.getGliaMessageRepository());
+        return new SendUnsentMessagesUseCase(
+            repositoryFactory.getGliaMessageRepository(),
+            repositoryFactory.getSecureConversationsRepository(),
+            repositoryFactory.getEngagementConfigRepository(),
+            createIsSecureEngagementUseCase()
+        );
     }
 
     @NonNull

--- a/widgetssdk/src/main/res/layout/chat_attachment_visitor_file_layout.xml
+++ b/widgetssdk/src/main/res/layout/chat_attachment_visitor_file_layout.xml
@@ -33,6 +33,23 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
+        android:id="@+id/error_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_x_small"
+        tools:text="@string/chat_message_delivery_failed_retry"
+        android:gravity="end"
+        android:textAppearance="?attr/textAppearanceCaption"
+        android:textColor="?attr/gliaSystemNegativeColor"
+        android:visibility="gone"
+        android:importantForAccessibility="no"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/attachment_file_view" />
+
+    <TextView
         android:id="@+id/delivered_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/widgetssdk/src/main/res/layout/chat_attachment_visitor_image_layout.xml
+++ b/widgetssdk/src/main/res/layout/chat_attachment_visitor_image_layout.xml
@@ -32,6 +32,23 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
+        android:id="@+id/error_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_x_small"
+        tools:text="@string/chat_message_delivery_failed_retry"
+        android:gravity="end"
+        android:textAppearance="?attr/textAppearanceCaption"
+        android:textColor="?attr/gliaSystemNegativeColor"
+        android:visibility="gone"
+        android:importantForAccessibility="no"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/incoming_image_attachment" />
+
+    <TextView
         android:id="@+id/delivered_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/widgetssdk/src/main/res/layout/chat_visitor_message_layout.xml
+++ b/widgetssdk/src/main/res/layout/chat_visitor_message_layout.xml
@@ -40,6 +40,23 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
+        android:id="@+id/error_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_x_small"
+        tools:text="@string/chat_message_delivery_failed_retry"
+        android:gravity="end"
+        android:textAppearance="?attr/textAppearanceCaption"
+        android:textColor="?attr/gliaSystemNegativeColor"
+        android:visibility="gone"
+        android:importantForAccessibility="no"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/content" />
+
+    <TextView
         android:id="@+id/delivered_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -81,10 +81,12 @@
     <string name="engagement_queue_transferring">@string/glia_chat_visitor_status_transferring</string>
     <string name="android_chat_visitor_message_accessibility">@string/glia_chat_visitor_message_content_description</string>
     <string name="android_chat_visitor_message_delivered_accessibility">@string/glia_chat_visitor_message_delivered_content_description</string>
+    <string name="android_chat_visitor_message_not_delivered_accessibility">Your message: %1$s \n Failed to deliver.</string>
     <string name="android_chat_operator_name_accessibility_message">@string/glia_chat_operator_name_message_content_description</string>
     <string name="android_chat_operator_message_accessibility">@string/glia_chat_operator_message_content_description</string>
     <string name="android_chat_visitor_image_attachment_accessibility">@string/glia_chat_visitor_image_content_description</string>
     <string name="android_chat_visitor_image_attachment_delivered_accessibility">@string/glia_chat_visitor_image_delivered_content_description</string>
+    <string name="android_chat_visitor_image_attachment_not_delivered_accessibility">Your attached image. \n Failed to deliver.</string>
     <string name="android_chat_operator_image_attachment_accessibility">@string/glia_chat_operator_image_content_description</string>
     <string name="android_chat_operator_file_accessibility">@string/glia_chat_operator_file_content_description</string>
     <string name="chat_download_downloading">@string/glia_chat_attachment_downloading_label</string>
@@ -96,10 +98,12 @@
     <string name="chat_file_upload_in_progress">@string/glia_chat_attachment_upload_uploading</string>
     <string name="engagement_connection_screen_message">@string/glia_chat_in_queue_message</string>
     <string name="chat_message_delivered">@string/glia_chat_delivered</string>
+    <string name="chat_message_delivery_failed_retry">Failed to deliver. Tap to retry.</string>
     <string name="chat_unread_message_divider">@string/glia_chat_new_messages</string>
     <string name="chat_attach_files">@string/glia_chat_add_attachment_description</string>
     <string name="android_chat_visitor_file_accessibility">@string/glia_chat_visitor_file_content_description</string>
     <string name="android_chat_visitor_file_delivered_accessibility">@string/glia_chat_visitor_file_delivered_content_description</string>
+    <string name="android_chat_visitor_file_not_delivered_accessibility">Your attached file %1$s, size %2$s. \n Failed to deliver.</string>
     <string name="android_bubble_accessibility">@string/glia_chat_head_view_content_description</string>
     <string name="android_upload_error_engagement_missing">@string/glia_chat_attachment_upload_error_engagement_missing</string>
     <string name="android_upload_error_file_limit">@string/glia_chat_attachment_upload_error_file_count_limit_reached</string>
@@ -182,6 +186,7 @@
     <string name="general_unknown">Unknown</string>
     <string name="general_browse">@string/glia_chat_attachment_upload_menu_browse</string>
     <string name="general_open">@string/glia_chat_attachment_open_button_label</string>
+    <string name="general_retry">Retry</string>
 
     <!-- Screen sharing -->
     <string name="screen_sharing_visitor_screen_disclaimer_info">@string/glia_dialog_screen_sharing_offer_message</string>
@@ -192,7 +197,6 @@
     <string name="error_unexpected_title">Something went wrong.</string> <!-- TODO NEW -->
     <string name="general_back">Back</string> <!-- TODO NEW -->
     <string name="general_message">Message</string> <!-- TODO NEW -->
-    <string name="general_retry">Retry</string><!-- TODO NEW -->
     <string name="general_selected">Selected</string><!-- TODO NEW, maybe unify? -->
     <string name="engagement_phone_title">Phone</string> <!-- TODO NEW -->
 

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -19,6 +19,7 @@ import com.glia.widgets.chat.model.MediaUpgradeStartedTimerItem
 import com.glia.widgets.chat.model.NewMessagesDividerItem
 import com.glia.widgets.chat.model.OperatorMessageItem
 import com.glia.widgets.chat.model.OperatorStatusItem
+import com.glia.widgets.chat.model.SendMessagePayload
 import com.glia.widgets.chat.model.Unsent
 import com.glia.widgets.core.engagement.domain.model.ChatHistoryResponse
 import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
@@ -181,7 +182,7 @@ class ChatManagerTest {
 
     @Test
     fun `addUnsentMessage adds Unsent message before OperatorStatusItem when chatItems contain OperatorStatusItem_InQueue`() {
-        val message: Unsent.Message = Unsent.Message(message = "message")
+        val message = Unsent(SendMessagePayload(content = "message"))
         val inQueue = OperatorStatusItem.InQueue("company_name")
         assertTrue(state.unsentItems.isEmpty())
         assertTrue(state.chatItems.isEmpty())
@@ -472,18 +473,16 @@ class ChatManagerTest {
 
     @Test
     fun `checkUnsentMessages calls sendUnsentMessagesUseCase when unsent messages list is not empty`() {
-        val mockUnsentMessage: Unsent.Message = mock {
-            on { message } doReturn "message"
-        }
+        val unsentMessage = Unsent(SendMessagePayload(content = "message"))
 
-        whenever(sendUnsentMessagesUseCase(any(), any())).thenAnswer {
+        whenever(sendUnsentMessagesUseCase(any(), any(), any())).thenAnswer {
             (it.getArgument(1) as ((VisitorMessage) -> Unit)).invoke(mock())
         }
 
-        state.unsentItems.add(mockUnsentMessage)
+        state.unsentItems.add(unsentMessage)
 
         subjectUnderTest.checkUnsentMessages(state)
-        verify(sendUnsentMessagesUseCase).invoke(any(), any())
+        verify(sendUnsentMessagesUseCase).invoke(any(), any(), any())
         verify(subjectUnderTest).onChatAction(any())
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.glia.androidsdk.chat.AttachmentFile
 import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.ChatManager
+import com.glia.widgets.chat.model.SendMessagePayload
 import com.glia.widgets.chat.model.Unsent
 import com.glia.widgets.chat.model.VisitorAttachmentItem
 import com.glia.widgets.chat.model.VisitorChatItem
@@ -56,25 +57,30 @@ class AppendNewVisitorMessageUseCaseTest {
         val content = "content"
         whenever(visitorMessage.content) doReturn content
 
-        state.unsentItems.add(Unsent.Message(message = content))
+        state.unsentItems.add(Unsent(SendMessagePayload(content = content)))
         assertFalse(useCase.addUnsentItem(state, visitorMessage))
     }
 
     @Test
     fun `addUnsentItem returns true when unsentItems and chatItems contain received message`() {
-        val lastDelivered: VisitorChatItem = VisitorMessageItem("message", "id", 1, true)
+        val lastDelivered: VisitorChatItem = VisitorMessageItem("message", "id1", 1, true)
 
         useCase.lastDeliveredItem = lastDelivered
         state.chatItems.add(lastDelivered)
 
+        val id = "id2"
         val content = "content"
         whenever(visitorMessage.content) doReturn content
-        whenever(visitorMessage.id) doReturn "id"
+        whenever(visitorMessage.id) doReturn id
         whenever(visitorMessage.timestamp) doReturn 1
 
-        val unsentMessage = Unsent.Message(message = content)
+        val unsentMessage: Unsent = mock()
+        val unsentMessageItem = VisitorMessageItem(content, id, 2, showDelivered = false, showError = true)
+        whenever(unsentMessage.messageId) doReturn id
+        whenever(unsentMessage.chatMessage) doReturn unsentMessageItem
+
         state.unsentItems.add(unsentMessage)
-        state.chatItems.add(unsentMessage.chatMessage)
+        state.chatItems.add(unsentMessageItem)
 
         assertTrue(useCase.addUnsentItem(state, visitorMessage))
         assertTrue(state.unsentItems.isEmpty())

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/MapOperatorAttachmentUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/MapOperatorAttachmentUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.glia.widgets.chat.domain
 
 import com.glia.androidsdk.chat.AttachmentFile
 import com.glia.widgets.chat.MockChatMessageInternal
+import com.glia.widgets.chat.model.Attachment
 import com.glia.widgets.chat.model.OperatorAttachmentItem
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -20,6 +21,7 @@ class MapOperatorAttachmentUseCaseTest {
     @Before
     fun setUp() {
         mockAttachment = mock()
+        whenever(mockAttachment.id) doReturn "attachment_id"
         mockChatMessageInternal.mockChatMessage()
         mockChatMessageInternal.mockOperatorProperties()
     }
@@ -35,11 +37,11 @@ class MapOperatorAttachmentUseCaseTest {
         mockChatMessageInternal.apply {
             val mappedMessage = useCase(mockAttachment, chatMessageInternal, true)
             assertTrue(mappedMessage is OperatorAttachmentItem.Image)
-            assertEquals(mappedMessage.attachmentFile, mockAttachment)
-            assertEquals(mappedMessage.timestamp, messageTimeStamp)
-            assertEquals(mappedMessage.showChatHead, true)
-            assertEquals(mappedMessage.operatorProfileImgUrl, operatorImageUrl)
-            assertEquals(mappedMessage.operatorId, operatorId)
+            assertEquals(Attachment.Remote(mockAttachment), mappedMessage.attachment)
+            assertEquals(messageTimeStamp, mappedMessage.timestamp)
+            assertEquals(true, mappedMessage.showChatHead)
+            assertEquals(operatorImageUrl, mappedMessage.operatorProfileImgUrl)
+            assertEquals(operatorId, mappedMessage.operatorId)
         }
     }
 
@@ -49,11 +51,11 @@ class MapOperatorAttachmentUseCaseTest {
         mockChatMessageInternal.apply {
             val mappedMessage = useCase(mockAttachment, chatMessageInternal, false)
             assertTrue(mappedMessage is OperatorAttachmentItem.File)
-            assertEquals(mappedMessage.attachmentFile, mockAttachment)
-            assertEquals(mappedMessage.timestamp, messageTimeStamp)
-            assertEquals(mappedMessage.showChatHead, false)
-            assertEquals(mappedMessage.operatorProfileImgUrl, operatorImageUrl)
-            assertEquals(mappedMessage.operatorId, operatorId)
+            assertEquals(Attachment.Remote(mockAttachment), mappedMessage.attachment)
+            assertEquals(messageTimeStamp, mappedMessage.timestamp)
+            assertEquals(false, mappedMessage.showChatHead)
+            assertEquals(operatorImageUrl, mappedMessage.operatorProfileImgUrl)
+            assertEquals(operatorId, mappedMessage.operatorId)
         }
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/MapVisitorAttachmentUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/MapVisitorAttachmentUseCaseTest.kt
@@ -19,9 +19,10 @@ class MapVisitorAttachmentUseCaseTest {
     @Before
     fun setUp() {
         mockAttachment = mock()
+        whenever(mockAttachment.id) doReturn "attachment_id"
 
         visitorMessage = mock()
-        whenever(visitorMessage.id) doReturn "id"
+        whenever(visitorMessage.id) doReturn "message_id"
         whenever(visitorMessage.timestamp) doReturn -1
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2590

**What was solved?**

Added the ability to resend messages that were failed to send because of Internet connection issues.

Made ChatManager able to resend the failed messages.
The ChatAdapter was changed to make the ability to show the failed attachment.
The chat repositories were cleaned up. Now they work only with `SendMessagePayload`.
Also, I refactored how ChatAdapter binds the payloads. I hope it makes the code clear.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**

https://github.com/salemove/android-sdk-widgets/assets/79906470/8f2f1eb1-f583-465f-8bae-58ea35900ef8
