### PR TITLE
Hide Logger functionality from public usage, add unit tests for Logger class

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
@@ -6,7 +6,7 @@ import com.glia.androidsdk.LogLevel
 import com.glia.androidsdk.LoggingAdapter
 import java.util.function.Consumer
 
-object Logger {
+internal object Logger {
 
     const val SITE_ID_KEY = "site_id"
 
@@ -15,7 +15,7 @@ object Logger {
 
     @Suppress("unused")
     @JvmStatic
-    private fun addAdapter(loggingAdapter: LoggingAdapter) {
+    fun addAdapter(loggingAdapter: LoggingAdapter) {
         loggingAdapters.add(loggingAdapter)
     }
 
@@ -38,6 +38,50 @@ object Logger {
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
             loggingAdapter.log(LogLevel.DEBUG, tag, message, concatGlobalMeta(metadata))
+        })
+    }
+
+    @JvmStatic
+    fun i(tag: String, message: String) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.i(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.INFO, tag, message, concatGlobalMeta(null))
+        })
+    }
+
+    @JvmStatic
+    fun i(tag: String, message: String, metadata: Map<String, String>? = null) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.i(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.INFO, tag, message, concatGlobalMeta(metadata))
+        })
+    }
+
+    @JvmStatic
+    fun w(tag: String, message: String) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.w(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.WARN, tag, message, concatGlobalMeta(null))
+        })
+    }
+
+    @JvmStatic
+    fun w(tag: String, message: String, metadata: Map<String, String>? = null) {
+        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
+            Log.w(tag, message)
+        }
+
+        loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
+            loggingAdapter.log(LogLevel.WARN, tag, message, concatGlobalMeta(metadata))
         })
     }
 
@@ -83,11 +127,6 @@ object Logger {
     @Synchronized
     fun removeGlobalMetadata(metaKey: String) {
         globalMetadata.remove(metaKey)
-    }
-
-    @Synchronized
-    fun clearGlobalMetadata() {
-        globalMetadata.clear()
     }
 
     private fun concatGlobalMeta(metadata: Map<String, String>?): Map<String, String> {

--- a/widgetssdk/src/test/java/com/glia/widgets/helper/LoggerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/helper/LoggerTest.kt
@@ -1,0 +1,87 @@
+package com.glia.widgets.helper
+
+import com.glia.androidsdk.LogLevel
+import com.glia.androidsdk.LoggingAdapter
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import java.util.Collections
+
+class LoggerTest {
+    @Test
+    fun `loggingAdapter logs messages`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        Logger.addAdapter(loggingAdapter)
+        Logger.d(LoggerTest.TAG, MESSAGE)
+        Logger.i(LoggerTest.TAG, MESSAGE)
+        Logger.w(LoggerTest.TAG, MESSAGE)
+        Logger.e(LoggerTest.TAG, MESSAGE, error)
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, emptyMap())
+    }
+
+    @Test
+    fun `loggingAdapter logs messages with metadata`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        Logger.addAdapter(loggingAdapter)
+        val metadata = Collections.singletonMap("key", "value")
+        Logger.d(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.i(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.w(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, metadata)
+    }
+
+    @Test
+    fun `loggingAdapter logs messages with global metadata`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        Logger.addAdapter(loggingAdapter)
+        val metadata = Collections.singletonMap("key", "value")
+        val globalMeta = Collections.singletonMap("globalKey", "value0")
+        val combinedMetadata: MutableMap<String, String> = HashMap()
+        combinedMetadata.putAll(metadata)
+        combinedMetadata.putAll(globalMeta)
+        Logger.addGlobalMetadata(globalMeta)
+        Logger.d(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.i(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.w(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, combinedMetadata)
+        Logger.removeGlobalMetadata("globalKey")
+    }
+
+    @Test
+    fun `logger logs only locally when loggingAdapters list empty`() {
+        val error: Throwable = RuntimeException()
+        val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
+        val metadata = Collections.singletonMap("key", "value")
+        val globalMeta = Collections.singletonMap("globalKey", "value0")
+        val combinedMetadata: MutableMap<String, String> = HashMap()
+        combinedMetadata.putAll(metadata)
+        combinedMetadata.putAll(globalMeta)
+        Logger.addGlobalMetadata(globalMeta)
+        Logger.d(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.i(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.w(LoggerTest.TAG, MESSAGE, metadata)
+        Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
+        Mockito.verify(loggingAdapter, never()).log(any(), any(), any(), any())
+        Logger.removeGlobalMetadata("globalKey")
+    }
+
+    companion object {
+        private const val TAG = "tag"
+        private const val MESSAGE = "message"
+    }
+}


### PR DESCRIPTION
[Developers want the Logger functions to be non-static in Widgets and Core SDK](https://glia.atlassian.net/browse/MOB-2822)

**What was solved?**
1. Disallow integrators to use our Logger directly so that they should not be able to call `com.glia.widgets.helper.Logger.d("Integrator", "Hello, Glia developers ;)")`.
2. Add unit tests for `Logger class`.

I decided to go with a simple and reliable solution instead of initially planned (see TL;DR for the details).

TL;DR
The initial idea was to make logging functions non-static in `Logger`. Make the `Logger` constructor private. Inject Logger to the components using DI (e.g. ControllerFactory, etc).

However, it turned out that this approach has several disadvantages:
- it's not possible to inject to all type of components, in some places I had to create separate `Logger` instance
- we will have introduce new rules for `Logger` usage internally and follow them, so it will add development complexity
- it's a good deal of changes (actually, I made them but was not satisfied)
- we will have many instances of logger

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

