### PR TITLE
Fix The dialog for screen sharing in the CV flow is not appearing

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -348,6 +348,10 @@ internal class ActivityWatcherForCallVisualizer(
         }
     }
 
+    override fun engagementStarted() {
+        controller.addScreenSharingCallback(resumedActivity ?: return)
+    }
+
     override fun setupDialogCallback() {
         dialogController.addCallback(dialogCallback)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerContract.kt
@@ -26,6 +26,7 @@ class ActivityWatcherForCallVisualizerContract {
         fun onMediaProjectionRejected()
         fun isWaitingMediaProjectionResult(): Boolean
         fun setIsWaitingMediaProjectionResult(isWaiting: Boolean)
+        fun addScreenSharingCallback(activity: Activity)
     }
 
     interface Watcher {
@@ -52,5 +53,6 @@ class ActivityWatcherForCallVisualizerContract {
         fun dismissOverlayDialog()
         fun isSupportActivityOpen(): Boolean
         fun showEngagementConfirmationDialog()
+        fun engagementStarted()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -31,6 +31,7 @@ internal class CallVisualizerController(
     OnSurveyListener {
 
     private var engagementEndedCallback: (() -> Unit)? = null
+    private var startEngagementListener: ((OmnibrowseEngagement) -> Unit)? = null
 
     fun init() {
         Logger.d(TAG, "CallVisualizerController initialized")
@@ -60,7 +61,7 @@ internal class CallVisualizerController(
     override fun onEngagementRequested() {
         dialogController.dismissVisitorCodeDialog()
 
-        confirmationDialogUseCase{ shouldShow ->
+        confirmationDialogUseCase { shouldShow ->
             if (shouldShow) {
                 dialogController.showEngagementConfirmationDialog()
             } else {
@@ -86,6 +87,7 @@ internal class CallVisualizerController(
 
     override fun newEngagementLoaded(engagement: OmnibrowseEngagement) {
         surveyUseCase.registerListener(this)
+        startEngagementListener?.invoke(engagement)
     }
 
     override fun callVisualizerEngagementEnded() {
@@ -98,7 +100,15 @@ internal class CallVisualizerController(
         this.engagementEndedCallback = callback
     }
 
+    fun setOnEngagementStartListener(callback: (OmnibrowseEngagement) -> Unit) {
+        startEngagementListener = callback
+    }
+
     fun removeOnEngagementEndedCallback() {
         this.engagementEndedCallback = null
+    }
+
+    fun removeOnEngagementStartListener() {
+        startEngagementListener = null
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -367,8 +367,8 @@ public class ControllerFactory {
             activityWatcherforCallVisualizerController = new ActivityWatcherForCallVisualizerController(
                 getCallVisualizerController(),
                 getScreenSharingController(),
-                useCaseFactory.createIsShowOverlayPermissionRequestDialogUseCase(),
-                useCaseFactory.createIsCallVisualizerUseCase());
+                useCaseFactory.createIsShowOverlayPermissionRequestDialogUseCase()
+            );
         }
         return activityWatcherforCallVisualizerController;
     }


### PR DESCRIPTION
MOB 2847

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2847

**What was solved?**
Add Screen sharing callback only when the `CallVisualizer` engagement is started.
This way we will not brake showing screen sharing dialog from `ActivityWatcherForCallVisualizer` only for CV flows and it will also be safe for configuration changes

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
