### PR TITLE
Send logs with important events

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -134,7 +134,7 @@ public class GliaWidgets {
         Dependencies.glia().init(gliaConfig);
         Dependencies.init(gliaWidgetsConfig);
         setupLoggingMetadata(gliaWidgetsConfig);
-        Logger.d(TAG, "init");
+        Logger.i(TAG, "Initialize Glia Widgets SDK");
         Dependencies.getGliaThemeManager().applyJsonConfig(gliaWidgetsConfig.uiJsonRemoteConfig);
     }
 
@@ -201,7 +201,7 @@ public class GliaWidgets {
      * Clears visitor session
      */
     public static void clearVisitorSession() {
-        Logger.d(TAG, "clearVisitorSession");
+        Logger.i(TAG, "Clear visitor session");
         Dependencies.getControllerFactory().destroyControllers();
         Dependencies.getUseCaseFactory().resetState();
         Dependencies.glia().clearVisitorSession();
@@ -213,7 +213,7 @@ public class GliaWidgets {
      * Ends active engagement if existing and closes Widgets SDK UI (includes bubble).
      */
     public static void endEngagement() {
-        Logger.d(TAG, "endEngagement");
+        Logger.i(TAG, "End engagement by integrator");
         Dependencies.getControllerFactory().destroyControllers();
         Dependencies.glia().getCurrentEngagement().ifPresent(engagement -> engagement.end(e -> {
             if (e != null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -3,7 +3,7 @@ package com.glia.widgets
 import android.content.Context
 import com.glia.androidsdk.SiteApiKey
 import com.glia.androidsdk.screensharing.ScreenSharing
-import com.glia.widgets.helper.Logger.d
+import com.glia.widgets.helper.Logger.i
 import com.glia.widgets.helper.TAG
 
 /**
@@ -178,7 +178,7 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
 
         fun setUiJsonRemoteConfig(uiJsonRemoteConfig: String?): Builder {
             // Log
-            d(TAG, "Setting Unified UI Config")
+            i(TAG, "Setting Unified UI Config")
             this.uiJsonRemoteConfig = uiJsonRemoteConfig
             return this
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.java
@@ -38,6 +38,7 @@ public class CallActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Logger.i(TAG, "Create Call screen");
         setContentView(R.layout.call_activity);
         callView = findViewById(R.id.call_view);
         configuration = CallIntentReader.from(this).getConfiguration();
@@ -93,6 +94,7 @@ public class CallActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
+        Logger.i(TAG, "Destroy Call screen");
         onBackClickedListener = null;
         onNavigateToChatListener = null;
         callView.onDestroy();

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.java
@@ -218,7 +218,6 @@ public class CallController implements
 
     @Override
     public void onNewVisitorMediaState(VisitorMediaState visitorMediaState) {
-        Logger.d(TAG, "newVisitorMediaState: " + visitorMediaState);
         emitViewState(callState.visitorMediaStateChanged(visitorMediaState));
     }
 
@@ -229,7 +228,7 @@ public class CallController implements
 
     @Override
     public void engagementEnded() {
-        Logger.d(TAG, "engagementEndedByOperator");
+        Logger.i(TAG, "Engagement ended");
         stop();
         if (!isOngoingEngagementUseCase.invoke()) {
             dialogController.dismissDialogs();
@@ -285,8 +284,6 @@ public class CallController implements
                           Engagement.MediaType mediaType,
                           boolean useOverlays,
                           ScreenSharing.Mode screenSharingMode) {
-        Logger.d(TAG, "initCall");
-
         sdkConfigurationManager.setUseOverlay(useOverlays);
         sdkConfigurationManager.setScreenSharingMode(screenSharingMode);
 
@@ -451,7 +448,7 @@ public class CallController implements
     }
 
     public void acceptUpgradeOfferClicked(MediaUpgradeOffer mediaUpgradeOffer) {
-        Logger.d(TAG, "upgradeToAudioClicked");
+        Logger.i(TAG, "Upgrade offer accepted by visitor");
         mediaUpgradeOfferRepository.acceptOffer(
                 mediaUpgradeOffer,
                 MediaUpgradeOfferRepository.Submitter.CALL
@@ -460,7 +457,7 @@ public class CallController implements
     }
 
     public void declineUpgradeOfferClicked(MediaUpgradeOffer mediaUpgradeOffer) {
-        Logger.d(TAG, "closeUpgradeDialogClicked");
+        Logger.i(TAG, "Upgrade offer declined by visitor");
         mediaUpgradeOfferRepository.declineOffer(
                 mediaUpgradeOffer,
                 MediaUpgradeOfferRepository.Submitter.CALL
@@ -536,7 +533,7 @@ public class CallController implements
 
     @Override
     public void onSurveyLoaded(@Nullable Survey survey) {
-        Logger.d(TAG, "newSurveyLoaded");
+        Logger.i(TAG, "Survey loaded");
         setPendingSurveyUsedUseCase.invoke();
         if (viewCallback != null && survey != null) {
             viewCallback.navigateToSurvey(survey);
@@ -557,12 +554,11 @@ public class CallController implements
     }
 
     public void queueForEngagementStarted() {
-        Logger.d(TAG, "queueForEngagementStarted");
         observeQueueTicketState();
     }
 
     public void queueForEngagementStopped() {
-        Logger.d(TAG, "queueForEngagementStopped");
+        Logger.i(TAG, "Queue for engagement stopped due to error or empty queue");
     }
 
     public void queueForEngagementError(Throwable exception) {
@@ -612,15 +608,15 @@ public class CallController implements
             public void newOffer(MediaUpgradeOffer offer) {
                 if (offer.video == MediaDirection.NONE && offer.audio == MediaDirection.TWO_WAY) {
                     // audio call
-                    Logger.d(TAG, "audioUpgradeRequested");
+                    Logger.d(TAG, "Audio upgrade requested");
                     showUpgradeAudioDialog(offer);
                 } else if (offer.video == MediaDirection.TWO_WAY) {
                     // 2 way video call
-                    Logger.d(TAG, "2 way videoUpgradeRequested");
+                    Logger.d(TAG, "2 way video upgrade requested");
                     showUpgradeVideoDialog2Way(offer);
                 } else if (offer.video == MediaDirection.ONE_WAY) {
                     // 1 way video call
-                    Logger.d(TAG, "1 way videoUpgradeRequested");
+                    Logger.d(TAG, "1 way video upgrade requested");
                     showUpgradeVideoDialog1Way(offer);
                 }
             }
@@ -749,7 +745,9 @@ public class CallController implements
                 cancelQueueTicketUseCase.execute()
                         .subscribe(
                                 this::queueForEngagementStopped,
-                                throwable -> Logger.e(TAG, "cancelQueueTicketUseCase error: " + throwable.getMessage())
+                                throwable -> {
+                                    if (throwable.getMessage() != null) Logger.e(TAG, "cancelQueueTicketUseCase error: " + throwable.getMessage());
+                                }
                         )
         );
         endEngagementUseCase.invoke();

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
@@ -7,10 +7,13 @@ import com.glia.androidsdk.comms.Media;
 import com.glia.androidsdk.comms.OperatorMediaState;
 import com.glia.androidsdk.comms.Video;
 import com.glia.androidsdk.comms.VisitorMediaState;
+import com.glia.widgets.helper.Logger;
 
 import java.util.Objects;
 
 class CallState {
+    private static final String TAG = CallState.class.getSimpleName();
+
     public final boolean integratorCallStarted;
     public final boolean isVisible;
     public final int messagesNotSeen;
@@ -166,6 +169,7 @@ class CallState {
     }
 
     public CallState engagementStarted() {
+        Logger.i(TAG, "Engagement started");
         return new Builder()
                 .copyFrom(this)
                 .setIsOnHold(false)
@@ -220,6 +224,7 @@ class CallState {
     }
 
     public CallState audioCallStarted(OperatorMediaState operatorMediaState, String formattedTime) {
+        Logger.i(TAG, "Audio or video call started");
         return new Builder()
                 .copyFrom(this)
                 .setCallStatus(
@@ -306,6 +311,7 @@ class CallState {
     }
 
     public CallState speakerValueChanged(boolean isSpeakerOn) {
+        Logger.i(TAG, "Speaker value changed to " + isSpeakerOn);
         return new Builder()
                 .copyFrom(this)
                 .setIsSpeakerOn(isSpeakerOn)
@@ -320,6 +326,7 @@ class CallState {
     }
 
     public CallState setTransferring() {
+        Logger.i(TAG, "Transfer the call");
         return new Builder()
                 .copyFrom(this)
                 .setCallStatus(

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -371,7 +371,6 @@ internal class ActivityWatcherForCallVisualizer(
         if (alertDialog != null && alertDialog!!.isShowing) {
             return
         }
-        Logger.d(TAG, "Show visitor code dialog")
         val theme = UiTheme.UiThemeBuilder().build()
         val contextWithStyle = activity.wrapWithMaterialThemeOverlay()
 

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizerController.kt
@@ -251,6 +251,7 @@ internal class ActivityWatcherForCallVisualizerController(
     }
 
     override fun onMediaProjectionPermissionResult(isGranted: Boolean, activity: Activity) {
+        Logger.i(TAG, "Media projection granted by visitor: $isGranted")
         if (isGranted) {
             screenSharingController.onScreenSharingAccepted(activity)
         } else {
@@ -260,6 +261,7 @@ internal class ActivityWatcherForCallVisualizerController(
 
     @VisibleForTesting
     internal fun onMediaUpgradeAccept(error: GliaException?) {
+        Logger.d(TAG, "Media upgrade request accepted by visitor")
         error?.let {
             Logger.e(TAG, it.debugMessage, error)
         } ?: run {
@@ -278,6 +280,7 @@ internal class ActivityWatcherForCallVisualizerController(
 
     @VisibleForTesting
     internal fun onMediaUpgradeDecline(error: GliaException?) {
+        Logger.i(TAG, "Media upgrade request declined by visitor")
         error?.let {
             Logger.e(TAG, it.debugMessage, error)
         } ?: run {

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerRepository.kt
@@ -48,7 +48,7 @@ class CallVisualizerRepository(private val gliaCore: GliaCore) {
                 if (error != null) {
                     Logger.e(TAG, "Error during accepting engagement request, reason" + error.message)
                 } else {
-                    Logger.d(TAG, "Incoming Call Visualizer engagement auto accepted")
+                    Logger.i(TAG, "Incoming Call Visualizer engagement auto accepted")
                 }
             }
             engagementRequest.accept(visitorContext ?: null as String?, onResult)

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingActivity.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.glia.widgets.databinding.EndScreenSharingActivityBinding
 import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
 
 class EndScreenSharingActivity : AppCompatActivity(), EndScreenSharingView.OnFinishListener {
 
@@ -11,6 +13,7 @@ class EndScreenSharingActivity : AppCompatActivity(), EndScreenSharingView.OnFin
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Logger.i(TAG, "Create End Screen Sharing screen")
         binding = EndScreenSharingActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -24,6 +27,7 @@ class EndScreenSharingActivity : AppCompatActivity(), EndScreenSharingView.OnFin
 
     override fun onDestroy() {
         super.onDestroy()
+        Logger.i(TAG, "Destroy End Screen Sharing screen")
         binding.screenSharingScreenView.onDestroy()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -63,6 +63,7 @@ internal class CallVisualizerController(
     }
 
     override fun newEngagementLoaded(engagement: OmnibrowseEngagement) {
+        Logger.i(TAG, "New Call visualizer engagement loaded")
         surveyUseCase.registerListener(this)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -16,10 +16,12 @@ import com.glia.widgets.UiTheme;
 import com.glia.widgets.call.CallActivity;
 import com.glia.widgets.call.Configuration;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
+import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.Utils;
 import com.glia.widgets.survey.SurveyActivity;
 
 public class ChatActivity extends AppCompatActivity {
+    private static final String TAG = ChatActivity.class.getSimpleName();
     private ChatView chatView;
 
     private GliaSdkConfiguration configuration;
@@ -64,6 +66,7 @@ public class ChatActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Logger.i(TAG, "Create Chat screen");
         setContentView(R.layout.chat_activity);
         chatView = findViewById(R.id.chat_view);
 
@@ -113,6 +116,7 @@ public class ChatActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         chatView.onDestroyView();
+        Logger.i(TAG, "Destroy Chat screen");
         super.onDestroy();
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/authentication/AuthenticationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/authentication/AuthenticationManager.kt
@@ -37,10 +37,12 @@ internal class AuthenticationManager(
         requestCallback: RequestCallback<Void>
     ) {
         cleanup()
+        Logger.i(TAG, "Authenticate. Is external access token used: ${externalAccessToken != null}")
         authentication.authenticate(jwtToken, externalAccessToken, requestCallback)
     }
 
     override fun deauthenticate(requestCallback: RequestCallback<Void>) {
+        Logger.i(TAG, "De-authenticate")
         cleanup()
         authentication.deauthenticate(requestCallback)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerEndUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/GliaOnCallVisualizerEndUseCase.kt
@@ -8,6 +8,8 @@ import com.glia.widgets.core.notification.domain.RemoveScreenSharingNotification
 import com.glia.widgets.core.operator.GliaOperatorMediaRepository
 import com.glia.widgets.core.survey.GliaSurveyRepository
 import com.glia.widgets.core.visitor.GliaVisitorMediaRepository
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
 
 internal class GliaOnCallVisualizerEndUseCase(
     private val repository: CallVisualizerRepository,
@@ -25,6 +27,7 @@ internal class GliaOnCallVisualizerEndUseCase(
 
     inner class EndCallVisualizerRunnable(private val engagement: Engagement) : Runnable {
         override fun run() {
+            Logger.i(TAG, "Call visualizer engagement ended")
             surveyRepository.onEngagementEnded(engagement)
             listener?.callVisualizerEngagementEnded()
             operatorMediaRepository.onEngagementEnded(engagement)

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
@@ -29,10 +29,10 @@ internal class ToggleChatHeadServiceUseCase(
     override operator fun invoke(viewName: String?): Boolean {
         val isDisplayDeviceBubble = super.invoke(viewName)
         if (isDisplayDeviceBubble) {
-            Logger.d(TAG, "Starting ChatHeadService")
+            Logger.i(TAG, "Bubble: show device bubble")
             chatHeadManager.startChatHeadService()
         } else {
-            Logger.d(TAG, "Stopping ChatHeadService")
+            Logger.d(TAG, "Bubble: hide device bubble")
             chatHeadManager.stopChatHeadService()
         }
         return isDisplayDeviceBubble

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
@@ -51,32 +51,32 @@ public class DialogController {
     }
 
     public void showExitQueueDialog() {
-        Logger.d(TAG, "Show Exit Queue Dialog");
+        Logger.i(TAG, "Show Exit Queue Dialog");
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_EXIT_QUEUE));
     }
 
     public void showExitChatDialog(String operatorName) {
-        Logger.d(TAG, "Show Exit Chat Dialog");
+        Logger.i(TAG, "Show End Engagement Dialog");
         dialogManager.addAndEmit(new DialogState.OperatorName(Dialog.MODE_END_ENGAGEMENT, operatorName));
     }
 
     public void showUpgradeAudioDialog(MediaUpgradeOffer mediaUpgradeOffer, String operatorName) {
-        Logger.d(TAG, "Show Upgrade Audio Dialog");
+        Logger.i(TAG, "Show Upgrade Audio Dialog");
         dialogManager.addAndEmit(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_AUDIO));
     }
 
     public void showUpgradeVideoDialog2Way(MediaUpgradeOffer mediaUpgradeOffer, String operatorName) {
-        Logger.d(TAG, "Show Upgrade 2WayVideo Dialog");
+        Logger.i(TAG, "Show Upgrade 2WayVideo Dialog");
         dialogManager.addAndEmit(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_VIDEO_TWO_WAY));
     }
 
     public void showUpgradeVideoDialog1Way(MediaUpgradeOffer mediaUpgradeOffer, String operatorName) {
-        Logger.d(TAG, "Show Upgrade 1WayVide Dialog");
+        Logger.i(TAG, "Show Upgrade 1WayVide Dialog");
         dialogManager.addAndEmit(new DialogState.MediaUpgrade(mediaUpgradeOffer, operatorName, DialogState.MediaUpgrade.MODE_VIDEO_ONE_WAY));
     }
 
     public void showVisitorCodeDialog() {
-        Logger.d(TAG, "Show Visitor Code Dialog");
+        Logger.i(TAG, "Show Visitor Code Dialog");
         if (isOverlayDialogShown() || isExitQueueDialogShown()) {
             dialogManager.add(new DialogState(Dialog.MODE_VISITOR_CODE));
         } else {
@@ -85,12 +85,12 @@ public class DialogController {
     }
 
     public void dismissVisitorCodeDialog() {
-        Logger.d(TAG, "Dismiss Visitor Code Dialog");
+        Logger.i(TAG, "Dismiss Visitor Code Dialog");
         dialogManager.remove(new DialogState(Dialog.MODE_VISITOR_CODE));
     }
 
     public void showNoMoreOperatorsAvailableDialog() {
-        Logger.d(TAG, "Show No More Operators Dialog");
+        Logger.i(TAG, "Show No More Operators Dialog");
         if (isOverlayDialogShown() || isExitQueueDialogShown()) {
             dialogManager.add(new DialogState(Dialog.MODE_NO_MORE_OPERATORS));
         } else {
@@ -99,18 +99,18 @@ public class DialogController {
     }
 
     public void showEngagementEndedDialog() {
-        Logger.d(TAG, "Show Engagement EngagementEndedEvent Dialog");
+        Logger.i(TAG, "Show Engagement Ended Dialog");
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_ENGAGEMENT_ENDED));
     }
 
     public void showUnexpectedErrorDialog() {
         // PRIORITISE THIS ERROR AS IT IS ENGAGEMENT FATAL ERROR INDICATOR (eg. GliaException:{"details":"Queue is closed","error":"Unprocessable entity"}) for example
-        Logger.d(TAG, "Show Unexpected error Dialog");
+        Logger.i(TAG, "Show Unexpected error Dialog");
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_UNEXPECTED_ERROR));
     }
 
     public void showOverlayPermissionsDialog() {
-        Logger.d(TAG, "Show Overlay permissions Dialog");
+        Logger.i(TAG, "Show Overlay permissions Dialog");
         setOverlayPermissionRequestDialogShownUseCase.execute();
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_OVERLAY_PERMISSION));
     }
@@ -126,28 +126,28 @@ public class DialogController {
     }
 
     public void showStartScreenSharingDialog() {
-        Logger.d(TAG, "Show Start Screen Sharing Dialog");
+        Logger.i(TAG, "Show Start Screen Sharing Dialog");
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_START_SCREEN_SHARING));
     }
 
     public void showEnableCallNotificationChannelDialog() {
-        Logger.d(TAG, "Show Enable Notification Channel Dialog");
+        Logger.i(TAG, "Show Enable Call Notification Channel Dialog");
         setEnableCallNotificationChannelDialogShownUseCase.execute();
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_ENABLE_NOTIFICATION_CHANNEL));
     }
 
     public void showEnableScreenSharingNotificationsAndStartSharingDialog() {
-        Logger.d(TAG, "Show Enable Notification Channel Dialog");
+        Logger.i(TAG, "Show Enable Screen Sharing Notifications And Start Screen Sharing Dialog");
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_ENABLE_SCREEN_SHARING_NOTIFICATIONS_AND_START_SHARING));
     }
 
     public void showMessageCenterUnavailableDialog() {
-        Logger.d(TAG, "Show Message Center Unavailable Dialog");
+        Logger.i(TAG, "Show Message Center Unavailable Dialog");
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_MESSAGE_CENTER_UNAVAILABLE));
     }
 
     public void showUnauthenticatedDialog() {
-        Logger.d(TAG, "Show Unauthenticated Dialog");
+        Logger.i(TAG, "Show Unauthenticated Dialog");
         dialogManager.addAndEmit(new DialogState(Dialog.MODE_UNAUTHENTICATED));
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationActionReceiver.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationActionReceiver.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import com.glia.widgets.core.screensharing.ScreenSharingController
 import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
 
 class NotificationActionReceiver : BroadcastReceiver() {
     private val controller: ScreenSharingController by lazy {
@@ -18,6 +20,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
     }
 
     private fun onScreenSharingEndPressed() {
+        Logger.i(TAG, "End screen sharing tapped from notification")
         controller.onScreenSharingNotificationEndPressed()
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
@@ -12,6 +12,8 @@ import com.glia.androidsdk.comms.MediaDirection
 import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.widgets.core.notification.NotificationFactory
 import com.glia.widgets.core.notification.areNotificationsEnabledForChannel
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
 import com.glia.widgets.permissions.Permissions
 import com.glia.widgets.permissions.PermissionsGrantedCallback
 import com.glia.widgets.permissions.PermissionsRequestRepository
@@ -36,6 +38,7 @@ internal class PermissionManager(
 
     @SuppressLint("InlinedApi")
     fun getPermissionsForMediaUpgradeOffer(offer: MediaUpgradeOffer): Permissions {
+        Logger.i(TAG, "Request permissions for media upgrade offer")
         val requiredPermissions = emptyList<String>() // required permissions for media upgrade are handling in the Core SDK
         val additionalPermissions = mutableListOf<String>()
         if (sdkInt > Build.VERSION_CODES.R && offer.audio != null && offer.audio == MediaDirection.TWO_WAY) {
@@ -97,6 +100,7 @@ internal class PermissionManager(
         additionalPermissionsGrantedCallback: PermissionsGrantedCallback? = null,
         callback: PermissionsRequestResult? = null
     ) {
+        Logger.i(TAG, "Request permissions")
         val allPermissions = (necessaryPermissions ?: emptyList()) + (additionalPermissions ?: emptyList())
 
         if (allPermissions.isEmpty()) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/GliaQueueRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/GliaQueueRepository.java
@@ -38,6 +38,7 @@ public class GliaQueueRepository {
             String queueId,
             String  visitorContextAssetId
     ) {
+        Logger.i(TAG, "Start queueing for chat engagement");
         return queueForEngagement(queueId, visitorContextAssetId)
                 .mergeWith(
                         awaitTicket()
@@ -49,6 +50,7 @@ public class GliaQueueRepository {
                                                        String  visitorContextAssetId,
                                                        Engagement.MediaType mediaType
     ) {
+        Logger.i(TAG, "Start queueing for media engagement");
         return queueForMediaEngagement(queueId, visitorContextAssetId, mediaType)
                 .mergeWith(
                         awaitTicket()
@@ -103,6 +105,7 @@ public class GliaQueueRepository {
     }
 
     public Completable cancelTicket(String ticketId) {
+        Logger.i(TAG, "Cancel queue ticket");
         return Completable.create(emitter -> gliaCore.cancelQueueTicket(ticketId, exception -> {
             if (exception != null) {
                 Logger.e(TAG, "cancelQueueTicketError: " + exception);

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/data/GliaScreenSharingRepository.java
@@ -55,7 +55,7 @@ public class GliaScreenSharingRepository {
             Activity activity,
             ScreenSharing.Mode screenSharingMode
     ) {
-        Logger.d(TAG, "screen sharing accepted by the user");
+        Logger.i(TAG, "Screen sharing accepted by visitor");
         screenSharingRequest.accept(
                 screenSharingMode,
                 activity,
@@ -68,7 +68,7 @@ public class GliaScreenSharingRepository {
             Activity activity,
             ScreenSharing.Mode screenSharingMode
     ) {
-        Logger.d(TAG, "Screen sharing accepted by the user, permission asked");
+        Logger.i(TAG, "Screen sharing accepted by visitor, permission asked");
 
         screenSharingRequest.accept(
                 screenSharingMode,
@@ -79,7 +79,7 @@ public class GliaScreenSharingRepository {
     }
 
     public void onScreenSharingDeclined() {
-        Logger.d(TAG, "screen sharing declined by the user");
+        Logger.i(TAG, "Screen sharing declined by visitor");
         gliaCore.getCurrentEngagement().ifPresent(engagement -> {
             // Pass RESULT_CANCELED to Core SDK to stop waiting for permission result. Otherwise, subsequent screen sharing requests won't be shown to the visitor.
             // Also see related bug ticket: MOB-2102
@@ -146,14 +146,14 @@ public class GliaScreenSharingRepository {
     }
 
     private void onScreenSharingStarted(LocalScreen screen) {
-        Logger.d(TAG, "screen sharing IS SHARING");
+        Logger.i(TAG, "Screen sharing started");
 
         currentScreen = screen;
         callback.onScreenSharingStarted();
     }
 
     private void onScreenSharingEnded() {
-        Logger.d(TAG, "screen sharing NOT SHARING");
+        Logger.i(TAG, "Screen sharing ended");
 
         currentScreen = null;
         callback.onScreenSharingEnded();

--- a/widgetssdk/src/main/java/com/glia/widgets/core/survey/GliaSurveyRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/survey/GliaSurveyRepository.java
@@ -8,12 +8,14 @@ import com.glia.androidsdk.GliaException;
 import com.glia.androidsdk.RequestCallback;
 import com.glia.androidsdk.engagement.Survey;
 import com.glia.widgets.di.GliaCore;
+import com.glia.widgets.helper.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
 public class GliaSurveyRepository implements RequestCallback<Survey> {
+    private static final String TAG = GliaSurveyRepository.class.getSimpleName();
 
     private final GliaCore gliaCore;
     private final List<OnSurveyListener> listeners = new ArrayList<>();
@@ -72,6 +74,7 @@ public class GliaSurveyRepository implements RequestCallback<Survey> {
                                     @NonNull String surveyId,
                                     @NonNull String engagementId,
                                     @NonNull Consumer<GliaException> callback) {
+        Logger.i(TAG, "Submit survey answers");
         gliaCore.submitSurveyAnswers(answers, surveyId, engagementId, callback);
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/FilePreviewActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/FilePreviewActivity.kt
@@ -21,6 +21,8 @@ import com.glia.androidsdk.chat.AttachmentFile
 import com.glia.widgets.R
 import com.glia.widgets.databinding.FilePreviewActivityBinding
 import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.fileProviderAuthority
 import com.glia.widgets.helper.showToast
 import java.io.File
@@ -53,6 +55,7 @@ internal class FilePreviewActivity : AppCompatActivity(), FilePreviewContract.Vi
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Logger.i(TAG, "Create File Preview screen")
         setContentView(binding.root)
         title = stringProvider.getRemoteString(R.string.android_preview_title)
 
@@ -115,6 +118,7 @@ internal class FilePreviewActivity : AppCompatActivity(), FilePreviewContract.Vi
     }
 
     override fun onDestroy() {
+        Logger.i(TAG, "Destroy File Preview screen")
         filePreviewController?.onDestroy()
         super.onDestroy()
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt
@@ -1,9 +1,10 @@
 package com.glia.widgets.helper
 
 import android.util.Log
-import com.glia.androidsdk.BuildConfig
+import androidx.annotation.VisibleForTesting
 import com.glia.androidsdk.LogLevel
 import com.glia.androidsdk.LoggingAdapter
+import com.glia.widgets.BuildConfig
 import java.util.function.Consumer
 
 internal object Logger {
@@ -11,9 +12,14 @@ internal object Logger {
     const val SITE_ID_KEY = "site_id"
     private const val DEPRECATED_METHOD_CALL_LOG_MESSAGE = "Deprecated method usage: "
     private const val DEPRECATED_CLASS_CALL_LOG_MESSAGE = "Deprecated class usage: "
+    internal const val TAG_PREFIX = "Glia Widgets: "
 
     private val loggingAdapters = mutableListOf<LoggingAdapter>()
     private val globalMetadata = mutableMapOf<String, String>()
+    private var isDebug = BuildConfig.DEBUG
+
+    private val setOfUsedDeprecatedFunctions = mutableSetOf<String>()
+    private val setOfUsedDeprecatedClasses = mutableSetOf<String>()
 
     @Suppress("unused")
     @JvmStatic
@@ -21,111 +27,143 @@ internal object Logger {
         loggingAdapters.add(loggingAdapter)
     }
 
+    @VisibleForTesting
+    fun setIsDebug(isDebug: Boolean) {
+        this.isDebug = isDebug
+    }
+
     @JvmStatic
     fun d(tag: String, message: String) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.d(tag, message)
+        if (isDebug) {
+            Log.d(TAG_PREFIX + tag, message)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.DEBUG, tag, message, concatGlobalMeta(null))
+            loggingAdapter.log(LogLevel.DEBUG, TAG_PREFIX + tag, message, concatGlobalMeta(null))
         })
     }
 
     @JvmStatic
     fun d(tag: String, message: String, metadata: Map<String, String>? = null) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.d(tag, message)
+        if (isDebug) {
+            Log.d(TAG_PREFIX + tag, message)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.DEBUG, tag, message, concatGlobalMeta(metadata))
+            loggingAdapter.log(LogLevel.DEBUG, TAG_PREFIX + tag, message, concatGlobalMeta(metadata))
         })
     }
 
     @JvmStatic
     fun i(tag: String, message: String) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.i(tag, message)
+        if (isDebug) {
+            Log.i(TAG_PREFIX + tag, message)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.INFO, tag, message, concatGlobalMeta(null))
+            loggingAdapter.log(LogLevel.INFO, TAG_PREFIX + tag, message, concatGlobalMeta(null))
         })
     }
 
     @JvmStatic
     fun i(tag: String, message: String, metadata: Map<String, String>? = null) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.i(tag, message)
+        if (isDebug) {
+            Log.i(TAG_PREFIX + tag, message)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.INFO, tag, message, concatGlobalMeta(metadata))
+            loggingAdapter.log(LogLevel.INFO, TAG_PREFIX + tag, message, concatGlobalMeta(metadata))
         })
     }
 
     @JvmStatic
     fun w(tag: String, message: String) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.w(tag, message)
+        if (isDebug) {
+            Log.w(TAG_PREFIX + tag, message)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.WARN, tag, message, concatGlobalMeta(null))
+            loggingAdapter.log(LogLevel.WARN, TAG_PREFIX + tag, message, concatGlobalMeta(null))
         })
     }
 
     @JvmStatic
     fun w(tag: String, message: String, metadata: Map<String, String>? = null) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.w(tag, message)
+        if (isDebug) {
+            Log.w(TAG_PREFIX + tag, message)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.WARN, tag, message, concatGlobalMeta(metadata))
+            loggingAdapter.log(LogLevel.WARN, TAG_PREFIX + tag, message, concatGlobalMeta(metadata))
         })
     }
 
     @JvmStatic
     fun e(tag: String, message: String) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.e(tag, message)
+        if (isDebug) {
+            Log.e(TAG_PREFIX + tag, message)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.error(tag, message, null, concatGlobalMeta(null))
+            loggingAdapter.error(TAG_PREFIX + tag, message, null, concatGlobalMeta(null))
         })
     }
 
     @JvmStatic
     fun e(tag: String, message: String, throwable: Throwable?) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.e(tag, message, throwable)
+        if (isDebug) {
+            Log.e(TAG_PREFIX + tag, message, throwable)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.error(tag, message, throwable, concatGlobalMeta(null))
+            loggingAdapter.error(TAG_PREFIX + tag, message, throwable, concatGlobalMeta(null))
         })
     }
 
     @JvmStatic
     fun e(tag: String, message: String, throwable: Throwable?, metadata: Map<String, String>? = null) {
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.e(tag, message, throwable)
+        if (isDebug) {
+            Log.e(TAG_PREFIX + tag, message, throwable)
+            // Normally, Widgets DEBUG build uses Core SDK with RELEASE build variant.
+            // Hence, Core will add ClientLoggerAdapter to loggingAdapters.
+            // Return to avoid sending logs to ClientLoggerAdapter for Widgets DEBUG build.
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.error(tag, message, throwable, concatGlobalMeta(metadata))
+            loggingAdapter.error(TAG_PREFIX + tag, message, throwable, concatGlobalMeta(metadata))
         })
     }
 
@@ -133,13 +171,15 @@ internal object Logger {
     fun logDeprecatedMethodUse(tag: String, methodName: String) {
         val logMessage = DEPRECATED_METHOD_CALL_LOG_MESSAGE + methodName
 
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.d(tag, logMessage)
+        if (!setOfUsedDeprecatedFunctions.add(logMessage)) return // Log only once per session
+
+        if (isDebug) {
+            // Do not log this event to console for debug builds because we see them in IDE
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.INFO, tag, logMessage, concatGlobalMeta(null))
+            loggingAdapter.log(LogLevel.INFO, TAG_PREFIX + tag, logMessage, concatGlobalMeta(null))
         })
     }
 
@@ -147,13 +187,15 @@ internal object Logger {
     fun logDeprecatedClassUse(tag: String) {
         val logMessage = DEPRECATED_CLASS_CALL_LOG_MESSAGE + tag
 
-        if (loggingAdapters.isEmpty() && BuildConfig.DEBUG) {
-            // Log to console even if there were no any logging adapter set for debug build
-            Log.d(tag, logMessage)
+        if (!setOfUsedDeprecatedClasses.add(logMessage)) return // Log only once per session
+
+        if (isDebug) {
+            // Do not log this event to console for debug builds because we see them in IDE
+            return
         }
 
         loggingAdapters.forEach(Consumer { loggingAdapter: LoggingAdapter ->
-            loggingAdapter.log(LogLevel.INFO, tag, logMessage, concatGlobalMeta(null))
+            loggingAdapter.log(LogLevel.INFO, TAG_PREFIX + tag, logMessage, concatGlobalMeta(null))
         })
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
@@ -71,6 +71,7 @@ class MessageCenterActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Logger.i(TAG, "Create Message Center screen")
         binding = MessageCenterActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -100,6 +101,11 @@ class MessageCenterActivity :
         messageCenterView.onPause()
 
         super.onPause()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Logger.i(TAG, "Destroy Message Center screen")
     }
 
     override fun selectAttachmentFile(type: String) {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
@@ -22,7 +22,9 @@ import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.core.fileupload.model.FileAttachment
 import com.glia.widgets.databinding.MessageCenterViewBinding
 import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.SimpleWindowInsetsAndAnimationHandler
+import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.Utils
 import com.glia.widgets.helper.asActivity
 import com.glia.widgets.helper.changeStatusBarColor
@@ -229,6 +231,7 @@ class MessageCenterView(
     }
 
     override fun showConfirmationScreen() {
+        Logger.i(TAG, "Show Message Center Confirmation screen")
         confirmationView?.fadeThrough(messageView!!)
 
         showConfirmationAppBar()

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.java
@@ -12,19 +12,24 @@ import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.InsetsKt;
+import com.glia.widgets.helper.Logger;
 
 public class SurveyActivity extends AppCompatActivity implements SurveyView.OnFinishListener {
+    private static final String TAG = SurveyActivity.class.getSimpleName();
+
     private SurveyView surveyView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Logger.i(TAG, "Create Survey screen");
         setContentView(R.layout.survey_activity);
         prepareSurveyView();
     }
 
     @Override
     protected void onDestroy() {
+        Logger.i(TAG, "Destroy Survey screen");
         hideSoftKeyboard();
         if (surveyView != null) {
             surveyView.onDestroyView();

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ButtonConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ButtonConfiguration.java
@@ -138,7 +138,7 @@ public class ButtonConfiguration implements Parcelable {
         }
 
         public ButtonConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(ButtonConfiguration.class.getSimpleName() + "." + TAG);
             if (textConfiguration == null) {
                 ResourceProvider resourceProvider = Dependencies.getResourceProvider();
                 textConfiguration = new TextConfiguration.Builder()

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ChatHeadConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ChatHeadConfiguration.java
@@ -241,7 +241,7 @@ public class ChatHeadConfiguration implements Parcelable {
         }
 
         public ChatHeadConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(ChatHeadConfiguration.class.getSimpleName() + "." + TAG);
             return new ChatHeadConfiguration(this);
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/LayerConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/LayerConfiguration.java
@@ -78,7 +78,7 @@ public class LayerConfiguration implements Parcelable {
 
         @SuppressLint("ResourceType")
         public LayerConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(LayerConfiguration.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             // Default configuration
             if (this.backgroundColor == null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/OptionButtonConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/OptionButtonConfiguration.java
@@ -104,7 +104,7 @@ public class OptionButtonConfiguration implements Parcelable {
         }
 
         public OptionButtonConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(OptionButtonConfiguration.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             if (this.normalText == null) {
                 this.normalText = prepareDefaultTextConfiguration(resourceProvider, R.color.glia_base_dark_color);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
@@ -147,7 +147,7 @@ public class TextConfiguration implements Parcelable {
         }
 
         public TextConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(TextConfiguration.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             // Default configuration
             if (this.textSize == 0) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/BooleanQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/BooleanQuestionConfiguration.java
@@ -59,7 +59,7 @@ public class BooleanQuestionConfiguration implements Parcelable {
         }
 
         public BooleanQuestionConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(BooleanQuestionConfiguration.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             if (this.title == null) {
                 this.title = prepareDefaultTitleConfiguration(resourceProvider);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
@@ -59,7 +59,7 @@ public class InputQuestionConfiguration implements Parcelable {
         }
 
         public InputQuestionConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(InputQuestionConfiguration.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             if (this.title == null) {
                 this.title = prepareDefaultTitleConfiguration(resourceProvider);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/ScaleQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/ScaleQuestionConfiguration.java
@@ -59,7 +59,7 @@ public class ScaleQuestionConfiguration implements Parcelable {
         }
 
         public ScaleQuestionConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(ScaleQuestionConfiguration.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             if (this.title == null) {
                 this.title = prepareDefaultTitleConfiguration(resourceProvider);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SingleQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SingleQuestionConfiguration.java
@@ -75,7 +75,7 @@ public class SingleQuestionConfiguration implements Parcelable {
 
         @SuppressLint("ResourceType")
         public SingleQuestionConfiguration build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(SingleQuestionConfiguration.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             if (this.title == null) {
                 this.title = prepareDefaultTitleConfiguration(resourceProvider);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SurveyStyle.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SurveyStyle.java
@@ -176,7 +176,7 @@ public class SurveyStyle implements Parcelable {
         }
 
         public SurveyStyle build() {
-            Logger.logDeprecatedClassUse(TAG);
+            Logger.logDeprecatedClassUse(SurveyStyle.class.getSimpleName() + "." + TAG);
             ResourceProvider resourceProvider = Dependencies.getResourceProvider();
 
             if (this.layerConfiguration == null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
@@ -107,6 +107,7 @@ internal class ActivityWatcherForChatHead(
             activity.runOnUiThread {
                 chatHeadLayout.get()?.let {
                     if (!viewGroup.contains(it)) {
+                        Logger.i(TAG, "Bubble: show application-only bubble")
                         viewGroup.addView(it)
                     } else {
                         Logger.e(TAG, "Duplicate bubble adding detected")
@@ -119,7 +120,7 @@ internal class ActivityWatcherForChatHead(
     }
 
     override fun removeChatHeadLayoutIfPresent() {
-        Logger.d(TAG, "Removing application-only bubble")
+        Logger.d(TAG, "Bubble: remove application-only bubble")
         saveBubblePosition()
         (fetchGliaOrRootView() as? ViewGroup)?.removeView(chatHeadLayout.get())
         chatHeadLayout.clear()

--- a/widgetssdk/src/test/java/com/glia/widgets/core/permissions/PermissionManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/permissions/PermissionManagerTest.kt
@@ -7,13 +7,17 @@ import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.GliaException
+import com.glia.widgets.helper.Logger
 import com.glia.widgets.permissions.Permissions
 import com.glia.widgets.permissions.PermissionsGrantedCallback
 import com.glia.widgets.permissions.PermissionsRequestRepository
 import com.glia.widgets.permissions.PermissionsRequestResult
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
@@ -28,6 +32,7 @@ class PermissionManagerTest {
     private lateinit var permissionsRequestRepository: PermissionsRequestRepository
 
     private lateinit var permissionManager: PermissionManager
+    private var logger: MockedStatic<Logger>? = null
 
     @Before
     fun setUp() {
@@ -41,6 +46,12 @@ class PermissionManagerTest {
             permissionsRequestRepository,
             Build.VERSION_CODES.R
         )
+        logger = Mockito.mockStatic(Logger::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        logger?.close()
     }
 
     // Tests for .getPermissionsForEngagementMediaType()

--- a/widgetssdk/src/test/java/com/glia/widgets/helper/LoggerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/helper/LoggerTest.kt
@@ -2,6 +2,7 @@ package com.glia.widgets.helper
 
 import com.glia.androidsdk.LogLevel
 import com.glia.androidsdk.LoggingAdapter
+import com.glia.widgets.helper.Logger.TAG_PREFIX
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -14,14 +15,17 @@ class LoggerTest {
         val error: Throwable = RuntimeException()
         val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
         Logger.addAdapter(loggingAdapter)
+        Logger.setIsDebug(false)
+
         Logger.d(LoggerTest.TAG, MESSAGE)
         Logger.i(LoggerTest.TAG, MESSAGE)
         Logger.w(LoggerTest.TAG, MESSAGE)
         Logger.e(LoggerTest.TAG, MESSAGE, error)
-        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, emptyMap())
-        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, emptyMap())
-        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, emptyMap())
-        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, emptyMap())
+
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, TAG_PREFIX + LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, TAG_PREFIX + LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, TAG_PREFIX + LoggerTest.TAG, MESSAGE, emptyMap())
+        Mockito.verify(loggingAdapter).error(TAG_PREFIX + LoggerTest.TAG, MESSAGE, error, emptyMap())
     }
 
     @Test
@@ -30,14 +34,17 @@ class LoggerTest {
         val loggingAdapter = Mockito.mock(LoggingAdapter::class.java)
         Logger.addAdapter(loggingAdapter)
         val metadata = Collections.singletonMap("key", "value")
+        Logger.setIsDebug(false)
+
         Logger.d(LoggerTest.TAG, MESSAGE, metadata)
         Logger.i(LoggerTest.TAG, MESSAGE, metadata)
         Logger.w(LoggerTest.TAG, MESSAGE, metadata)
         Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
-        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, metadata)
-        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, metadata)
-        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, metadata)
-        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, metadata)
+
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, TAG_PREFIX + LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, TAG_PREFIX + LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, TAG_PREFIX + LoggerTest.TAG, MESSAGE, metadata)
+        Mockito.verify(loggingAdapter).error(TAG_PREFIX + LoggerTest.TAG, MESSAGE, error, metadata)
     }
 
     @Test
@@ -51,14 +58,17 @@ class LoggerTest {
         combinedMetadata.putAll(metadata)
         combinedMetadata.putAll(globalMeta)
         Logger.addGlobalMetadata(globalMeta)
+        Logger.setIsDebug(false)
+
         Logger.d(LoggerTest.TAG, MESSAGE, metadata)
         Logger.i(LoggerTest.TAG, MESSAGE, metadata)
         Logger.w(LoggerTest.TAG, MESSAGE, metadata)
         Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
-        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, LoggerTest.TAG, MESSAGE, combinedMetadata)
-        Mockito.verify(loggingAdapter).log(LogLevel.INFO, LoggerTest.TAG, MESSAGE, combinedMetadata)
-        Mockito.verify(loggingAdapter).log(LogLevel.WARN, LoggerTest.TAG, MESSAGE, combinedMetadata)
-        Mockito.verify(loggingAdapter).error(LoggerTest.TAG, MESSAGE, error, combinedMetadata)
+
+        Mockito.verify(loggingAdapter).log(LogLevel.DEBUG, TAG_PREFIX + LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.INFO, TAG_PREFIX + LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).log(LogLevel.WARN, TAG_PREFIX + LoggerTest.TAG, MESSAGE, combinedMetadata)
+        Mockito.verify(loggingAdapter).error(TAG_PREFIX + LoggerTest.TAG, MESSAGE, error, combinedMetadata)
         Logger.removeGlobalMetadata("globalKey")
     }
 
@@ -71,11 +81,14 @@ class LoggerTest {
         val combinedMetadata: MutableMap<String, String> = HashMap()
         combinedMetadata.putAll(metadata)
         combinedMetadata.putAll(globalMeta)
+        Logger.setIsDebug(false)
+
         Logger.addGlobalMetadata(globalMeta)
         Logger.d(LoggerTest.TAG, MESSAGE, metadata)
         Logger.i(LoggerTest.TAG, MESSAGE, metadata)
         Logger.w(LoggerTest.TAG, MESSAGE, metadata)
         Logger.e(LoggerTest.TAG, MESSAGE, error, metadata)
+
         Mockito.verify(loggingAdapter, never()).log(any(), any(), any(), any())
         Logger.removeGlobalMetadata("globalKey")
     }


### PR DESCRIPTION
[Developers want to send logs with important events that could help them debug issues](https://glia.atlassian.net/browse/MOB-2810)

**What was solved?**
- Added new logs for important events
- Renamed some existing events
- Removed some useless/duplicated logs
- Changed to send logs for deprecated functions and classes only once per session
- Turned off sending  logs for deprecated functions and classes to console for debug builds because integrators see them in IDE
- Added "Glia Widgets" to prefix
- Prevented sending logs to client logger from `debug` Widgets SDK builds with `release` Core SDK

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [x] Logging for future troubleshooting of client issues added?

Collected all Widgets SDK events to a [Logging events](https://docs.google.com/spreadsheets/d/1ty9bhrbX3VTXBThI5f4GFzy5X-RbEHOCPWfXd7nGzbo/edit#gid=0) doc.
