### PR TITLE
Fix Confirmation Dialog overlaps with Overlay Dialog

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.java
@@ -21,8 +21,8 @@ public class DialogController {
     private final DialogManager dialogManager;
 
     public DialogController(
-            SetOverlayPermissionRequestDialogShownUseCase setOverlayPermissionRequestDialogShownUseCase,
-            SetEnableCallNotificationChannelDialogShownUseCase setEnableCallNotificationChannelDialogShownUseCase
+        SetOverlayPermissionRequestDialogShownUseCase setOverlayPermissionRequestDialogShownUseCase,
+        SetEnableCallNotificationChannelDialogShownUseCase setEnableCallNotificationChannelDialogShownUseCase
     ) {
         this.setOverlayPermissionRequestDialogShownUseCase = setOverlayPermissionRequestDialogShownUseCase;
         this.setEnableCallNotificationChannelDialogShownUseCase = setEnableCallNotificationChannelDialogShownUseCase;
@@ -155,7 +155,11 @@ public class DialogController {
 
     public void showEngagementConfirmationDialog() {
         Logger.d(TAG, "Show Live Observation Opt In Dialog");
-        dialogManager.addAndEmit(new DialogState(Dialog.MODE_LIVE_OBSERVATION_OPT_IN));
+        if (isOverlayDialogShown() || isExitQueueDialogShown()) {
+            dialogManager.add(new DialogState(Dialog.MODE_LIVE_OBSERVATION_OPT_IN));
+        } else {
+            dialogManager.addAndEmit(new DialogState(Dialog.MODE_LIVE_OBSERVATION_OPT_IN));
+        }
     }
 
     public void addCallback(Callback callback) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2985

**What was solved?**
Currently, If the Overlay dialog is shown, the Confirmation dialog replaces the Overlay dialog, and that looks not so user-friendly. It’s better to put the Confirmation dialog into a queue until the OverlayDialog is dismissed.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
