### PR TITLE
Changed default screen sharing mode

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
+++ b/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
@@ -132,7 +132,7 @@ object ExampleAppConfigManager {
         val bounded = context.getString(R.string.screen_sharing_mode_app_bounded)
         val unbounded = context.getString(R.string.screen_sharing_mode_unbounded)
         val screenSharingMode = if (
-            preferences.getString(context.getString(R.string.pref_screen_sharing_mode), unbounded) == bounded
+            preferences.getString(context.getString(R.string.pref_screen_sharing_mode), bounded) == bounded
         ) {
             ScreenSharing.Mode.APP_BOUNDED
         } else {

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -240,6 +240,6 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
 
     companion object {
         const val DEFAULT_USE_OVERLAY = true
-        val DEFAULT_SCREEN_SHARING_MODE = ScreenSharing.Mode.UNBOUNDED
+        val DEFAULT_SCREEN_SHARING_MODE = ScreenSharing.Mode.APP_BOUNDED
     }
 }


### PR DESCRIPTION
MOB-2945

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2945

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [X] Release notes (Is it clear from the description here?)
 - [X] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**
Default screen sharing mode is changed from `UNBOUNDED` to `APP_BOUNDED`. To have the same screen sharing capabilities the screen sharing modes need to be specified during initialisation.
 
```
 GliaWidgetsConfig widgetsConfig = new GliaWidgetsConfig.Builder()
     ...
     .setScreenSharingMode(screenSharingMode)
     ...                
.build();
``` 