### PR TITLE
Refactor Dialogs to inflate views independently

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
@@ -1,13 +1,20 @@
 package com.glia.widgets
 
+import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.FontRes
+import androidx.core.content.res.ResourcesCompat
+import com.glia.widgets.helper.isAlertDialogButtonUseVerticalAlignment
 import com.glia.widgets.view.configuration.ButtonConfiguration
 import com.glia.widgets.view.configuration.ChatHeadConfiguration
 import com.glia.widgets.view.configuration.TextConfiguration
 import com.glia.widgets.view.configuration.survey.SurveyStyle
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.ColorPallet
+import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
+import com.glia.widgets.view.unifiedui.theme.defaulttheme.AlertTheme
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -418,6 +425,25 @@ data class UiTheme(
         gvaQuickReplyBackgroundColor = builder.gvaQuickReplyBackgroundColor,
         gvaQuickReplyStrokeColor = builder.gvaQuickReplyStrokeColor,
         gvaQuickReplyTextColor = builder.gvaQuickReplyTextColor
+    )
+
+    private fun toColorPallet(context: Context): ColorPallet = context.run {
+        ColorPallet(
+            baseDarkColorTheme = ColorTheme(context.getColor(baseDarkColor ?: R.color.glia_base_dark_color)),
+            baseLightColorTheme = ColorTheme(context.getColor(baseLightColor ?: R.color.glia_base_light_color)),
+            baseNeutralColorTheme = ColorTheme(context.getColor(R.color.glia_system_agent_bubble_color)),
+            baseNormalColorTheme = ColorTheme(context.getColor(baseNormalColor ?: R.color.glia_base_normal_color)),
+            baseShadeColorTheme = ColorTheme(context.getColor(baseShadeColor ?: R.color.glia_base_shade_color)),
+            primaryColorTheme = ColorTheme(context.getColor(brandPrimaryColor ?: R.color.glia_brand_primary_color)),
+            secondaryColorTheme = null,
+            systemNegativeColorTheme = ColorTheme(context.getColor(systemNegativeColor ?: R.color.glia_system_negative_color))
+        )
+    }
+
+    internal fun alertTheme(context: Context): AlertThemeWrapper = AlertThemeWrapper(
+        AlertTheme(toColorPallet(context)).copy(isVerticalAxis = isAlertDialogButtonUseVerticalAlignment()),
+        fontRes?.let { ResourcesCompat.getFont(context, it) },
+        whiteLabel
     )
 
     class UiThemeBuilder {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.call
 
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.Configuration
 import android.content.res.TypedArray
@@ -366,13 +365,9 @@ internal class CallView(
     }
 
     private fun showExitQueueDialog() {
-        alertDialog = Dialogs.showOptionsDialog(
-            context = this.context,
-            theme = theme,
-            title = stringProvider.getRemoteString(R.string.engagement_queue_leave_header),
-            message = stringProvider.getRemoteString(R.string.engagement_queue_leave_message),
-            positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-            negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+        alertDialog = Dialogs.showExitQueueDialog(
+            context = context,
+            uiTheme = theme,
             positiveButtonClickListener = {
                 dismissAlertDialog()
                 callController?.endEngagementDialogYesClicked()
@@ -383,23 +378,18 @@ internal class CallView(
                 dismissAlertDialog()
                 callController?.endEngagementDialogDismissed()
             },
-            cancelListener = {
+            onCancelListener = {
                 it.dismiss()
                 callController?.endEngagementDialogDismissed()
-            },
-            isButtonsColorsReversed = true
+            }
         )
     }
 
     private fun showAllowScreenSharingNotificationsAndStartSharingDialog() {
         if (alertDialog == null || !alertDialog!!.isShowing) {
-            alertDialog = Dialogs.showOptionsDialog(
-                context = this.context,
-                theme = theme,
-                title = stringProvider.getRemoteString(R.string.android_screen_sharing_offer_with_notifications_title),
-                message = stringProvider.getRemoteString(R.string.android_screen_sharing_offer_with_notifications_message),
-                positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-                negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+            alertDialog = Dialogs.showAllowScreenSharingNotificationsAndStartSharingDialog(
+                context = context,
+                uiTheme = theme,
                 positiveButtonClickListener = {
                     callController?.notificationsDialogDismissed()
                     this.context.openNotificationChannelScreen()
@@ -408,7 +398,7 @@ internal class CallView(
                     callController?.notificationsDialogDismissed()
                     screenSharingController?.onScreenSharingDeclined()
                 },
-                cancelListener = {
+                onCancelListener = {
                     callController?.notificationsDialogDismissed()
                     screenSharingController?.onScreenSharingDeclined()
                 }
@@ -418,13 +408,9 @@ internal class CallView(
 
     private fun showAllowNotificationsDialog() {
         if (alertDialog == null || !alertDialog!!.isShowing) {
-            alertDialog = Dialogs.showOptionsDialog(
-                context = this.context,
-                theme = theme,
-                title = stringProvider.getRemoteString(R.string.android_notification_allow_notifications_title),
-                message = stringProvider.getRemoteString(R.string.android_notification_allow_notifications_message),
-                positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-                negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+            alertDialog = Dialogs.showAllowNotificationsDialog(
+                context = context,
+                uiTheme = theme,
                 positiveButtonClickListener = {
                     dismissAlertDialog()
                     callController?.notificationsDialogDismissed()
@@ -434,7 +420,7 @@ internal class CallView(
                     dismissAlertDialog()
                     callController?.notificationsDialogDismissed()
                 },
-                cancelListener = {
+                onCancelListener = {
                     it.dismiss()
                     callController?.notificationsDialogDismissed()
                 }
@@ -444,16 +430,16 @@ internal class CallView(
 
     private fun showScreenSharingDialog() {
         if (alertDialog == null || !alertDialog!!.isShowing) {
-            alertDialog =
-                Dialogs.showScreenSharingDialog(
-                    this.context,
-                    theme,
-                    stringProvider.getRemoteString(R.string.screen_sharing_visitor_screen_disclaimer_title),
-                    stringProvider.getRemoteString(R.string.screen_sharing_visitor_screen_disclaimer_info),
-                    R.string.general_accept,
-                    R.string.general_decline,
-                    { screenSharingController!!.onScreenSharingAccepted(context.requireActivity()) }
-                ) { screenSharingController!!.onScreenSharingDeclined() }
+            alertDialog = Dialogs.showScreenSharingDialog(
+                context = context,
+                theme = theme,
+                positiveButtonClickListener = {
+                    screenSharingController!!.onScreenSharingAccepted(context.requireActivity())
+                },
+                negativeButtonClickListener = {
+                    screenSharingController!!.onScreenSharingDeclined()
+                }
+            )
         }
     }
 
@@ -676,13 +662,9 @@ internal class CallView(
     }
 
     private fun showEndEngagementDialog() {
-        alertDialog = Dialogs.showOptionsDialog(
-            context = this.context,
-            theme = theme,
-            title = stringProvider.getRemoteString(R.string.engagement_end_confirmation_header),
-            message = stringProvider.getRemoteString(R.string.engagement_end_message),
-            positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-            negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+        alertDialog = Dialogs.showEndEngagementDialog(
+            context = context,
+            uiTheme = theme,
             positiveButtonClickListener = {
                 dismissAlertDialog()
                 callController?.endEngagementDialogYesClicked()
@@ -691,11 +673,10 @@ internal class CallView(
                 dismissAlertDialog()
                 callController?.endEngagementDialogDismissed()
             },
-            cancelListener = {
+            onCancelListener = {
                 it.dismiss()
                 callController?.endEngagementDialogDismissed()
-            },
-            isButtonsColorsReversed = true
+            }
         )
     }
 
@@ -705,43 +686,6 @@ internal class CallView(
         }) {
             callController?.declineUpgradeOfferClicked(mediaUpgrade.mediaUpgradeOffer)
         }
-    }
-
-    private fun showOptionsDialog(
-        title: String,
-        message: String,
-        positiveButtonText: String,
-        neutralButtonText: String,
-        positiveButtonClickListener: OnClickListener,
-        neutralButtonClickListener: OnClickListener,
-        cancelListener: DialogInterface.OnCancelListener
-    ) {
-        alertDialog = Dialogs.showOptionsDialog(
-            context = this.context,
-            theme = theme,
-            title = title,
-            message = message,
-            positiveButtonText = positiveButtonText,
-            negativeButtonText = neutralButtonText,
-            positiveButtonClickListener = positiveButtonClickListener,
-            negativeButtonClickListener = neutralButtonClickListener,
-            cancelListener = cancelListener
-        )
-    }
-
-    private fun showAlertDialog(
-        @StringRes title: Int,
-        @StringRes message: Int,
-        buttonClickListener: OnClickListener
-    ) {
-        dismissAlertDialog()
-        alertDialog = Dialogs.showAlertDialog(
-            this.context,
-            theme,
-            title,
-            message,
-            buttonClickListener
-        )
     }
 
     private fun showEngagementEndedDialog() {
@@ -755,23 +699,18 @@ internal class CallView(
     }
 
     private fun showNoMoreOperatorsAvailableDialog() {
-        showAlertDialog(
-            R.string.engagement_queue_closed_header,
-            R.string.engagement_queue_closed_message
-        ) {
+        dismissAlertDialog()
+        alertDialog = Dialogs.showNoMoreOperatorsAvailableDialog(context, theme) {
             dismissAlertDialog()
             callController?.noMoreOperatorsAvailableDismissed()
             onEndListener?.onEnd()
             callEnded()
-            alertDialog = null
         }
     }
 
     private fun showUnexpectedErrorDialog() {
-        showAlertDialog(
-            R.string.error_general,
-            R.string.engagement_queue_reconnection_failed
-        ) {
+        dismissAlertDialog()
+        alertDialog = Dialogs.showUnexpectedErrorDialog(context, theme) {
             dismissAlertDialog()
             callController?.unexpectedErrorDialogDismissed()
             onEndListener?.onEnd()
@@ -779,10 +718,8 @@ internal class CallView(
     }
 
     override fun showMissingPermissionsDialog() {
-        showAlertDialog(
-            R.string.android_permissions_title,
-            R.string.android_permissions_message
-        ) {
+        dismissAlertDialog()
+        alertDialog = Dialogs.showMissingPermissionsDialog(context, theme) {
             dismissAlertDialog()
             callController?.unexpectedErrorDialogDismissed()
             onEndListener?.onEnd()
@@ -809,12 +746,10 @@ internal class CallView(
     }
 
     private fun showOverlayPermissionsDialog() {
-        showOptionsDialog(
-            stringProvider.getRemoteString(R.string.android_overlay_permission_title),
-            stringProvider.getRemoteString(R.string.android_overlay_permission_message),
-            stringProvider.getRemoteString(R.string.general_ok),
-            stringProvider.getRemoteString(R.string.general_no),
-            {
+        alertDialog = Dialogs.showOverlayPermissionsDialog(
+            context = context,
+            uiTheme = theme,
+            positiveButtonClickListener = {
                 dismissAlertDialog()
                 callController?.overlayPermissionsDialogDismissed()
                 val overlayIntent = Intent(
@@ -824,22 +759,21 @@ internal class CallView(
                 overlayIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 this.context.startActivity(overlayIntent)
             },
-            {
+            negativeButtonClickListener = {
                 dismissAlertDialog()
                 callController?.overlayPermissionsDialogDismissed()
+            },
+            onCancelListener = {
+                it.dismiss()
+                callController?.overlayPermissionsDialogDismissed()
             }
-        ) {
-            it.dismiss()
-            callController?.overlayPermissionsDialogDismissed()
-        }
+        )
     }
 
     private fun dismissAlertDialog() {
         currentDialogState = null
-        alertDialog?.apply {
-            dismiss()
-            alertDialog = null
-        }
+        alertDialog?.dismiss()
+        alertDialog = null
     }
 
     private fun callEnded() {

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -38,6 +38,7 @@ import com.glia.widgets.helper.WeakReferenceDelegate
 import com.glia.widgets.helper.getFullHybridTheme
 import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
 import com.glia.widgets.view.Dialogs
+import com.glia.widgets.view.dialog.base.DialogPayload
 
 @SuppressLint("CheckResult")
 internal class ActivityWatcherForCallVisualizer(
@@ -234,21 +235,17 @@ internal class ActivityWatcherForCallVisualizer(
         showAlertDialogOnUiThreadWithStyledContext(
             "Show allow notifications dialog",
             UiTheme.UiThemeBuilder().build()
-        ) { context, uiTheme, activity ->
-            alertDialog = Dialogs.showOptionsDialog(
+        ) { context, uiTheme, _ ->
+            alertDialog = Dialogs.showAllowNotificationsDialog(
                 context = context,
-                theme = uiTheme,
-                title = stringProvider.getRemoteString(R.string.android_notification_allow_notifications_title),
-                message = stringProvider.getRemoteString(R.string.android_notification_allow_notifications_message),
-                positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-                negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+                uiTheme = uiTheme,
                 positiveButtonClickListener = {
                     controller.onPositiveDialogButtonClicked()
                 },
                 negativeButtonClickListener = {
                     controller.onNegativeDialogButtonClicked()
                 },
-                cancelListener = {
+                onCancelListener = {
                     controller.onNegativeDialogButtonClicked()
                 }
             )
@@ -263,21 +260,33 @@ internal class ActivityWatcherForCallVisualizer(
         showAlertDialogOnUiThreadWithStyledContext(
             "Show screen sharing and notifications dialog",
             UiTheme.UiThemeBuilder().build()
-        ) { context, uiTheme, activity ->
-            alertDialog = Dialogs.showOptionsDialog(
-                context = context,
-                theme = uiTheme,
+        ) { context, uiTheme, _ ->
+            val payload = DialogPayload.Option(
                 title = stringProvider.getRemoteString(R.string.android_screen_sharing_offer_with_notifications_title),
                 message = stringProvider.getRemoteString(R.string.android_screen_sharing_offer_with_notifications_message),
                 positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
                 negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+                poweredByText = stringProvider.getRemoteString(R.string.general_powered),
+                positiveButtonClickListener = {
+                    controller.onPositiveDialogButtonClicked()
+                },
+                negativeButtonClickListener = {
+                    controller.onNegativeDialogButtonClicked()
+                }
+
+            )
+
+            alertDialog = Dialogs.showAllowScreenSharingNotificationsAndStartSharingDialog(
+                context = context,
+                uiTheme = uiTheme,
                 positiveButtonClickListener = {
                     controller.onPositiveDialogButtonClicked()
                 },
                 negativeButtonClickListener = {
                     controller.onNegativeDialogButtonClicked()
                 },
-                cancelListener = {
+                onCancelListener = {
+                    it.dismiss()
                     controller.onNegativeDialogButtonClicked()
                 }
             )
@@ -288,21 +297,18 @@ internal class ActivityWatcherForCallVisualizer(
         showAlertDialogOnUiThreadWithStyledContext(
             "Show overlay permissions dialog",
             UiTheme.UiThemeBuilder().build()
-        ) { context, uiTheme, activity ->
-            alertDialog = Dialogs.showOptionsDialog(
-                context,
-                uiTheme,
-                stringProvider.getRemoteString(R.string.android_overlay_permission_title),
-                stringProvider.getRemoteString(R.string.android_overlay_permission_message),
-                stringProvider.getRemoteString(R.string.general_ok),
-                stringProvider.getRemoteString(R.string.general_no),
-                {
+        ) { context, uiTheme, _ ->
+            alertDialog = Dialogs.showOverlayPermissionsDialog(
+                context = context,
+                uiTheme = uiTheme,
+                positiveButtonClickListener = {
                     controller.onPositiveDialogButtonClicked()
                 },
-                {
+                negativeButtonClickListener = {
                     controller.onNegativeDialogButtonClicked()
                 },
-                {
+                onCancelListener = {
+                    it.dismiss()
                     controller.onNegativeDialogButtonClicked()
                 }
             )
@@ -312,16 +318,15 @@ internal class ActivityWatcherForCallVisualizer(
     override fun showScreenSharingDialog() {
         showAlertDialogOnUiThreadWithStyledContext("Show screen sharing dialog") { context, uiTheme, activity ->
             alertDialog = Dialogs.showScreenSharingDialog(
-                context,
-                uiTheme,
-                stringProvider.getRemoteString(R.string.screen_sharing_visitor_screen_disclaimer_title),
-                stringProvider.getRemoteString(R.string.screen_sharing_visitor_screen_disclaimer_info),
-                R.string.general_accept,
-                R.string.general_decline,
-                {
+                context = context,
+                theme = uiTheme,
+                positiveButtonClickListener = {
                     controller.onPositiveDialogButtonClicked(activity)
+                },
+                negativeButtonClickListener = {
+                    controller.onNegativeDialogButtonClicked()
                 }
-            ) { controller.onNegativeDialogButtonClicked() }
+            )
         }
     }
 
@@ -380,10 +385,7 @@ internal class ActivityWatcherForCallVisualizer(
             return
         }
         Logger.d(TAG, "Show visitor code dialog")
-        val theme = UiTheme.UiThemeBuilder().build()
-        val contextWithStyle = activity.wrapWithMaterialThemeOverlay()
-
-        alertDialog = Dialogs.showVisitorCodeDialog(contextWithStyle, theme)
+        alertDialog = Dialogs.showVisitorCodeDialog(activity.wrapWithMaterialThemeOverlay())
     }
 
     private fun getRuntimeTheme(activity: Activity): UiTheme {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.app.Activity
 import android.content.ClipData
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.TypedArray
@@ -19,7 +18,6 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
 import android.widget.Toast
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -664,13 +662,9 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
     private fun showAllowScreenSharingNotificationsAndStartSharingDialog() {
         if (alertDialog == null || !alertDialog!!.isShowing) {
-            alertDialog = Dialogs.showOptionsDialog(
-                context = this.context,
-                theme = theme,
-                title = stringProvider.getRemoteString(R.string.android_screen_sharing_offer_with_notifications_title),
-                message = stringProvider.getRemoteString(R.string.android_screen_sharing_offer_with_notifications_message),
-                positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-                negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+            alertDialog = Dialogs.showAllowScreenSharingNotificationsAndStartSharingDialog(
+                context = context,
+                uiTheme = theme,
                 positiveButtonClickListener = {
                     dismissAlertDialog()
                     this.context.openNotificationChannelScreen()
@@ -680,7 +674,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                     controller?.notificationDialogDismissed()
                     screenSharingController?.onScreenSharingDeclined()
                 },
-                cancelListener = {
+                onCancelListener = {
                     it.dismiss()
                     controller?.notificationDialogDismissed()
                     screenSharingController?.onScreenSharingDeclined()
@@ -691,13 +685,9 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
     private fun showAllowNotificationsDialog() {
         if (alertDialog == null || !alertDialog!!.isShowing) {
-            alertDialog = Dialogs.showOptionsDialog(
-                context = this.context,
-                theme = theme,
-                title = stringProvider.getRemoteString(R.string.android_notification_allow_notifications_title),
-                message = stringProvider.getRemoteString(R.string.android_notification_allow_notifications_message),
-                positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-                negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+            alertDialog = Dialogs.showAllowNotificationsDialog(
+                context = context,
+                uiTheme = theme,
                 positiveButtonClickListener = {
                     dismissAlertDialog()
                     controller?.notificationDialogDismissed()
@@ -707,7 +697,7 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                     dismissAlertDialog()
                     controller?.notificationDialogDismissed()
                 },
-                cancelListener = {
+                onCancelListener = {
                     it.dismiss()
                     controller?.notificationDialogDismissed()
                 }
@@ -718,14 +708,15 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     private fun showScreenSharingDialog() {
         if (alertDialog == null || !alertDialog!!.isShowing) {
             alertDialog = Dialogs.showScreenSharingDialog(
-                context,
-                theme,
-                stringProvider.getRemoteString(R.string.screen_sharing_visitor_screen_disclaimer_title),
-                stringProvider.getRemoteString(R.string.screen_sharing_visitor_screen_disclaimer_info),
-                R.string.general_accept,
-                R.string.general_decline,
-                { screenSharingController?.onScreenSharingAccepted(context.requireActivity()) }
-            ) { screenSharingController?.onScreenSharingDeclined() }
+                context = context,
+                theme = theme,
+                positiveButtonClickListener = {
+                    screenSharingController?.onScreenSharingAccepted(context.requireActivity())
+                },
+                negativeButtonClickListener = {
+                    screenSharingController?.onScreenSharingDeclined()
+                }
+            )
         }
     }
 
@@ -955,13 +946,9 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     }
 
     private fun showExitQueueDialog() {
-        alertDialog = Dialogs.showOptionsDialog(
+        alertDialog = Dialogs.showExitQueueDialog(
             context = context,
-            theme = theme,
-            title = stringProvider.getRemoteString(R.string.engagement_queue_leave_header),
-            message = stringProvider.getRemoteString(R.string.engagement_queue_leave_message),
-            positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-            negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+            uiTheme = theme,
             positiveButtonClickListener = {
                 dismissAlertDialog()
                 controller?.endEngagementDialogYesClicked()
@@ -972,22 +959,17 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                 dismissAlertDialog()
                 controller?.endEngagementDialogDismissed()
             },
-            cancelListener = {
+            onCancelListener = {
                 it.dismiss()
                 controller?.endEngagementDialogDismissed()
-            },
-            isButtonsColorsReversed = true
+            }
         )
     }
 
     private fun showEndEngagementDialog() {
-        alertDialog = Dialogs.showOptionsDialog(
+        alertDialog = Dialogs.showEndEngagementDialog(
             context = context,
-            theme = theme,
-            title = stringProvider.getRemoteString(R.string.engagement_end_confirmation_header),
-            message = stringProvider.getRemoteString(R.string.engagement_end_message),
-            positiveButtonText = stringProvider.getRemoteString(R.string.general_yes),
-            negativeButtonText = stringProvider.getRemoteString(R.string.general_no),
+            uiTheme = theme,
             positiveButtonClickListener = {
                 dismissAlertDialog()
                 controller?.endEngagementDialogYesClicked()
@@ -996,44 +978,11 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                 dismissAlertDialog()
                 controller?.endEngagementDialogDismissed()
             },
-            cancelListener = {
+            onCancelListener = {
                 controller?.endEngagementDialogDismissed()
                 it.dismiss()
-            },
-            isButtonsColorsReversed = true
+            }
         )
-    }
-
-    private fun showOptionsDialog(
-        title: String,
-        message: String,
-        positiveButtonText: String,
-        neutralButtonText: String,
-        positiveButtonClickListener: OnClickListener,
-        neutralButtonClickListener: OnClickListener,
-        cancelListener: DialogInterface.OnCancelListener
-    ) {
-        dismissAlertDialog()
-        alertDialog = Dialogs.showOptionsDialog(
-            context = this.context,
-            theme = theme,
-            title = title,
-            message = message,
-            positiveButtonText = positiveButtonText,
-            negativeButtonText = neutralButtonText,
-            positiveButtonClickListener = positiveButtonClickListener,
-            negativeButtonClickListener = neutralButtonClickListener,
-            cancelListener = cancelListener
-        )
-    }
-
-    private fun showAlertDialog(
-        @StringRes title: Int,
-        @StringRes message: Int,
-        buttonClickListener: OnClickListener
-    ) {
-        dismissAlertDialog()
-        alertDialog = Dialogs.showAlertDialog(context, theme, title, message, buttonClickListener)
     }
 
     private fun showEngagementEndedDialog() {
@@ -1047,10 +996,8 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     }
 
     private fun showNoMoreOperatorsAvailableDialog() {
-        showAlertDialog(
-            R.string.engagement_queue_closed_header,
-            R.string.engagement_queue_closed_message
-        ) {
+        dismissAlertDialog()
+        alertDialog = Dialogs.showNoMoreOperatorsAvailableDialog(context, theme) {
             dismissAlertDialog()
             controller?.noMoreOperatorsAvailableDismissed()
             onEndListener?.onEnd()
@@ -1067,10 +1014,8 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     }
 
     private fun showUnexpectedErrorDialog() {
-        showAlertDialog(
-            R.string.error_general,
-            R.string.engagement_queue_reconnection_failed
-        ) {
+        dismissAlertDialog()
+        alertDialog = Dialogs.showUnexpectedErrorDialog(context, theme) {
             dismissAlertDialog()
             controller?.unexpectedErrorDialogDismissed()
             onEndListener?.onEnd()
@@ -1078,12 +1023,12 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
     }
 
     private fun showOverlayPermissionsDialog() {
-        showOptionsDialog(
-            stringProvider.getRemoteString(R.string.android_overlay_permission_title),
-            stringProvider.getRemoteString(R.string.android_overlay_permission_message),
-            stringProvider.getRemoteString(R.string.general_ok),
-            stringProvider.getRemoteString(R.string.general_no),
-            {
+        dismissAlertDialog()
+
+        alertDialog = Dialogs.showOverlayPermissionsDialog(
+            context = context,
+            uiTheme = theme,
+            positiveButtonClickListener = {
                 controller?.overlayPermissionsDialogDismissed()
                 dismissAlertDialog()
                 val overlayIntent = Intent(
@@ -1093,14 +1038,15 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
                 overlayIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 this.context.startActivity(overlayIntent)
             },
-            {
+            negativeButtonClickListener = {
+                controller?.overlayPermissionsDialogDismissed()
+                dismissAlertDialog()
+            },
+            onCancelListener = {
                 controller?.overlayPermissionsDialogDismissed()
                 dismissAlertDialog()
             }
-        ) {
-            controller?.overlayPermissionsDialogDismissed()
-            dismissAlertDialog()
-        }
+        )
     }
 
     private fun chatEnded() {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
@@ -74,7 +74,7 @@ class MessageCenterView(
 
     private var alertDialog: AlertDialog? = null
 
-    // Is needed for setting status bar color back when view is gone
+    // Is needed for setting status bar color back when the view is gone
     private var defaultStatusBarColor: Int? = null
     private var statusBarColor: Int by Delegates.notNull()
 
@@ -183,12 +183,7 @@ class MessageCenterView(
 
     private fun showUnAuthenticatedDialog() {
         changeStatusBarColor(Color.TRANSPARENT)
-        alertDialog = Dialogs.showAlertDialog(
-            context,
-            theme,
-            R.string.message_center_unavailable_title,
-            R.string.message_center_not_authenticated_message
-        ) {
+        alertDialog = Dialogs.showUnAuthenticatedDialog(context, theme) {
             controller?.dismissCurrentDialog()
             controller?.onCloseButtonClicked()
         }
@@ -215,12 +210,8 @@ class MessageCenterView(
     }
 
     private fun showUnexpectedErrorDialog() {
-        alertDialog = Dialogs.showAlertDialog(
-            this.context,
-            theme,
-            R.string.error_general,
-            R.string.engagement_queue_reconnection_failed
-        ) {
+        dismissAlertDialog()
+        alertDialog = Dialogs.showUnexpectedErrorDialog(context, theme) {
             controller?.dismissCurrentDialog()
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewBinding.kt
@@ -1,0 +1,21 @@
+package com.glia.widgets.view.dialog.alert
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ImageButton
+import android.widget.TextView
+import com.glia.widgets.databinding.AlertDialogBinding
+import com.glia.widgets.view.dialog.base.DialogViewBinding
+
+class AlertDialogViewBinding(layoutInflater: LayoutInflater) : DialogViewBinding<AlertDialogBinding> {
+    override val binding: AlertDialogBinding = AlertDialogBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    val messageTv: TextView
+        get() = binding.dialogMessageView
+
+    val closeBtn: ImageButton
+        get() = binding.closeDialogButton
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewInflater.kt
@@ -1,0 +1,29 @@
+package com.glia.widgets.view.dialog.alert
+
+import android.view.LayoutInflater
+import androidx.core.view.isVisible
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogViewInflater
+import com.glia.widgets.view.unifiedui.applyImageColorTheme
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+
+internal class AlertDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.AlertDialog
+) :
+    DialogViewInflater<AlertDialogViewBinding, DialogPayload.AlertDialog>(
+        AlertDialogViewBinding(layoutInflater),
+        themeWrapper,
+        payload
+    ) {
+    override fun setup(binding: AlertDialogViewBinding, themeWrapper: AlertThemeWrapper, payload: DialogPayload.AlertDialog) {
+        val theme = themeWrapper.theme
+
+        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+        binding.closeBtn.applyImageColorTheme(theme.closeButtonColor)
+        binding.closeBtn.isVisible = payload.buttonVisible
+        payload.buttonClickListener?.also(binding.closeBtn::setOnClickListener)
+        payload.buttonDescription?.also { binding.closeBtn.contentDescription = it }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogDelegate.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogDelegate.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.view.dialog.base
+
+import androidx.appcompat.app.AlertDialog
+import com.glia.widgets.core.dialog.model.DialogState
+
+internal interface DialogDelegate {
+    fun showDialogIfNoDialogPresent(showDialogCallback: () -> AlertDialog)
+    fun forceShowDialog(showDialogCallback: () -> AlertDialog)
+    fun updateDialogState(dialogState: DialogState): Boolean
+    fun dismissAlertDialog()
+    fun resetDialogStateAndDismiss()
+}
+
+internal class DialogDelegateImpl : DialogDelegate {
+    private var alertDialog: AlertDialog? = null
+    private var dialogState: DialogState? = null
+
+    override fun showDialogIfNoDialogPresent(showDialogCallback: () -> AlertDialog) {
+        if (alertDialog?.isShowing == true) return
+        alertDialog = showDialogCallback()
+    }
+
+    override fun forceShowDialog(showDialogCallback: () -> AlertDialog) {
+        dismissAlertDialog()
+        alertDialog = showDialogCallback()
+    }
+
+    override fun updateDialogState(dialogState: DialogState): Boolean {
+        if (this.dialogState?.mode == dialogState.mode) return false
+
+        this.dialogState = dialogState
+
+        return true
+    }
+
+    override fun dismissAlertDialog() {
+        alertDialog?.dismiss()
+        alertDialog = null
+    }
+
+    override fun resetDialogStateAndDismiss() {
+        dialogState = null
+        dismissAlertDialog()
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
@@ -1,0 +1,54 @@
+package com.glia.widgets.view.dialog.base
+
+import android.view.View
+import androidx.annotation.DrawableRes
+
+internal sealed interface DialogPayload {
+    val title: String
+
+    data class Option(
+        override val title: String,
+        val message: String,
+        val positiveButtonText: String,
+        val negativeButtonText: String,
+        val poweredByText: String,
+        val positiveButtonClickListener: View.OnClickListener,
+        val negativeButtonClickListener: View.OnClickListener,
+    ) : DialogPayload
+
+    data class ScreenSharing(
+        override val title: String,
+        val message: String,
+        val positiveButtonText: String,
+        val negativeButtonText: String,
+        val poweredByText: String,
+        val positiveButtonClickListener: View.OnClickListener,
+        val negativeButtonClickListener: View.OnClickListener,
+    ) : DialogPayload
+
+    data class Upgrade(
+        override val title: String,
+        val positiveButtonText: String,
+        val negativeButtonText: String,
+        val poweredByText: String,
+        @DrawableRes
+        val iconRes: Int,
+        val positiveButtonClickListener: View.OnClickListener,
+        val negativeButtonClickListener: View.OnClickListener,
+    ) : DialogPayload
+
+    data class OperatorEndedEngagement(
+        override val title: String,
+        val message: String,
+        val buttonText: String,
+        val buttonClickListener: View.OnClickListener,
+    ) : DialogPayload
+
+    data class AlertDialog(
+        override val title: String,
+        val message: String,
+        val buttonVisible: Boolean = false,
+        val buttonDescription: String? = null,
+        val buttonClickListener: View.OnClickListener? = null
+    ) : DialogPayload
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogService.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogService.kt
@@ -1,0 +1,41 @@
+package com.glia.widgets.view.dialog.base
+
+import android.app.Dialog
+import android.content.Context
+import androidx.appcompat.app.AlertDialog
+import com.glia.widgets.R
+import com.glia.widgets.UiTheme
+import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+typealias DialogOnShowCallback = (AlertDialog) -> Unit
+typealias DialogOnLayoutCallback = Dialog.() -> Unit
+
+internal class DialogService(private val unifiedTheme: UnifiedTheme?) {
+    fun showDialog(
+        context: Context,
+        theme: UiTheme,
+        type: DialogType,
+        cancelable: Boolean = false,
+        onShow: DialogOnShowCallback? = null,
+        onLayout: DialogOnLayoutCallback? = null
+    ): AlertDialog {
+        val verticalInset = context.resources.getDimensionPixelSize(R.dimen.glia_large_x_large)
+        val view = DialogViewFactory(context, theme, unifiedTheme).createView(type)
+
+        val alertDialog = MaterialAlertDialogBuilder(context)
+            .setView(view)
+            .setCancelable(cancelable)
+            .setBackgroundInsetBottom(verticalInset)
+            .setBackgroundInsetTop(verticalInset)
+            .create()
+
+        onShow?.also { listener -> alertDialog.setOnShowListener { listener.invoke(alertDialog) } }
+
+        return alertDialog.also {
+            it.show()
+            onLayout?.invoke(it)
+        }
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogType.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogType.kt
@@ -1,0 +1,10 @@
+package com.glia.widgets.view.dialog.base
+
+internal sealed class DialogType(payload: DialogPayload) {
+    data class Option(val payload: DialogPayload.Option) : DialogType(payload)
+    data class ReversedOption(val payload: DialogPayload.Option) : DialogType(payload)
+    data class Upgrade(val payload: DialogPayload.Upgrade) : DialogType(payload)
+    data class ScreenSharing(val payload: DialogPayload.ScreenSharing) : DialogType(payload)
+    data class OperatorEndedEngagement(val payload: DialogPayload.OperatorEndedEngagement) : DialogType(payload)
+    data class AlertDialog(val payload: DialogPayload.AlertDialog) : DialogType(payload)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewBinding.kt
@@ -1,0 +1,12 @@
+package com.glia.widgets.view.dialog.base
+
+import android.view.View
+import android.widget.TextView
+import androidx.viewbinding.ViewBinding
+
+internal interface DialogViewBinding<T : ViewBinding> {
+    val root: View
+    val binding: T
+
+    val titleTv: TextView
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.view.dialog.base
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import com.glia.widgets.UiTheme
+import com.glia.widgets.view.dialog.alert.AlertDialogViewInflater
+import com.glia.widgets.view.dialog.operatorendedengagement.OperatorEndedEngagementDialogViewInflater
+import com.glia.widgets.view.dialog.option.OptionDialogViewInflater
+import com.glia.widgets.view.dialog.option.ReversedOptionDialogViewInflater
+import com.glia.widgets.view.dialog.option.VerticalOptionDialogViewInflater
+import com.glia.widgets.view.dialog.option.VerticalReversedOptionDialogViewInflater
+import com.glia.widgets.view.dialog.screensharing.ScreenSharingDialogViewInflater
+import com.glia.widgets.view.dialog.screensharing.VerticalScreenSharingDialogViewInflater
+import com.glia.widgets.view.dialog.update.UpgradeDialogViewInflater
+import com.glia.widgets.view.dialog.update.VerticalUpgradeDialogViewInflater
+import com.glia.widgets.view.unifiedui.deepMerge
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
+
+internal class DialogViewFactory(context: Context, uiTheme: UiTheme, unifiedTheme: UnifiedTheme?) {
+    private val themeWrapper: AlertThemeWrapper = uiTheme.alertTheme(context).run {
+        copy(theme = this.theme.deepMerge(unifiedTheme?.alertTheme)!!)
+    }
+
+    private val layoutInflater: LayoutInflater = LayoutInflater.from(context)
+    private val isVerticalAxis: Boolean = themeWrapper.theme.isVerticalAxis ?: false
+
+    fun createView(type: DialogType): View = getInflater(type).view
+
+    private fun getInflater(type: DialogType): DialogViewInflater<*, *> = when {
+        type is DialogType.Option && isVerticalAxis -> VerticalOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.Option -> OptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.ReversedOption && isVerticalAxis -> VerticalReversedOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.ReversedOption -> ReversedOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.Upgrade && isVerticalAxis -> VerticalUpgradeDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.Upgrade -> UpgradeDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.ScreenSharing && isVerticalAxis -> VerticalScreenSharingDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.ScreenSharing -> ScreenSharingDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.OperatorEndedEngagement -> OperatorEndedEngagementDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.AlertDialog -> AlertDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        else -> throw UnsupportedOperationException("Dialog of unsupported -> $type type was requested")
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
@@ -1,0 +1,56 @@
+package com.glia.widgets.view.dialog.base
+
+import android.graphics.Typeface
+import android.view.View
+import android.widget.TextView
+import androidx.viewbinding.ViewBinding
+import com.glia.widgets.view.unifiedui.applyButtonTheme
+import com.glia.widgets.view.unifiedui.applyColorTheme
+import com.glia.widgets.view.unifiedui.applyTextTheme
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
+import com.google.android.material.button.MaterialButton
+
+internal abstract class DialogViewInflater<T : DialogViewBinding<out ViewBinding>, R : DialogPayload>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: R
+) {
+
+    val view: View = binding.root
+
+    init {
+        initialSetup(binding, themeWrapper, payload)
+    }
+
+    private fun initialSetup(binding: T, themeWrapper: AlertThemeWrapper, payload: R) {
+        val alertTheme = themeWrapper.theme
+        view.applyColorTheme(alertTheme.backgroundColor)
+        setupText(binding.titleTv, payload.title, alertTheme.title, themeWrapper.typeface)
+        setup(binding, themeWrapper, payload)
+    }
+
+    abstract fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: R)
+
+    private fun setupTypeface(tv: TextView, typeface: Typeface?) {
+        typeface?.also { tv.typeface = it }
+    }
+
+    protected fun setupText(tv: TextView, text: String, textTheme: TextTheme?, typeface: Typeface?) {
+        tv.apply {
+            this.text = text
+            applyTextTheme(textTheme)
+            setupTypeface(this, typeface)
+        }
+    }
+
+    protected fun setupButton(btn: MaterialButton, text: String, btnTheme: ButtonTheme?, typeface: Typeface?, onClickListener: View.OnClickListener) {
+        btn.apply {
+            this.text = text
+            applyButtonTheme(btnTheme)
+            setupTypeface(this, typeface)
+            setOnClickListener(onClickListener)
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/operatorendedengagement/OperatorEndedEngagementDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/operatorendedengagement/OperatorEndedEngagementDialogViewBinding.kt
@@ -1,0 +1,20 @@
+package com.glia.widgets.view.dialog.operatorendedengagement
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import com.glia.widgets.databinding.OperatorEndedEngagementDialogBinding
+import com.glia.widgets.view.button.GliaPositiveButton
+import com.glia.widgets.view.dialog.base.DialogViewBinding
+
+internal class OperatorEndedEngagementDialogViewBinding(layoutInflater: LayoutInflater) : DialogViewBinding<OperatorEndedEngagementDialogBinding> {
+    override val binding: OperatorEndedEngagementDialogBinding = OperatorEndedEngagementDialogBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    val messageTv: TextView
+        get() = binding.dialogMessageView
+    val button: GliaPositiveButton
+        get() = binding.okButton
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/operatorendedengagement/OperatorEndedEngagementDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/operatorendedengagement/OperatorEndedEngagementDialogViewInflater.kt
@@ -1,0 +1,26 @@
+package com.glia.widgets.view.dialog.operatorendedengagement
+
+import android.view.LayoutInflater
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogViewInflater
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+
+internal class OperatorEndedEngagementDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.OperatorEndedEngagement
+) : DialogViewInflater<OperatorEndedEngagementDialogViewBinding, DialogPayload.OperatorEndedEngagement>(
+    OperatorEndedEngagementDialogViewBinding(layoutInflater), themeWrapper, payload
+) {
+    override fun setup(
+        binding: OperatorEndedEngagementDialogViewBinding,
+        themeWrapper: AlertThemeWrapper,
+        payload: DialogPayload.OperatorEndedEngagement
+    ) {
+        val theme = themeWrapper.theme
+
+        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+        setupButton(binding.button, payload.buttonText, theme.positiveButton, themeWrapper.typeface, payload.buttonClickListener)
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewBinding.kt
@@ -1,0 +1,103 @@
+package com.glia.widgets.view.dialog.option
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.viewbinding.ViewBinding
+import com.glia.widgets.databinding.OptionsDialogBinding
+import com.glia.widgets.databinding.OptionsDialogReversedBinding
+import com.glia.widgets.databinding.OptionsDialogVerticalBinding
+import com.glia.widgets.databinding.OptionsDialogVerticalReversedBinding
+import com.glia.widgets.view.button.GliaNegativeButton
+import com.glia.widgets.view.button.GliaPositiveButton
+import com.glia.widgets.view.dialog.base.DialogViewBinding
+
+internal interface BaseOptionDialogViewBinding<T : ViewBinding> : DialogViewBinding<T> {
+    val messageTv: TextView
+    val logoContainer: View
+    val poweredByTv: TextView
+}
+
+internal interface DefaultOptionDialogViewBinding<T : ViewBinding> : BaseOptionDialogViewBinding<T> {
+    val positiveButton: GliaPositiveButton
+    val negativeButton: GliaNegativeButton
+}
+
+internal class OptionDialogViewBinding(layoutInflater: LayoutInflater) : DefaultOptionDialogViewBinding<OptionsDialogBinding> {
+    override val binding: OptionsDialogBinding = OptionsDialogBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val positiveButton: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeButton: GliaNegativeButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+}
+
+internal class VerticalOptionDialogViewBinding(layoutInflater: LayoutInflater) : DefaultOptionDialogViewBinding<OptionsDialogVerticalBinding> {
+    override val binding: OptionsDialogVerticalBinding = OptionsDialogVerticalBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val positiveButton: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeButton: GliaNegativeButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+}
+
+internal interface DefaultReversedOptionDialogViewBinding<T : ViewBinding> : BaseOptionDialogViewBinding<T> {
+    val positiveButton: GliaNegativeButton
+    val negativeButton: GliaPositiveButton
+}
+
+internal class ReversedOptionDialogViewBinding(layoutInflater: LayoutInflater) :
+    DefaultReversedOptionDialogViewBinding<OptionsDialogReversedBinding> {
+    override val binding: OptionsDialogReversedBinding = OptionsDialogReversedBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val positiveButton: GliaNegativeButton
+        get() = binding.acceptButton
+    override val negativeButton: GliaPositiveButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+}
+
+internal class VerticalReversedOptionDialogViewBinding(layoutInflater: LayoutInflater) :
+    DefaultReversedOptionDialogViewBinding<OptionsDialogVerticalReversedBinding> {
+    override val binding: OptionsDialogVerticalReversedBinding = OptionsDialogVerticalReversedBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val positiveButton: GliaNegativeButton
+        get() = binding.acceptButton
+    override val negativeButton: GliaPositiveButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
@@ -1,0 +1,91 @@
+package com.glia.widgets.view.dialog.option
+
+import android.view.LayoutInflater
+import androidx.core.view.isGone
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogViewInflater
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+
+internal abstract class BaseOptionDialogViewInflater<T : BaseOptionDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Option
+) : DialogViewInflater<T, DialogPayload.Option>(binding, themeWrapper, payload) {
+    override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) {
+        val theme = themeWrapper.theme
+
+        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.poweredByTv.text = payload.poweredByText
+
+        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+    }
+}
+
+internal open class DefaultOptionDialogViewInflater<T : DefaultOptionDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Option
+) : BaseOptionDialogViewInflater<T>(binding, themeWrapper, payload) {
+    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) {
+        super.setup(binding, themeWrapper, payload)
+        val theme = themeWrapper.theme
+        setupButton(
+            binding.positiveButton,
+            payload.positiveButtonText,
+            theme.positiveButton,
+            themeWrapper.typeface,
+            payload.positiveButtonClickListener
+        )
+        setupButton(
+            binding.negativeButton,
+            payload.negativeButtonText,
+            theme.negativeButton,
+            themeWrapper.typeface,
+            payload.negativeButtonClickListener
+        )
+    }
+}
+
+internal class OptionDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) :
+    DefaultOptionDialogViewInflater<OptionDialogViewBinding>(OptionDialogViewBinding(layoutInflater), themeWrapper, payload)
+
+internal class VerticalOptionDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) :
+    DefaultOptionDialogViewInflater<VerticalOptionDialogViewBinding>(VerticalOptionDialogViewBinding(layoutInflater), themeWrapper, payload)
+
+internal open class DefaultReversedOptionDialogViewInflater<T : DefaultReversedOptionDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Option
+) : BaseOptionDialogViewInflater<T>(binding, themeWrapper, payload) {
+    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) {
+        super.setup(binding, themeWrapper, payload)
+        val theme = themeWrapper.theme
+        setupButton(
+            binding.positiveButton,
+            payload.positiveButtonText,
+            theme.negativeButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
+            themeWrapper.typeface,
+            payload.positiveButtonClickListener
+        )
+        setupButton(
+            binding.negativeButton,
+            payload.negativeButtonText,
+            theme.positiveButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
+            themeWrapper.typeface,
+            payload.negativeButtonClickListener
+        )
+    }
+}
+
+internal class ReversedOptionDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) :
+    DefaultReversedOptionDialogViewInflater<ReversedOptionDialogViewBinding>(ReversedOptionDialogViewBinding(layoutInflater), themeWrapper, payload)
+
+internal class VerticalReversedOptionDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Option
+) : DefaultReversedOptionDialogViewInflater<VerticalReversedOptionDialogViewBinding>(
+    VerticalReversedOptionDialogViewBinding(layoutInflater),
+    themeWrapper,
+    payload
+)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewBinding.kt
@@ -1,0 +1,64 @@
+package com.glia.widgets.view.dialog.screensharing
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.viewbinding.ViewBinding
+import com.glia.widgets.databinding.ScreensharingDialogBinding
+import com.glia.widgets.databinding.ScreensharingDialogVerticalBinding
+import com.glia.widgets.view.button.GliaNegativeButton
+import com.glia.widgets.view.button.GliaPositiveButton
+import com.glia.widgets.view.dialog.base.DialogViewBinding
+
+internal interface BaseScreenSharingDialogViewBinding<T : ViewBinding> : DialogViewBinding<T> {
+    val messageTv: TextView
+    val positiveBtn: GliaPositiveButton
+    val negativeBtn: GliaNegativeButton
+    val logoContainer: View
+    val poweredByTv: TextView
+    val icon: ImageView
+}
+
+internal class ScreenSharingDialogViewBinding(layoutInflater: LayoutInflater) : BaseScreenSharingDialogViewBinding<ScreensharingDialogBinding> {
+    override val binding: ScreensharingDialogBinding = ScreensharingDialogBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val icon: ImageView
+        get() = binding.titleIcon
+    override val positiveBtn: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeBtn: GliaNegativeButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+
+}
+
+internal class VerticalScreenSharingDialogViewBinding(layoutInflater: LayoutInflater) :
+    BaseScreenSharingDialogViewBinding<ScreensharingDialogVerticalBinding> {
+    override val binding: ScreensharingDialogVerticalBinding = ScreensharingDialogVerticalBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val icon: ImageView
+        get() = binding.titleIcon
+    override val positiveBtn: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeBtn: GliaNegativeButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewInflater.kt
@@ -1,0 +1,45 @@
+package com.glia.widgets.view.dialog.screensharing
+
+import android.view.LayoutInflater
+import androidx.core.view.isGone
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogViewInflater
+import com.glia.widgets.view.unifiedui.applyImageColorTheme
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+
+internal open class BaseScreenSharingDialogViewInflater<T : BaseScreenSharingDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.ScreenSharing
+) : DialogViewInflater<T, DialogPayload.ScreenSharing>(binding, themeWrapper, payload) {
+    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.ScreenSharing) {
+        val theme = themeWrapper.theme
+
+        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.poweredByTv.text = payload.poweredByText
+        binding.icon.applyImageColorTheme(theme.titleImageColor)
+
+        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+        setupButton(binding.positiveBtn, payload.positiveButtonText, theme.positiveButton, themeWrapper.typeface, payload.positiveButtonClickListener)
+        setupButton(binding.negativeBtn, payload.negativeButtonText, theme.negativeButton, themeWrapper.typeface, payload.negativeButtonClickListener)
+    }
+
+}
+
+internal class ScreenSharingDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.ScreenSharing
+) :
+    BaseScreenSharingDialogViewInflater<ScreenSharingDialogViewBinding>(ScreenSharingDialogViewBinding(layoutInflater), themeWrapper, payload)
+
+internal class VerticalScreenSharingDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.ScreenSharing
+) :
+    BaseScreenSharingDialogViewInflater<VerticalScreenSharingDialogViewBinding>(
+        VerticalScreenSharingDialogViewBinding(layoutInflater),
+        themeWrapper,
+        payload
+    )

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewBinding.kt
@@ -1,0 +1,58 @@
+package com.glia.widgets.view.dialog.update
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.viewbinding.ViewBinding
+import com.glia.widgets.databinding.UpgradeDialogBinding
+import com.glia.widgets.databinding.UpgradeDialogVerticalBinding
+import com.glia.widgets.view.button.GliaNegativeButton
+import com.glia.widgets.view.button.GliaPositiveButton
+import com.glia.widgets.view.dialog.base.DialogViewBinding
+
+internal interface BaseUpgradeDialogViewBinding<T : ViewBinding> : DialogViewBinding<T> {
+    val titleIcon: ImageView
+    val positiveBtn: GliaPositiveButton
+    val negativeBtn: GliaNegativeButton
+    val logoContainer: View
+    val poweredByTv: TextView
+}
+
+internal class UpgradeDialogViewBinding(layoutInflater: LayoutInflater) : BaseUpgradeDialogViewBinding<UpgradeDialogBinding> {
+    override val binding: UpgradeDialogBinding = UpgradeDialogBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val titleIcon: ImageView
+        get() = binding.chatTitleIcon
+    override val positiveBtn: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeBtn: GliaNegativeButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+
+}
+
+internal class VerticalUpgradeDialogViewBinding(layoutInflater: LayoutInflater) : BaseUpgradeDialogViewBinding<UpgradeDialogVerticalBinding> {
+    override val binding: UpgradeDialogVerticalBinding = UpgradeDialogVerticalBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val titleIcon: ImageView
+        get() = binding.chatTitleIcon
+    override val positiveBtn: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeBtn: GliaNegativeButton
+        get() = binding.declineButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewInflater.kt
@@ -1,0 +1,35 @@
+package com.glia.widgets.view.dialog.update
+
+import android.view.LayoutInflater
+import androidx.core.view.isGone
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogViewInflater
+import com.glia.widgets.view.unifiedui.applyImageColorTheme
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+
+internal open class BaseUpgradeDialogViewInflater<T : BaseUpgradeDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Upgrade
+) : DialogViewInflater<T, DialogPayload.Upgrade>(binding, themeWrapper, payload) {
+    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Upgrade) {
+        val theme = themeWrapper.theme
+
+        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.poweredByTv.text = payload.poweredByText
+
+        setupButton(binding.positiveBtn, payload.positiveButtonText, theme.positiveButton, themeWrapper.typeface, payload.positiveButtonClickListener)
+        setupButton(binding.negativeBtn, payload.negativeButtonText, theme.negativeButton, themeWrapper.typeface, payload.negativeButtonClickListener)
+        binding.titleIcon.apply {
+            setImageResource(payload.iconRes)
+            applyImageColorTheme(theme.titleImageColor)
+        }
+    }
+}
+
+
+internal class UpgradeDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Upgrade) :
+    BaseUpgradeDialogViewInflater<UpgradeDialogViewBinding>(UpgradeDialogViewBinding(layoutInflater), themeWrapper, payload)
+
+internal class VerticalUpgradeDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Upgrade) :
+    BaseUpgradeDialogViewInflater<VerticalUpgradeDialogViewBinding>(VerticalUpgradeDialogViewBinding(layoutInflater), themeWrapper, payload)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/ThemeWrapper.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/ThemeWrapper.kt
@@ -1,0 +1,12 @@
+package com.glia.widgets.view.unifiedui.theme
+
+import android.graphics.Typeface
+import com.glia.widgets.view.unifiedui.theme.alert.AlertTheme
+
+internal interface TypefaceThemeWrapper<T : Any> {
+    val theme: T
+    val typeface: Typeface?
+}
+
+internal data class AlertThemeWrapper(override val theme: AlertTheme, override val typeface: Typeface?, val whiteLabel: Boolean?) :
+    TypefaceThemeWrapper<AlertTheme>


### PR DESCRIPTION
MOB 2814

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2814

**What was solved?**

- Created a mechanism to create GlobalColors from UiTheme. This helped to create AlertTheme from UiTheme and then merge it with provided by UnifiedUi, so now all the Dialog Views are configured with AlertTheme
- Created a mechanism to inflate all the Dialog Views independently and before Dialog is created. This will make all the Views(fully configured with themes) available outside of Alertdialogs and Dialog builders so that these views can be easily tested in snapshot tests.

All these changes will make it easy to change any of these views independently, without affecting other dialogs.

2nd part of improvements are here - https://github.com/salemove/android-sdk-widgets/pull/834

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
