### PR TITLE
Fix IllegalStateException: for NotificationRemovalService

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/INotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/INotificationManager.kt
@@ -6,4 +6,5 @@ interface INotificationManager {
     fun removeCallNotification()
     fun showScreenSharingNotification()
     fun removeScreenSharingNotification()
+    fun startNotificationRemovalService()
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
@@ -62,7 +62,6 @@ internal class NotificationManager(private val applicationContext: Application, 
                 NotificationFactory.CALL_NOTIFICATION_ID,
                 NotificationFactory.createAudioCallNotification(applicationContext)
             )
-            startNotificationRemovalService()
         }
     }
 
@@ -72,11 +71,12 @@ internal class NotificationManager(private val applicationContext: Application, 
                 NotificationFactory.CALL_NOTIFICATION_ID,
                 NotificationFactory.createVideoCallNotification(applicationContext, isTwoWayVideo, hasAudio)
             )
-            startNotificationRemovalService()
         }
     }
 
-    private fun startNotificationRemovalService() {
+    override fun startNotificationRemovalService() {
+        // If this service is not already running, it will be instantiated and started (creating a process for it if needed);
+        // if it is running then it remains running.
         applicationContext.startService(
             Intent(applicationContext, NotificationRemovalService::class.java)
         )

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -204,6 +204,7 @@ public class Dependencies {
         lifecycleManager.addObserver((source, event) -> {
             if (event == Lifecycle.Event.ON_STOP) {
                 chatBubbleController.onApplicationStop();
+                notificationManager.startNotificationRemovalService();
             } else if (event == Lifecycle.Event.ON_DESTROY) {
                 chatBubbleController.onDestroy();
             }


### PR DESCRIPTION
[MOB-2837](https://glia.atlassian.net/browse/MOB-2837)

**Crash details:**
```
java.lang.IllegalStateException: Not allowed to start service Intent { com.glia.widgets.core.notification.NotificationRemovalService }: app is in background
```
Example from Sentry is [here](https://glia.sentry.io/issues/4766376086/?alert_rule_id=967509&alert_timestamp=1703689998756&alert_type=email&environment=prod-us&notification_uuid=097e6631-f490-4032-8f8f-622acb0a80d3&project=1887832&referrer=alert_email).

This happens if an app is in the background for 60+ seconds and `NotificationRemovalService` is attempted to be started.

**What was solved?**
Lets start `NotificationRemovalService` when app goes to 'OnStop' to make sure the service is not attempted to start after app being in background for over than 60 seconds.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Release note:**
Fix IllegalStateException: for NotificationRemovalService

[MOB-2837]: https://glia.atlassian.net/browse/MOB-2837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
