### PR TITLE
Add links to confirmation dialog

### DIFF
--- a/app/src/main/res/raw/sample_unified_config.json
+++ b/app/src/main/res/raw/sample_unified_config.json
@@ -32,6 +32,48 @@
         ]
       }
     },
+    "linkButton": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 0,
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "cornerRadius": 8
+      },
+      "shadow": {
+        "color": {
+          "type": "fill",
+          "value": ["#FF0000"]
+        },
+        "offset": 0,
+        "opacity": 1,
+        "radius": 8
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FF0000"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#04728c"]
+        }
+      },
+      "tintColor": {
+        "type": "fill",
+        "value": ["#ffd100"]
+      }
+    },
     "negativeButton": {
       "background": {
         "border": {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -726,7 +726,9 @@ internal class CallView(
                 callController?.onLiveObservationDialogRejected()
                 onEndListener?.onEnd()
                 callEnded()
-            }
+            },
+            link1ClickListener = {}, //TODO: will be implemented on the next task
+            link2ClickListener = {}
         )
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -343,7 +343,9 @@ internal class ActivityWatcherForCallVisualizer(
                 theme = uiTheme,
                 companyName = companyName,
                 positiveButtonClickListener = { controller.onPositiveDialogButtonClicked() },
-                negativeButtonClickListener = { controller.onNegativeDialogButtonClicked() }
+                negativeButtonClickListener = { controller.onNegativeDialogButtonClicked() },
+                link1ClickListener = {}, //TODO: will be implemented on the next task
+                link2ClickListener = {}
             )
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -517,7 +517,9 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
             theme = theme,
             companyName = companyName,
             positiveButtonClickListener = { onEngagementConfirmationDialogAllowed() },
-            negativeButtonClickListener = { onEngagementConfirmationDialogDismissed() }
+            negativeButtonClickListener = { onEngagementConfirmationDialogDismissed() },
+            link1ClickListener = {}, //TODO: will be implemented on the next task
+            link2ClickListener = {}
         )
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -199,22 +199,27 @@ internal object Dialogs {
         context: Context,
         theme: UiTheme,
         companyName: String,
+        link1ClickListener: View.OnClickListener? = null,
+        link2ClickListener: View.OnClickListener? = null,
         positiveButtonClickListener: View.OnClickListener,
         negativeButtonClickListener: View.OnClickListener
     ): AlertDialog {
 
-        val payload = DialogPayload.Option(
-            title = stringProvider.getRemoteString(R.string.live_observation_confirm_title),
-            message = stringProvider.getRemoteString(R.string.live_observation_confirm_message, StringKeyPair(StringKey.COMPANY_NAME, companyName)),
+        val payload = DialogPayload.Confirmation(
+            title = stringProvider.getRemoteString(R.string.engagement_confirm_title),
+            message = stringProvider.getRemoteString(R.string.engagement_confirm_message, StringKeyPair(StringKey.COMPANY_NAME, companyName)),
+            link1Text = stringProvider.getRemoteString(R.string.engagement_confirm_link1_text),
+            link2Text = stringProvider.getRemoteString(R.string.engagement_confirm_link2_text),
             positiveButtonText = allow,
             negativeButtonText = cancel,
             poweredByText = poweredByText,
             positiveButtonClickListener = positiveButtonClickListener,
-            negativeButtonClickListener = negativeButtonClickListener
-
+            negativeButtonClickListener = negativeButtonClickListener,
+            link1ClickListener = link1ClickListener,
+            link2ClickListener = link2ClickListener
         )
 
-        return dialogService.showDialog(context, theme, DialogType.Option(payload))
+        return dialogService.showDialog(context, theme, DialogType.Confirmation(payload))
     }
 
     fun showOperatorEndedEngagementDialog(context: Context, theme: UiTheme, buttonClickListener: View.OnClickListener): AlertDialog {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
@@ -16,6 +16,20 @@ internal sealed interface DialogPayload {
         val negativeButtonClickListener: View.OnClickListener,
     ) : DialogPayload
 
+    data class Confirmation(
+        override val title: String,
+        val message: String,
+        val positiveButtonText: String,
+        val negativeButtonText: String,
+        val poweredByText: String,
+        val positiveButtonClickListener: View.OnClickListener,
+        val negativeButtonClickListener: View.OnClickListener,
+        val link1Text: String? = null,
+        val link2Text: String? = null,
+        val link1ClickListener: View.OnClickListener? = null,
+        val link2ClickListener: View.OnClickListener? = null,
+    ) : DialogPayload
+
     data class ScreenSharing(
         override val title: String,
         val message: String,

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogType.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogType.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.view.dialog.base
 internal sealed class DialogType(payload: DialogPayload) {
     data class Option(val payload: DialogPayload.Option) : DialogType(payload)
     data class ReversedOption(val payload: DialogPayload.Option) : DialogType(payload)
+    data class Confirmation(val payload: DialogPayload.Confirmation) : DialogType(payload)
     data class Upgrade(val payload: DialogPayload.Upgrade) : DialogType(payload)
     data class ScreenSharing(val payload: DialogPayload.ScreenSharing) : DialogType(payload)
     data class OperatorEndedEngagement(val payload: DialogPayload.OperatorEndedEngagement) : DialogType(payload)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import com.glia.widgets.UiTheme
 import com.glia.widgets.view.dialog.alert.AlertDialogViewInflater
+import com.glia.widgets.view.dialog.confirmation.ConfirmationDialogViewInflater
+import com.glia.widgets.view.dialog.confirmation.VerticalConfirmationDialogViewInflater
 import com.glia.widgets.view.dialog.operatorendedengagement.OperatorEndedEngagementDialogViewInflater
 import com.glia.widgets.view.dialog.option.OptionDialogViewInflater
 import com.glia.widgets.view.dialog.option.ReversedOptionDialogViewInflater
@@ -33,6 +35,8 @@ internal class DialogViewFactory(context: Context, uiTheme: UiTheme, unifiedThem
         type is DialogType.Option -> OptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
         type is DialogType.ReversedOption && isVerticalAxis -> VerticalReversedOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
         type is DialogType.ReversedOption -> ReversedOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.Confirmation && isVerticalAxis -> VerticalConfirmationDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.Confirmation -> ConfirmationDialogViewInflater(layoutInflater, themeWrapper, type.payload)
         type is DialogType.Upgrade && isVerticalAxis -> VerticalUpgradeDialogViewInflater(layoutInflater, themeWrapper, type.payload)
         type is DialogType.Upgrade -> UpgradeDialogViewInflater(layoutInflater, themeWrapper, type.payload)
         type is DialogType.ScreenSharing && isVerticalAxis -> VerticalScreenSharingDialogViewInflater(layoutInflater, themeWrapper, type.payload)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
@@ -45,8 +45,12 @@ internal abstract class DialogViewInflater<T : DialogViewBinding<out ViewBinding
         }
     }
 
-    protected fun setupButton(btn: MaterialButton, text: String, btnTheme: ButtonTheme?, typeface: Typeface?, onClickListener: View.OnClickListener) {
+    protected fun setupButton(btn: MaterialButton, text: String?, btnTheme: ButtonTheme?, typeface: Typeface?, onClickListener: View.OnClickListener?) {
         btn.apply {
+            if (text.isNullOrEmpty() || onClickListener == null) {
+                this.visibility = View.GONE
+                return@apply
+            }
             this.text = text
             applyButtonTheme(btnTheme)
             setupTypeface(this, typeface)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewBinding.kt
@@ -1,0 +1,79 @@
+package com.glia.widgets.view.dialog.confirmation
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.viewbinding.ViewBinding
+import com.glia.widgets.databinding.ConfirmationDialogBinding
+import com.glia.widgets.databinding.ConfirmationDialogVerticalBinding
+import com.glia.widgets.view.button.GliaNegativeButton
+import com.glia.widgets.view.button.GliaPositiveButton
+import com.glia.widgets.view.dialog.base.DialogViewBinding
+import com.google.android.material.button.MaterialButton
+
+internal interface BaseConfirmationDialogViewBinding<T : ViewBinding> : DialogViewBinding<T> {
+    val messageTv: TextView
+    val logoContainer: View
+    val poweredByTv: TextView
+}
+
+internal interface DefaultConfirmationDialogViewBinding<T : ViewBinding> : BaseConfirmationDialogViewBinding<T> {
+    val link1Button: MaterialButton
+    val link2Button: MaterialButton
+    val positiveButton: GliaPositiveButton
+    val negativeButton: GliaNegativeButton
+    val additionalButtonsSpace: View
+}
+
+internal class ConfirmationDialogViewBinding(layoutInflater: LayoutInflater) : DefaultConfirmationDialogViewBinding<ConfirmationDialogBinding> {
+    override val binding: ConfirmationDialogBinding = ConfirmationDialogBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val link1Button: MaterialButton
+        get() = binding.link1Button
+    override val link2Button: MaterialButton
+        get() = binding.link2Button
+    override val positiveButton: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeButton: GliaNegativeButton
+        get() = binding.declineButton
+    override val additionalButtonsSpace: View
+        get() = binding.additionalButtonsSpace
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+}
+
+internal class VerticalConfirmationDialogViewBinding(layoutInflater: LayoutInflater) : DefaultConfirmationDialogViewBinding<ConfirmationDialogVerticalBinding> {
+    override val binding: ConfirmationDialogVerticalBinding = ConfirmationDialogVerticalBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    override val link1Button: MaterialButton
+        get() = binding.link1Button
+    override val link2Button: MaterialButton
+        get() = binding.link2Button
+    override val positiveButton: GliaPositiveButton
+        get() = binding.acceptButton
+    override val negativeButton: GliaNegativeButton
+        get() = binding.declineButton
+    override val additionalButtonsSpace: View
+        get() = binding.additionalButtonsSpace
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+}
+
+internal interface DefaultReversedConfirmationDialogViewBinding<T : ViewBinding> : BaseConfirmationDialogViewBinding<T> {
+    val positiveButton: GliaNegativeButton
+    val negativeButton: GliaPositiveButton
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
@@ -1,0 +1,95 @@
+package com.glia.widgets.view.dialog.confirmation
+
+import android.view.LayoutInflater
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogViewInflater
+import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+
+internal abstract class BaseConfirmationDialogViewInflater<T : BaseConfirmationDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Confirmation
+) : DialogViewInflater<T, DialogPayload.Confirmation>(binding, themeWrapper, payload) {
+    override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) {
+        val theme = themeWrapper.theme
+
+        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.poweredByTv.text = payload.poweredByText
+
+        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+    }
+}
+
+internal open class DefaultConfirmationDialogViewInflater<T : DefaultConfirmationDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Confirmation
+) : BaseConfirmationDialogViewInflater<T>(binding, themeWrapper, payload) {
+    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) {
+        super.setup(binding, themeWrapper, payload)
+        val theme = themeWrapper.theme
+        setupButton(
+            binding.link1Button,
+            payload.link1Text,
+            theme.linkButton,
+            themeWrapper.typeface,
+            payload.link1ClickListener
+        )
+        setupButton(
+            binding.link2Button,
+            payload.link2Text,
+            theme.linkButton,
+            themeWrapper.typeface,
+            payload.link2ClickListener
+        )
+        setupButton(
+            binding.positiveButton,
+            payload.positiveButtonText,
+            theme.positiveButton,
+            themeWrapper.typeface,
+            payload.positiveButtonClickListener
+        )
+        setupButton(
+            binding.negativeButton,
+            payload.negativeButtonText,
+            theme.negativeButton,
+            themeWrapper.typeface,
+            payload.negativeButtonClickListener
+        )
+        binding.additionalButtonsSpace.isGone = binding.link1Button.isVisible || binding.link2Button.isVisible
+    }
+}
+
+internal class ConfirmationDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) :
+    DefaultConfirmationDialogViewInflater<ConfirmationDialogViewBinding>(ConfirmationDialogViewBinding(layoutInflater), themeWrapper, payload)
+
+internal class VerticalConfirmationDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) :
+    DefaultConfirmationDialogViewInflater<VerticalConfirmationDialogViewBinding>(VerticalConfirmationDialogViewBinding(layoutInflater), themeWrapper, payload)
+
+internal open class DefaultReversedConfirmationDialogViewInflater<T : DefaultReversedConfirmationDialogViewBinding<*>>(
+    binding: T,
+    themeWrapper: AlertThemeWrapper,
+    payload: DialogPayload.Confirmation
+) : BaseConfirmationDialogViewInflater<T>(binding, themeWrapper, payload) {
+    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) {
+        super.setup(binding, themeWrapper, payload)
+        val theme = themeWrapper.theme
+        setupButton(
+            binding.positiveButton,
+            payload.positiveButtonText,
+            theme.negativeButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
+            themeWrapper.typeface,
+            payload.positiveButtonClickListener
+        )
+        setupButton(
+            binding.negativeButton,
+            payload.negativeButtonText,
+            theme.positiveButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
+            themeWrapper.typeface,
+            payload.negativeButtonClickListener
+        )
+    }
+}
+

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/UnifiedUiExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/UnifiedUiExtensions.kt
@@ -152,7 +152,10 @@ internal fun MaterialButton.applyButtonTheme(buttonTheme: ButtonTheme?) {
         bg.borderWidthInt?.also { strokeWidth = it }
     }
 
-    buttonTheme?.elevation?.also { elevation = it }
+    buttonTheme?.elevation?.also {
+        stateListAnimator = null // Default state list controls the button shadow (elevation)
+        elevation = it
+    }
     buttonTheme?.shadowColor?.also(::applyShadow)
     buttonTheme?.text?.also {
         applyTextTheme(it)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/alert/AlertRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/alert/AlertRemoteConfig.kt
@@ -23,6 +23,9 @@ internal data class AlertRemoteConfig(
     @SerializedName("closeButtonColor")
     val closeButtonColor: ColorLayerRemoteConfig?,
 
+    @SerializedName("linkButton")
+    val linkButtonRemoteConfig: ButtonRemoteConfig?,
+
     @SerializedName("positiveButton")
     val positiveButtonRemoteConfig: ButtonRemoteConfig?,
 
@@ -38,6 +41,7 @@ internal data class AlertRemoteConfig(
         message = message?.toTextTheme(),
         backgroundColor = backgroundColor?.toColorTheme(),
         closeButtonColor = closeButtonColor?.toColorTheme(),
+        linkButton = linkButtonRemoteConfig?.toButtonTheme(),
         positiveButton = positiveButtonRemoteConfig?.toButtonTheme(),
         negativeButton = negativeButtonRemoteConfig?.toButtonTheme(),
         isVerticalAxis = buttonAxisRemoteConfig?.isVertical

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/alert/AlertTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/alert/AlertTheme.kt
@@ -10,6 +10,7 @@ internal data class AlertTheme(
     val message: TextTheme? = null,
     val backgroundColor: ColorTheme? = null,
     val closeButtonColor: ColorTheme? = null,
+    val linkButton: ButtonTheme? = null,
     val positiveButton: ButtonTheme? = null,
     val negativeButton: ButtonTheme? = null,
     val isVerticalAxis: Boolean? = null

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Alert.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Alert.kt
@@ -15,6 +15,7 @@ internal fun AlertTheme(pallet: ColorPallet): AlertTheme = pallet.run {
         message = BaseDarkColorTextTheme(this),
         backgroundColor = baseLightColorTheme,
         closeButtonColor = baseNormalColorTheme,
+        linkButton = LinkDefaultButtonTheme(this),
         positiveButton = PositiveDefaultButtonTheme(this),
         negativeButton = NegativeDefaultButtonTheme(this)
     )

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Button.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Button.kt
@@ -2,6 +2,7 @@
 
 package com.glia.widgets.view.unifiedui.theme.defaulttheme
 
+import android.graphics.Color
 import com.glia.widgets.view.unifiedui.composeIfAtLeastOneNotNull
 import com.glia.widgets.view.unifiedui.theme.ColorPallet
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
@@ -27,6 +28,17 @@ internal fun PositiveDefaultButtonTheme(pallet: ColorPallet) = pallet.run {
  */
 internal fun NegativeDefaultButtonTheme(pallet: ColorPallet) = pallet.run {
     DefaultButtonTheme(text = baseLightColorTheme, background = systemNegativeColorTheme)
+}
+
+/**
+ * Default theme for Link Button
+ */
+internal fun LinkDefaultButtonTheme(pallet: ColorPallet) = pallet.run {
+    ButtonTheme(
+        background = LayerTheme(fill = ColorTheme(Color.TRANSPARENT)),
+        text = TextTheme(textColor = primaryColorTheme),
+        elevation = 0f
+    )
 }
 
 /**

--- a/widgetssdk/src/main/res/layout/confirmation_dialog.xml
+++ b/widgetssdk/src/main/res/layout/confirmation_dialog.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/start_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/glia_large_x_large" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/end_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/glia_large_x_large" />
+
+    <TextView
+        android:id="@+id/dialog_title_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_x_large"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceHeadline2"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginTop="@dimen/glia_x_large"
+        tools:text="@string/android_overlay_permission_title"
+        tools:textSize="20sp" />
+
+    <TextView
+        android:id="@+id/dialog_message_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_medium"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/dialog_title_view"
+        app:layout_goneMarginTop="@dimen/glia_large" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/link1_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_medium"
+        tools:text="@string/engagement_confirm_link1_text"
+        android:textAllCaps="false"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/dialog_message_view"
+        app:layout_goneMarginTop="@dimen/glia_medium" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/link2_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        tools:text="@string/engagement_confirm_link2_text"
+        android:textAllCaps="false"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/link1_button"
+        app:layout_goneMarginTop="@dimen/glia_medium" />
+
+    <Space
+        android:id="@+id/additional_buttons_space"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/glia_large"
+        android:visibility="gone"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/link2_button"/>
+
+    <com.glia.widgets.view.button.GliaNegativeButton
+        android:id="@+id/decline_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_medium"
+        android:layout_marginEnd="@dimen/glia_small"
+        tools:text="@string/general_decline"
+        app:layout_constraintEnd_toStartOf="@id/accept_button"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/additional_buttons_space" />
+
+    <com.glia.widgets.view.button.GliaPositiveButton
+        android:id="@+id/accept_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/glia_small"
+        android:layout_marginTop="@dimen/glia_medium"
+        tools:text="@string/general_accept"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toEndOf="@id/decline_button"
+        app:layout_constraintTop_toBottomOf="@id/additional_buttons_space" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/logo_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/accept_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/powered_by_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="Powered by"
+            style="@style/Application.Glia.Caption"
+            android:textColor="@color/glia_base_normal_color_50"
+            android:layout_marginEnd="@dimen/glia_medium"
+            android:importantForAccessibility="no"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintEnd_toStartOf="@id/logo_view"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <ImageView
+            android:id="@+id/logo_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/glia_pre_x_large"
+            android:layout_marginBottom="@dimen/glia_pre_x_large"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_glia_logo"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/powered_by_text"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <Space
+        android:id="@+id/space"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/glia_large_x_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/logo_container"
+        app:layout_constraintVertical_bias="0" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/widgetssdk/src/main/res/layout/confirmation_dialog_vertical.xml
+++ b/widgetssdk/src/main/res/layout/confirmation_dialog_vertical.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/start_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/glia_large_x_large" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/end_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/glia_large_x_large" />
+
+    <TextView
+        android:id="@+id/dialog_title_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_x_large"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceHeadline2"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginTop="@dimen/glia_x_large"
+        tools:text="@string/android_overlay_permission_title"
+        tools:textSize="20sp" />
+
+    <TextView
+        android:id="@+id/dialog_message_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_medium"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/dialog_title_view"
+        app:layout_goneMarginTop="@dimen/glia_large" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/link1_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_medium"
+        tools:text="@string/engagement_confirm_link1_text"
+        android:textAllCaps="false"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/dialog_message_view"
+        app:layout_goneMarginTop="@dimen/glia_medium" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/link2_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        tools:text="@string/engagement_confirm_link2_text"
+        android:textAllCaps="false"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/link1_button"
+        app:layout_goneMarginTop="@dimen/glia_medium" />
+
+    <Space
+        android:id="@+id/additional_buttons_space"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/glia_large"
+        android:visibility="gone"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/link2_button"/>
+
+    <com.glia.widgets.view.button.GliaPositiveButton
+        android:id="@+id/accept_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_medium"
+        tools:text="@string/glia_dialog_accept"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/additional_buttons_space" />
+
+    <com.glia.widgets.view.button.GliaNegativeButton
+        android:id="@+id/decline_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        tools:text="@string/glia_dialog_decline"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/accept_button" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/logo_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/decline_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/powered_by_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="Powered by"
+            style="@style/Application.Glia.Caption"
+            android:textColor="@color/glia_base_normal_color_50"
+            android:layout_marginEnd="@dimen/glia_medium"
+            android:importantForAccessibility="no"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintEnd_toStartOf="@id/logo_view"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <ImageView
+            android:id="@+id/logo_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/glia_pre_x_large"
+            android:layout_marginBottom="@dimen/glia_pre_x_large"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_glia_logo"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/powered_by_text"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <Space
+        android:id="@+id/space"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/glia_large_x_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/logo_container"
+        app:layout_constraintVertical_bias="0" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -202,8 +202,12 @@
     <string name="engagement_phone_title">Phone</string> <!-- TODO NEW -->
 
     <!--    Live Observation -->
-    <string name="live_observation_confirm_title">Before We Continue</string>
-    <string name="live_observation_confirm_message">Please allow the {companyName} representative to view this application screen for improved support.</string>
+    <string name="engagement_confirm_title">Before We Continue</string>
+    <string name="engagement_confirm_message">Please allow the {companyName} representative to view this application screen for improved support.</string>
+    <string name="engagement_confirm_link1_text">Terms and Conditions</string>
+    <string name="engagement_confirm_link1_url"/>
+    <string name="engagement_confirm_link2_text">Privacy Policies</string>
+    <string name="engagement_confirm_link2_url"/>
     <string name="live_observation_indicator_message">App screen is visible to the agent</string>
 
     <!--    GVA -->


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2862

**What was solved?**
Added the ability for integrators to add links to their “terms and conditions” or/and “privacy policies” to the live observation confirmation dialog.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
