### PR TITLE
Send logs through Core SDK logger

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -1,5 +1,8 @@
 package com.glia.widgets;
 
+import static com.glia.widgets.helper.Logger.SITE_ID_KEY;
+import static java.util.Collections.singletonMap;
+
 import android.app.Application;
 import android.content.Intent;
 
@@ -130,6 +133,7 @@ public class GliaWidgets {
         GliaConfig gliaConfig = createGliaConfig(gliaWidgetsConfig);
         Dependencies.glia().init(gliaConfig);
         Dependencies.init(gliaWidgetsConfig);
+        setupLoggingMetadata(gliaWidgetsConfig);
         Dependencies.getGliaThemeManager().applyJsonConfig(gliaWidgetsConfig.getUiJsonRemoteConfig());
         Logger.d(TAG, "init");
     }
@@ -321,6 +325,10 @@ public class GliaWidgets {
      */
     public static String getWidgetsCoreSdkVersion() {
         return BuildConfig.GLIA_CORE_SDK_VERSION;
+    }
+
+    private static void setupLoggingMetadata(GliaWidgetsConfig gliaWidgetsConfig) {
+        Logger.addGlobalMetadata(singletonMap(SITE_ID_KEY, gliaWidgetsConfig.getSiteId()));
     }
 
     // More info about global Rx error handler:

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.kt
@@ -60,7 +60,7 @@ internal open class ImageAttachmentViewHolder(
             .observeOn(schedulers.mainScheduler)
             .subscribe({ bm: Bitmap? -> imageView.setImageBitmap(bm) }
             ) { error: Throwable ->
-                e(TAG, error.message)
+                error.message?.let { e(TAG, it) }
                 imageView.setBackgroundColor(Color.BLACK)
             }
         setAccessibilityActions()

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -496,7 +496,7 @@ internal class ChatController(
 
         engagementStateEventDisposable = getGliaEngagementStateFlowableUseCase
             .execute()
-            .subscribe({ onEngagementStateChanged(it) }) { Logger.e(TAG, it.message) }
+            .subscribe({ onEngagementStateChanged(it) }) { throwable -> throwable.message?.let { Logger.e(TAG, it) } }
         disposable.add(engagementStateEventDisposable!!)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
@@ -1,32 +1,139 @@
 package com.glia.widgets.helper
 
 import android.util.Log
-import com.glia.widgets.BuildConfig
+import com.glia.androidsdk.BuildConfig
+import com.glia.androidsdk.LogLevel
+import com.glia.androidsdk.LoggingAdapter
+import java.util.function.Consumer
 
-object Logger {
+internal object Logger {
+
+    const val SITE_ID_KEY = "site_id"
+
+    private val loggingAdapters = mutableListOf<LoggingAdapter>()
+    private val globalMetadata = mutableMapOf<String, String>()
+
+    @Suppress("unused")
     @JvmStatic
-    fun d(tag: String, message: String?) {
-        if (BuildConfig.DEBUG) {
-            // No need to log an empty message
-            Log.d(tag, message ?: return)
-        }
+    fun addAdapter(loggingAdapter: LoggingAdapter) {
+        loggingAdapters.add(loggingAdapter)
     }
 
     @JvmStatic
-    fun e(tag: String, message: String?) {
-        if (BuildConfig.DEBUG) {
-            // //No need to log an empty message
-            Log.e(tag, message ?: return)
+    fun d(tag: String, message: String) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.d(tag, message)
         }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.DEBUG, tag, message, concatGlobalMeta(null))
+        })
     }
 
     @JvmStatic
-    fun e(tag: String, message: String?, tr: Throwable?) {
-        if (BuildConfig.DEBUG) {
-            // No problem with lint in here
-            if (message.isNullOrBlank() && tr == null) return
-            Log.e(tag, message, tr)
+    fun d(tag: String, message: String, metadata: Map<String, String>? = null) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.d(tag, message)
         }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.DEBUG, tag, message, concatGlobalMeta(metadata))
+        })
+    }
+
+    @JvmStatic
+    fun i(tag: String, message: String) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.i(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.INFO, tag, message, concatGlobalMeta(null))
+        })
+    }
+
+    @JvmStatic
+    fun i(tag: String, message: String, metadata: Map<String, String>? = null) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.i(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.INFO, tag, message, concatGlobalMeta(metadata))
+        })
+    }
+
+    @JvmStatic
+    fun w(tag: String, message: String) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.w(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.WARN, tag, message, concatGlobalMeta(null))
+        })
+    }
+
+    @JvmStatic
+    fun w(tag: String, message: String, metadata: Map<String, String>? = null) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.w(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.WARN, tag, message, concatGlobalMeta(metadata))
+        })
+    }
+
+    @JvmStatic
+    fun e(tag: String, message: String) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.e(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.error(tag, message, null, concatGlobalMeta(null))
+        })
+    }
+
+    @JvmStatic
+    fun e(tag: String, message: String, throwable: Throwable?) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.e(tag, message, throwable)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.error(tag, message, throwable, concatGlobalMeta(null))
+        })
+    }
+
+    @JvmStatic
+    fun e(tag: String, message: String, throwable: Throwable?, metadata: Map<String, String>? = null) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.e(tag, message, throwable)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.error(tag, message, throwable, concatGlobalMeta(metadata))
+        })
+    }
+
+    @JvmStatic
+    @Synchronized
+    fun addGlobalMetadata(metadata: Map<String, String>) {
+        globalMetadata.putAll(metadata)
+    }
+
+    @Synchronized
+    fun removeGlobalMetadata(metaKey: String) {
+        globalMetadata.remove(metaKey)
+    }
+
+    private fun concatGlobalMeta(metadata: Map<String, String>?): Map<String, String> {
+        val combinedMap: MutableMap<String, String> = HashMap()
+        if (globalMetadata.isNotEmpty()) combinedMap.putAll(globalMetadata)
+        if (!metadata.isNullOrEmpty()) combinedMap.putAll(metadata)
+        return combinedMap
     }
 }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
@@ -152,7 +152,7 @@ class VisitorCodeView internal constructor(
     }
 
     override fun showError(throwable: Throwable) {
-        Logger.e(TAG, throwable.message, throwable)
+        throwable.message?.let { Logger.e(TAG, it, throwable) }
         runOnUi {
             showProgressBar(false)
             showFailure()

--- a/widgetssdk/src/test/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepositoryTest.java
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepositoryTest.java
@@ -92,6 +92,7 @@ public class GliaScreenSharingRepositoryTest {
         OmnicoreEngagement engagement = mock(OmnicoreEngagement.class);
         ScreenSharing screenSharing = mock(ScreenSharing.class);
         ScreenSharingRequest request = mock(ScreenSharingRequest.class);
+        GliaException gliaException = new GliaException("Mock debug message", GliaException.Cause.INTERNAL_ERROR);
         doAnswer(invocation -> {
             Consumer<OmnicoreEngagement> callback = invocation.getArgument(1);
             callback.accept(engagement);
@@ -112,7 +113,7 @@ public class GliaScreenSharingRepositoryTest {
         }).when(OMNIBROWSE).on(any(), any());
         doAnswer(invocation -> {
             Consumer<GliaException> callback = invocation.getArgument(3);
-            callback.accept(mock(GliaException.class));
+            callback.accept(gliaException);
             return null;
         }).when(request).accept(any(), any(Activity.class), anyInt(), any());
         subjectUnderTest.init(screenSharingCallback);

--- a/widgetssdk/src/test/java/com/glia/widgets/helper/LoggerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/helper/LoggerTest.kt
@@ -1,0 +1,87 @@
+package com.glia.widgets.helper
+
+import com.glia.androidsdk.LogLevel
+import com.glia.androidsdk.LoggingAdapter
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import java.util.Collections
+
+class LoggerTest {
+    @Test
+    fun `loggingAdapter logs messages`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        Logger.addAdapter(loggingAdapter)
+        Logger.d(LoggerTest.TAG, MESSAGE)
+        Logger.i(LoggerTest.TAG, MESSAGE)
+        Logger.w(LoggerTest.TAG, MESSAGE)
+        Logger.e(LoggerTest.TAG, MESSAGE, error)
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, emptyMap())
+    }
+
+    @Test
+    fun `loggingAdapter logs messages with metadata`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        Logger.addAdapter(loggingAdapter)
+        val metadata = Collections.singletonMap("key", "value")
+        Logger.d(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.i(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.w(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, metadata)
+    }
+
+    @Test
+    fun `loggingAdapter logs messages with global metadata`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        Logger.addAdapter(loggingAdapter)
+        val metadata = Collections.singletonMap("key", "value")
+        val globalMeta = Collections.singletonMap("globalKey", "value0")
+        val combinedMetadata: MutableMap<String, String> = HashMap()
+        combinedMetadata.putAll(metadata)
+        combinedMetadata.putAll(globalMeta)
+        Logger.addGlobalMetadata(globalMeta)
+        Logger.d(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.i(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.w(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, combinedMetadata)
+        Logger.removeGlobalMetadata("globalKey")
+    }
+
+    @Test
+    fun `logger logs only locally when loggingAdapters list empty`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        val metadata = Collections.singletonMap("key", "value")
+        val globalMeta = Collections.singletonMap("globalKey", "value0")
+        val combinedMetadata: MutableMap<String, String> = HashMap()
+        combinedMetadata.putAll(metadata)
+        combinedMetadata.putAll(globalMeta)
+        Logger.addGlobalMetadata(globalMeta)
+        Logger.d(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.i(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.w(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
+        Mockito.verify(loggingAdapter, never()).log(any(), any(), any(), any())
+        Logger.removeGlobalMetadata("globalKey")
+    }
+
+    companion object {
+        private const val TAG = "tag"
+        private const val MESSAGE = "message"
+    }
+}


### PR DESCRIPTION
**Jira issue:**
[Developers want to be able to send logs from Widgets SDK](https://glia.atlassian.net/browse/MOB-2789)

**What was solved?**
These changes work based on the [Inject Core SDK Logger to Widgets SDK](https://github.com/salemove/android-sdk/pull/591) changes suggested for Core SDK.

So all logs will go through Core SDK `LoggingAdapters` and as a result will be sent to ~LogCat (via `StdoutAdapter`) and to the backend(via `ClientLoggerAdapter`)~ the same `LoggingAdapters` as attached to Core SDK.

**Mechanism explanation**
1. Added the `Logger.addAdapter(LoggingAdapter)` private method. It will be used by Core SDK through reflection. All added adapters are saved in a private `loggingAdapters` list.
2. When logging event happens, `Logger` will iterate through `loggingAdapters` list and call `log()` on each `LoggingAdapter`.

Build fails because changes require Core SDK release.

**Release notes:**
This change is for internal logging. There is no need to mention it in the release notes, I think.

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

