### PR TITLE
Fix - Sending image/file in SC is broken

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -27,6 +27,7 @@ import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
 import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
+import com.glia.widgets.helper.isValid
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -36,7 +37,7 @@ import io.reactivex.processors.BehaviorProcessor
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
 
-internal class ChatManager constructor(
+internal class ChatManager(
     private val onMessageUseCase: GliaOnMessageUseCase,
     private val loadHistoryUseCase: GliaLoadHistoryUseCase,
     private val addNewMessagesDividerUseCase: AddNewMessagesDividerUseCase,
@@ -159,6 +160,8 @@ internal class ChatManager constructor(
 
     @VisibleForTesting
     fun mapNewMessage(chatMessage: ChatMessageInternal, messagesState: State): State {
+        check(chatMessage.chatMessage.isValid()) { "Invalid chat message passed -> ${chatMessage.chatMessage}" }
+
         if (messagesState.isNew(chatMessage)) {
             appendNewChatMessageUseCase(messagesState, chatMessage)
             if (chatMessage.chatMessage is VisitorMessage) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -87,6 +87,7 @@ import com.glia.widgets.helper.TimeCounter
 import com.glia.widgets.helper.TimeCounter.FormattedTimerStatusListener
 import com.glia.widgets.helper.formattedName
 import com.glia.widgets.helper.imageUrl
+import com.glia.widgets.helper.isValid
 import com.glia.widgets.view.MessagesNotSeenHandler
 import com.glia.widgets.view.MinimizeHandler
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -158,7 +159,7 @@ internal class ChatController(
         object : GliaSendMessageUseCase.Listener {
             override fun messageSent(message: VisitorMessage?) {
                 Logger.d(TAG, "messageSent: $message, id: ${message?.id}")
-                message?.also { chatManager.onChatAction(ChatManager.Action.MessageSent(it)) }
+                message?.takeIf { it.isValid() }?.also { chatManager.onChatAction(ChatManager.Action.MessageSent(it)) }
                 scrollChatToBottom()
             }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaOnMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaOnMessageUseCase.kt
@@ -4,6 +4,7 @@ import com.glia.androidsdk.chat.ChatMessage
 import com.glia.widgets.chat.data.GliaChatRepository
 import com.glia.widgets.core.engagement.domain.MapOperatorUseCase
 import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
+import com.glia.widgets.helper.isValid
 import io.reactivex.Observable
 import java.util.function.Consumer
 
@@ -19,6 +20,7 @@ internal class GliaOnMessageUseCase(
 
         observer.setCancellable { messageRepository.unregisterAllMessageListener(messageListener) }
     }
+        .filter { it.isValid() }
         .flatMapSingle { mapOperatorUseCase(it) }
         .doOnError { it.printStackTrace() }
         .share()

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -10,6 +10,7 @@ import androidx.core.graphics.drawable.DrawableCompat
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.chat.AttachmentFile
+import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.chat.MessageAttachment
 import com.glia.androidsdk.chat.OperatorMessage
 import com.glia.androidsdk.chat.SingleChoiceAttachment
@@ -52,6 +53,8 @@ internal fun String.fromHtml(flags: Int = Html.FROM_HTML_MODE_COMPACT): Spanned 
 internal val AttachmentFile.isImage: Boolean get() = contentType.startsWith("image")
 
 internal fun MessageAttachment.asSingleChoice(): SingleChoiceAttachment? = this as? SingleChoiceAttachment
+
+internal fun ChatMessage.isValid(): Boolean = content.isNotBlank() || attachment != null || metadata?.takeIf { it.length() > 0 } != null
 
 internal fun OperatorMessage.toChatMessageInternal(): ChatMessageInternal =
     ChatMessageInternal(this, LocalOperator(operatorId.orEmpty(), operatorName.orEmpty(), operatorImageUrl))

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -12,7 +12,6 @@ import com.glia.widgets.chat.domain.GliaOnMessageUseCase
 import com.glia.widgets.chat.domain.HandleCustomCardClickUseCase
 import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.chat.domain.SendUnsentMessagesUseCase
-import com.glia.widgets.chat.model.ChatItem
 import com.glia.widgets.chat.model.GvaButton
 import com.glia.widgets.chat.model.GvaQuickReplies
 import com.glia.widgets.chat.model.MediaUpgradeStartedTimerItem
@@ -283,8 +282,11 @@ class ChatManagerTest {
 
     @Test
     fun `mapMessageSent adds new Message`() {
+        val visitorMessage = mock<VisitorMessage> {
+            on { content } doReturn "mock_content"
+        }
         val action: ChatManager.Action.MessageSent = mock {
-            on { message } doReturn mock()
+            on { message } doReturn visitorMessage
         }
 
         subjectUnderTest.mapMessageSent(action.message, state)
@@ -415,6 +417,14 @@ class ChatManagerTest {
         val action: ChatManager.Action.ChatRestored = ChatManager.Action.ChatRestored
 
         assertEquals(state, subjectUnderTest.mapAction(action, state))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `mapNewMessage throws exception when passed message is invalid`() {
+        val chatMessage: VisitorMessage = mock {
+            on { content } doReturn ""
+        }
+        subjectUnderTest.mapNewMessage(ChatMessageInternal((chatMessage)), state)
     }
 
     @Test
@@ -593,24 +603,24 @@ class ChatManagerTest {
         val chatMessageInternal = mockChatMessage<SystemMessage>()
         doReturn(true).whenever(state).isNew(chatMessageInternal)
 
-        whenever(loadHistoryUseCase()) doReturn Single.just(mock())
+        whenever(loadHistoryUseCase()) doReturn Single.just(ChatHistoryResponse(emptyList()))
         whenever(onMessageUseCase()) doReturn Observable.just(chatMessageInternal)
 
-        val chatItems = mutableListOf<ChatItem>(mock())
         subjectUnderTest.apply {
             val onHistoryLoaded = mock<(hasHistory: Boolean) -> Unit>()
             val onQuickReplyReceived = mock<(List<GvaButton>) -> Unit>()
             val onOperatorMessageReceived = mock<(count: Int) -> Unit>()
-            val itemsFlowable = initialize(onHistoryLoaded, onQuickReplyReceived, onOperatorMessageReceived)
+
+            initialize(onHistoryLoaded, onQuickReplyReceived, onOperatorMessageReceived).test().assertNoErrors().awaitCount(1)
+
             verify(this).subscribe(onHistoryLoaded, onOperatorMessageReceived, onQuickReplyReceived)
-
-            val test = itemsFlowable.test()
-
-            stateProcessor.onNext(ChatManager.State(chatItems = chatItems))
+            verify(this).subscribeToState(onHistoryLoaded, onOperatorMessageReceived)
+            verify(this).subscribeToQuickReplies(onQuickReplyReceived)
 
             verify(this, atLeastOnce()).updateQuickReplies(any())
 
-            assertEquals(test.values().last().last(), chatItems.last())
+            stateProcessor.onNext(state)
+            verify(state).immutableChatItems
         }
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2835

**What was solved?**
I have included new verifications to ensure that the `ChatMessage` is valid, before emitting it to the ChatManager. 

**Release notes:**
The issue of broken flow in the **image/file** sending feature of Secure Conversations Chat has been resolved.

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**
Copied `ChatmanagerTest`.`initialize subscribes to state and quick replies` test case improvement from LO branch, because it was flaky, and was failing the first time when there were changes related to that test.

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
