### PR TITLE
Improved chat start timer conditions to match call controller

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -913,7 +913,7 @@ internal class ChatController(
             upgradeMediaItemToVideo()
         } else if (!chatState.isMediaUpgradeStarted) {
             addMediaUpgradeItemToChatItems(operatorMediaState)
-            if (!callTimer.isRunning) {
+            if (chatState.isOperatorOnline && !callTimer.isRunning && timerStatusListener != null) {
                 startTimer()
             }
         }


### PR DESCRIPTION
MOB-2836

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2836

Improved start timer conditions during chat to match the implementation during a video call to prevent IllegalStateException: Task already scheduled or cancelled.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)