### PR TITLE
Do not mute visitor audio when operator puts engagement on Hold

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/visitor/GliaVisitorMediaRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/visitor/GliaVisitorMediaRepository.java
@@ -3,6 +3,8 @@ package com.glia.widgets.core.visitor;
 import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.comms.Media;
 import com.glia.androidsdk.comms.VisitorMediaState;
+import com.glia.widgets.helper.Logger;
+
 import java.util.HashSet;
 import java.util.Set;
 import io.reactivex.Completable;
@@ -118,7 +120,6 @@ public class GliaVisitorMediaRepository {
     private void visitorAudioMediaStatusOnHold(boolean isOnHold) {
         if (isOnHold) {
             saveVisitorAudioStatus();
-            muteVisitorAudio();
         } else {
             restoreVisitorAudioStatus();
         }


### PR DESCRIPTION
[MOB-2988](https://glia.atlassian.net/browse/MOB-2988)

**Steps to reproduce:**
1) Start a video session using an Android device
2) Have the agent place the session on hold
3) Have the agent take the session off hold
4) The member will see that audio and video are muted on the device
5) The member clicks to unmute the audio and video on the device
6) The member tries to talk to the agent, the agent will not be able to hear
7) The issue can be fixed by the agent placing the call on hold and then taking the call off of hold again or the member can fix the issue by muting audio and video and then unmuting audio and video

**What was solved?**
The issue is not reproduced in Davit's [refactoring branch](https://github.com/salemove/android-sdk-widgets/tree/end_engagement_refactoring).

I think the main difference is that in that branch audio is not paused when the operator puts engagement on hold, as far as I understand.

Tried this for the `development` branch and it fixes the issue. I can prepare a build for testing for CE.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Release notes:**
Operators want to hear visitors after on Hold


[MOB-2988]: https://glia.atlassian.net/browse/MOB-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ