### PR TITLE
Fix IllegalStateException: for ChatHeadService

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/ChatHeadManager.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/ChatHeadManager.java
@@ -3,8 +3,12 @@ package com.glia.widgets.core.chathead;
 import android.content.Context;
 import android.content.Intent;
 
+import com.glia.widgets.helper.Logger;
+
 
 public class ChatHeadManager {
+    private static final String TAG = ChatHeadManager.class.getSimpleName();
+
     private final Context applicationContext;
     private final Intent chatHeadServiceIntent;
 
@@ -20,7 +24,24 @@ public class ChatHeadManager {
     public void startChatHeadService() {
         if (!isServiceStarted) {
             isServiceStarted = true;
-            applicationContext.startService(chatHeadServiceIntent);
+            try {
+                applicationContext.startService(chatHeadServiceIntent);
+            } catch (IllegalStateException exception) {
+                isServiceStarted = false;
+                Logger.w(TAG, "Application is in a state where the service can not be started" +
+                    " (such as not in the foreground in a state when services are allowed)");
+                // This prevents the 'Not allowed to start ChatHeadService: app is in background' crash.
+                // Example scenario:
+                // Disable the 'Display over other apps' Android setting for Widgets example app
+                // Open Widgets example app, tap 'Start new chat flow'
+                // Tap 'OK' for 'Screen Overlay Permissions Required' dialog, you will be navigated to Android Settings
+                // Open Widgets example app, go to the main screen to have chat bubble displayed
+                // Come back to Android Settings, allow the 'Display over other apps' setting
+                // Tap device Home button (bubble is not displayed)
+                // Go to Glia Hub, wait for 60+ seconds
+                // Accept engagement
+                // IllegalStateException will be caught. Once visitor opens Widgets example app, bubble will be displayed and start working.
+            }
         }
     }
 


### PR DESCRIPTION
These changes will prevent the `IllegalStateException: Not allowed to start service ChatHeadService: app is in background` crash. A crash example is [here](https://glia.sentry.io/issues/4599728998/events/2fddaf124e8140beb2bcf286d8efcdea/?project=1887832).

[MOB-2974](https://glia.atlassian.net/browse/MOB-2974)

**What was solved?**
Crash details are described in the comments to the code. The reason is the same as for [IllegalStateException: for NotificationRemovalService](https://github.com/salemove/android-sdk-widgets/pull/874). However, the fix that I came up with is different. Taking into account two peculiarities:

1. We cannot start `ChatHeadService` before engagement is started or it's not straightforward to do this
2. `ChatHeadService` is attempted to be started once the app is resumed again

I decided that surrounding the `startService()` call with a `try` - `catch` block might prevent the crash, bubble will still be displayed once the app is in the foreground again.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [x] Logging for future troubleshooting of client issues added?

**Release note:**
Fix IllegalStateException: for ChatHeadService


[MOB-2974]: https://glia.atlassian.net/browse/MOB-2974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ