### PR TITLE
Remove queuing animation when current engagement is restored

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -17,7 +17,6 @@ import com.glia.androidsdk.omnicore.OmnicoreEngagement
 import com.glia.androidsdk.site.SiteInfo
 import com.glia.widgets.Constants
 import com.glia.widgets.GliaWidgets
-import com.glia.widgets.R
 import com.glia.widgets.chat.ChatManager
 import com.glia.widgets.chat.ChatType
 import com.glia.widgets.chat.ChatView
@@ -679,6 +678,8 @@ internal class ChatController(
     }
 
     private fun viewInitPreQueueing() {
+        if (isOngoingEngagementUseCase()) return
+
         Logger.d(TAG, "viewInitPreQueueing")
         chatManager.onChatAction(ChatManager.Action.QueuingStarted(chatState.companyName.orEmpty()))
         confirmationDialogUseCase{ shouldShow ->

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementStateRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementStateRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.processors.BehaviorProcessor;
+import io.reactivex.processors.ReplayProcessor;
 
 public class GliaEngagementStateRepository {
     private final EngagementStateEventVisitor<Operator> visitor = new EngagementStateEventVisitor.OperatorVisitor();
@@ -27,9 +28,7 @@ public class GliaEngagementStateRepository {
 
     private final BehaviorProcessor<Optional<EngagementState>> engagementStateProcessor = BehaviorProcessor.createDefault(Optional.empty());
 
-    private final BehaviorProcessor<EngagementStateEvent> engagementStateEventProcessor = BehaviorProcessor.createDefault(
-        new EngagementStateEvent.NoEngagementEvent()
-    );
+    private final ReplayProcessor<EngagementStateEvent> engagementStateEventProcessor = ReplayProcessor.createWithSize(20);
     private final Flowable<EngagementStateEvent> engagementStateEventFlowable = engagementStateEventProcessor.onBackpressureLatest();
     private final GliaOperatorRepository operatorRepository;
     private CompositeDisposable disposable = new CompositeDisposable();

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
@@ -14,7 +14,8 @@ internal class ManagerFactory(private val useCaseFactory: UseCaseFactory) {
                 appendNewChatMessageUseCase = createAppendNewChatMessageUseCase(),
                 sendUnsentMessagesUseCase = createSendUnsentMessagesUseCase(),
                 handleCustomCardClickUseCase = createHandleCustomCardClickUseCase(),
-                isAuthenticatedUseCase = createIsAuthenticatedUseCase()
+                isAuthenticatedUseCase = createIsAuthenticatedUseCase(),
+                isOngoingEngagementUseCase = createIsOngoingEngagementUseCase()
             )
         }
 }


### PR DESCRIPTION
MOB 2926

**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**
- I have optimized the chat history loading process to prevent unnecessary history requests.
- Prevent `ChatController.viewInitPreQueueing()` for ongoing engagements, this will prevent queuing state addition
- `private final ReplayProcessor<EngagementStateEvent> engagementStateEventProcessor = ReplayProcessor.createWithSize(20);` this is a really stupid solution, but I didn't find anything better, because we're starting to push states way before subscribing to them in the chat screen so `Operator Connected` state is getting lost for restored engagements. This part is already refactored in #849 so this is temp. solution.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
