### PR TITLE
Update Core SDK dependency to latest development build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
     // Internal maven repository with Core SDK build from `feature/live-observation` branch
     // TODO: delete before merging to `development` branch
-    maven { url "https://s01.oss.sonatype.org/content/repositories/comglia-1248" }
+    maven { url "https://s01.oss.sonatype.org/content/repositories/comglia-1250" }
   }
 }
 


### PR DESCRIPTION
**What was solved?**
Nullpoint error fix related to screen-sharing have been solved in the latest Core SDK build

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

