### PR TITLE
Fixed chat head duplications and crash

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementTypeRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementTypeRepository.java
@@ -2,6 +2,7 @@ package com.glia.widgets.core.engagement;
 
 import com.glia.widgets.core.operator.GliaOperatorMediaRepository;
 import com.glia.widgets.core.visitor.GliaVisitorMediaRepository;
+import com.glia.widgets.helper.Logger;
 
 public class GliaEngagementTypeRepository {
     private final GliaEngagementRepository engagementRepository;

--- a/widgetssdk/src/main/java/com/glia/widgets/core/visitor/GliaVisitorMediaRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/visitor/GliaVisitorMediaRepository.java
@@ -3,10 +3,8 @@ package com.glia.widgets.core.visitor;
 import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.comms.Media;
 import com.glia.androidsdk.comms.VisitorMediaState;
-
 import java.util.HashSet;
 import java.util.Set;
-
 import io.reactivex.Completable;
 import io.reactivex.Single;
 
@@ -34,10 +32,11 @@ public class GliaVisitorMediaRepository {
     }
 
     public void onEngagementEnded(Engagement engagement) {
-        engagement.getMedia().off(Media.Events.VISITOR_STATE_UPDATE, this::onNewVisitorMediaState);
+        engagement.getMedia().off(Media.Events.VISITOR_STATE_UPDATE);
         currentMediaState = null;
         isOnHold = false;
         notifyVisitorMediaStateChanged(null);
+        visitorMediaUpdatesListeners.clear();
     }
 
     public void addVisitorMediaStateListener(VisitorMediaUpdatesListener listener) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.util.Pair
+import androidx.core.view.contains
 import com.glia.widgets.GliaWidgets
 import com.glia.widgets.R
 import com.glia.widgets.base.BaseActivityWatcher
@@ -103,7 +104,15 @@ internal class ActivityWatcherForChatHead(
         createChatHeadLayout(activity)
         try {
             Logger.d(TAG, "Adding application-only bubble")
-            activity.runOnUiThread { viewGroup.addView(chatHeadLayout.get()) }
+            activity.runOnUiThread {
+                chatHeadLayout.get()?.let {
+                    if (!viewGroup.contains(it)) {
+                        viewGroup.addView(it)
+                    } else {
+                        Logger.e(TAG, "Duplicate bubble adding detected")
+                    }
+                }
+            }
         } catch (e: IllegalStateException) {
             Log.d(TAG, "Cannot add bubble: $e")
         }


### PR DESCRIPTION
MOB-2855

Audio channel state was restarted on engagement end and thus opening chat engagement after video had an empty audio state.

Also added a crash prevention mechanism to avoid "view already added" type of exceptions. 
