### PR TITLE
Temporary file cleanup after use during camera capture

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -386,6 +386,12 @@ class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defSty
 
     private fun setupChatStateCallback() {
         callback = object : ChatViewCallback {
+            override fun clearTempFile() {
+                controller?.photoCaptureFileUri?.let {
+                    context.contentResolver.delete(it, null, null)
+                }
+            }
+
             override fun emitUploadAttachments(attachments: List<FileAttachment>) {
                 post { uploadAttachmentAdapter.submitList(attachments) }
             }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatViewCallback.java
@@ -58,4 +58,6 @@ public interface ChatViewCallback {
     void showEngagementConfirmationDialog();
 
     void navigateToWebBrowserActivity(String title, String url);
+
+    void clearTempFile();
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -971,6 +971,7 @@ internal class ChatController(
             object : AddFileToAttachmentAndUploadUseCase.Listener {
                 override fun onFinished() {
                     Logger.d(TAG, "fileUploadFinished")
+                    viewCallback?.clearTempFile()
                 }
 
                 override fun onStarted() {
@@ -979,6 +980,7 @@ internal class ChatController(
 
                 override fun onError(ex: Exception) {
                     Logger.e(TAG, "Upload file failed: " + ex.message)
+                    viewCallback?.clearTempFile()
                 }
 
                 override fun onSecurityCheckStarted() {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
@@ -42,5 +42,6 @@ interface MessageCenterContract {
         fun showAttachmentPopup()
         fun showConfirmationScreen()
         fun hideSoftKeyboard()
+        fun clearTemporaryFile(uri: Uri?)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
@@ -206,6 +206,8 @@ internal class MessageCenterController(
             object : AddFileToAttachmentAndUploadUseCase.Listener {
                 override fun onFinished() {
                     Logger.d(TAG, "fileUploadFinished")
+                    view?.clearTemporaryFile(photoCaptureFileUri)
+                    photoCaptureFileUri = null
                 }
 
                 override fun onStarted() {
@@ -214,6 +216,8 @@ internal class MessageCenterController(
 
                 override fun onError(ex: Exception) {
                     Logger.e(TAG, "Upload file failed: " + ex.message)
+                    view?.clearTemporaryFile(photoCaptureFileUri)
+                    photoCaptureFileUri = null
                 }
 
                 override fun onSecurityCheckStarted() {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.messagecenter
 import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.Color
+import android.net.Uri
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.Window
@@ -236,6 +237,12 @@ class MessageCenterView(
 
     override fun hideSoftKeyboard() {
         insetsController?.hideKeyboard()
+    }
+
+    override fun clearTemporaryFile(uri: Uri?) {
+        uri?.let {
+            context.contentResolver.delete(it, null, null)
+        }
     }
 
     override fun setController(controller: MessageCenterContract.Controller?) {


### PR DESCRIPTION
MOB-2858

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2858

During camera capture attachment, the created file was left in the application file structure visible to anyone. Implemented a way to cleanup after file is used to ensure no residual files left over after engagement.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [X] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)