### PR TITLE
Added snapshot tests for visitor code dialog

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/CharCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/CharCodeView.kt
@@ -2,6 +2,7 @@ package com.glia.widgets.view
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.Gravity
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -82,6 +83,7 @@ class CharCodeView @JvmOverloads constructor(
         charView.isFocusable = false
         charView.text = character.toString()
         charView.textAlignment = TEXT_ALIGNMENT_CENTER
+        charView.gravity = Gravity.CENTER
         charView.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
 
         applyRuntimeTheme(runtimeTheme, charView)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
@@ -40,6 +40,7 @@ import com.glia.widgets.view.unifiedui.applyProgressColorTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.google.android.material.theme.overlay.MaterialThemeOverlay
+import java.util.concurrent.Executor
 
 /**
  * A view for displaying the visitor code to the visitor.
@@ -49,7 +50,8 @@ import com.google.android.material.theme.overlay.MaterialThemeOverlay
  * Use [CallVisualizer.createVisitorCodeView] to create an instance of this view.
  */
 class VisitorCodeView internal constructor(
-    context: Context
+    context: Context,
+    private val uiThreadExecutor: Executor? = null
 ) : FrameLayout(MaterialThemeOverlay.wrap(context, null, 0, R.style.Application_Glia_Chat), null, 0), VisitorCodeContract.View {
     private lateinit var controller: VisitorCodeContract.Controller
     private var theme: UiTheme? = null
@@ -189,12 +191,16 @@ class VisitorCodeView internal constructor(
             progressBar.visibility = View.VISIBLE
         } else {
             progressBar.visibility = View.GONE
-            charCodeView.animate().alpha(1f).duration = 200
+            charCodeView.animate().apply {
+                alpha(1f)
+                duration = 200
+                start()
+            }
         }
     }
 
     private fun runOnUi(function: () -> Unit) {
-        post(function)
+        uiThreadExecutor?.execute(function) ?: post(function)
     }
 
     private fun applyRemoteThemeConfig(theme: UnifiedTheme?) {

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_error.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_error.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1453fab19d91589d96df9d0e1c73f4340ed47e233db7a9133d1f9cd515119254
+size 28421

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5254908999273224072200a9d7f523bcf8571019accfb888df061329bb6f0c02
+size 28143

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithUiTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithUiTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b57f8dd3963633c6669f3f63de9a15dcae6c3eab3d4cfb74848716d5d39bd996
+size 19857

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:730b7aab4461eb9436eea70d3f30d7173f70875a80dc5cd17cb5b5f09898989b
+size 44552

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithUnifiedThemeWithoutVisitorCode.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_errorWithUnifiedThemeWithoutVisitorCode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1453fab19d91589d96df9d0e1c73f4340ed47e233db7a9133d1f9cd515119254
+size 28421

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_loading.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_loading.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5efd3b359fb0bc38b09d71f3307025423b3c612650dd28acb951ad7bd246c31
+size 25490

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCode.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5a24e3944d7f630adb597fe2fc55d09102d76f663053200a9523979a94a95b4
+size 36671

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6983cff13d1fe529dc6d045a1b9d644856cb6ac664982c77195ddbf1cccbbb66
+size 38864

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithUiTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithUiTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e8d2e9e5e5a87f765ef2cf07ed8f022770931bcf1881cb0953230de730ac9c0
+size 30038

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:814f4d931a0f63c9486172614c9ffd5127444592570dbb4d60c62db11a298352
+size 56172

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithUnifiedThemeWithoutVisitorCode.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_VisitorCodeDialogTest_visitorCodeWithUnifiedThemeWithoutVisitorCode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5a24e3944d7f630adb597fe2fc55d09102d76f663053200a9523979a94a95b4
+size 36671

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/VisitorCodeDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/VisitorCodeDialogTest.kt
@@ -1,0 +1,210 @@
+package com.glia.widgets.dialog
+
+import com.glia.androidsdk.omnibrowse.VisitorCode
+import com.glia.widgets.R
+import com.glia.widgets.SnapshotTest
+import com.glia.widgets.StringProvider
+import com.glia.widgets.UiTheme
+import com.glia.widgets.core.configuration.GliaSdkConfigurationManager
+import com.glia.widgets.di.ControllerFactory
+import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.ResourceProvider
+import com.glia.widgets.snapshotutils.SnapshotStringProvider
+import com.glia.widgets.view.VisitorCodeView
+import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
+import com.google.gson.JsonObject
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.concurrent.Executor
+
+class VisitorCodeDialogTest : SnapshotTest() {
+
+    override fun tearDown() {
+        super.tearDown()
+
+        Dependencies.getGliaThemeManager().theme = null
+    }
+
+    @Test
+    fun visitorCode() {
+        snapshotFullWidth(
+            setupView().apply {
+                startLoading()
+                showVisitorCode(code())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun visitorCodeWithUiTheme() {
+        snapshotFullWidth(
+            setupView(
+                uiTheme = uiTheme()
+            ).apply {
+                startLoading()
+                showVisitorCode(code())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun visitorCodeWithGlobalColors() {
+        snapshotFullWidth(
+            setupView(
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            ).apply {
+                startLoading()
+                showVisitorCode(code())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun visitorCodeWithUnifiedTheme() {
+        snapshotFullWidth(
+            setupView(
+                unifiedTheme = unifiedTheme()
+            ).apply {
+                startLoading()
+                showVisitorCode(code())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun visitorCodeWithUnifiedThemeWithoutVisitorCode() {
+        snapshotFullWidth(
+            setupView(
+                unifiedTheme = unifiedThemeWithoutVisitorCode()
+            ).apply {
+                startLoading()
+                showVisitorCode(code())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun error() {
+        snapshotFullWidth(
+            setupView().apply {
+                setClosable(true)
+                startLoading()
+                showError(Throwable())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun errorWithUiTheme() {
+        snapshotFullWidth(
+            setupView(
+                uiTheme = uiTheme()
+            ).apply {
+                setClosable(true)
+                startLoading()
+                showError(Throwable())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun errorWithGlobalColors() {
+        snapshotFullWidth(
+            setupView(
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            ).apply {
+                setClosable(true)
+                startLoading()
+                showError(Throwable())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun errorWithUnifiedTheme() {
+        snapshotFullWidth(
+            setupView(
+                unifiedTheme = unifiedTheme()
+            ).apply {
+                setClosable(true)
+                startLoading()
+                showError(Throwable())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun errorWithUnifiedThemeWithoutVisitorCode() {
+        snapshotFullWidth(
+            setupView(
+                unifiedTheme = unifiedThemeWithoutVisitorCode()
+            ).apply {
+                setClosable(true)
+                startLoading()
+                showError(Throwable())
+            },
+            offsetMillis = 200
+        )
+    }
+
+    @Test
+    fun loading() {
+        snapshotFullWidth(
+            setupView().apply {
+                setClosable(true)
+                startLoading() // Unfortunately, the progress bar is not snapped
+            }
+        )
+    }
+
+    private fun setupView(
+        uiTheme: UiTheme = UiTheme(),
+        unifiedTheme: UnifiedTheme? = null,
+        executor: Executor? = Executor(Runnable::run)
+    ): VisitorCodeView {
+        unifiedTheme?.let { Dependencies.getGliaThemeManager().theme = it }
+        val configurationManager = GliaSdkConfigurationManager().also {
+            it.uiTheme = uiTheme
+        }
+        val controllerFactoryMock: ControllerFactory = mock<ControllerFactory>().also {
+            whenever(it.visitorCodeController).thenReturn(mock())
+        }
+        val rp = ResourceProvider(context)
+        val sp: StringProvider = SnapshotStringProvider(context)
+        Dependencies.setSdkConfigurationManager(configurationManager)
+        Dependencies.setControllerFactory(controllerFactoryMock)
+        Dependencies.setResourceProvider(rp)
+        Dependencies.setStringProvider(sp)
+
+        return VisitorCodeView(context, executor).apply {
+            notifySetupComplete()
+        }
+    }
+
+    private fun code(
+        code: String = "12345",
+        duration: Long = 10000
+    ): VisitorCode = mock<VisitorCode>().also {
+        whenever(it.code).thenReturn(code)
+        whenever(it.duration).thenReturn(duration)
+    }
+
+    private fun unifiedThemeWithoutVisitorCode(): UnifiedTheme = unifiedTheme(R.raw.test_unified_config) { unifiedTheme ->
+        unifiedTheme.add(
+            "callVisualizer",
+            (unifiedTheme.remove("callVisualizer") as JsonObject).also {
+                it.remove("visitorCode")
+            }
+        )
+    }
+}

--- a/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
+++ b/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
@@ -1059,5 +1059,121 @@
         "#04728c"
       ]
     }
+  },
+  "callVisualizer": {
+    "visitorCode": {
+      "actionButton": {
+        "background": {
+          "color": {
+            "type": "gradient",
+            "value": ["#ffd03b", "#e76810"]
+          },
+          "border": {
+            "type": "fill",
+            "value": ["#a20013"]
+          },
+          "borderWidth": 6,
+          "cornerRadius": 26
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#ff3ff0"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 8
+        },
+        "text": {
+          "alignment": "trailing",
+          "background": {
+            "type": "gradient",
+            "value": ["#edff00", "#ff6a1e"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "gradient",
+            "value": ["#2e54ff", "#70ffe7"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#24ff11"]
+        }
+      },
+      "background": {
+        "color": {
+          "type": "gradient",
+          "value": ["#c2ff38", "#ede0cd"]
+        },
+        "border": {
+          "type": "fill",
+          "value": ["#00abe7"]
+        },
+        "borderWidth": 6,
+        "cornerRadius": 26
+      },
+      "closeButtonColor": {
+        "type": "gradient",
+        "value": ["#25e72c", "#4f82e7"]
+      },
+      "numberSlotBackground": {
+        "color": {
+          "type": "gradient",
+          "value": ["#3c0039", "#073c3a"]
+        },
+        "border": {
+          "type": "fill",
+          "value": ["#e7677e"]
+        },
+        "borderWidth": 6,
+        "cornerRadius": 26
+      },
+      "numberSlotText": {
+        "alignment": "trailing",
+        "background": {
+          "type": "fill",
+          "value": [
+            "#3c3722"
+          ]
+        },
+        "font": {
+          "size": 26,
+          "style": "bold_italic"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": [
+            "#f6ff68"
+          ]
+        }
+      },
+      "loadingProgressColor": {
+        "type": "gradient",
+        "value": ["#d300e7", "#e7b111"]
+      },
+      "title": {
+        "alignment": "trailing",
+        "background": {
+          "type": "fill",
+          "value": [
+            "#acff7d"
+          ]
+        },
+        "font": {
+          "size": 13,
+          "style": "bold"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": [
+            "#7f27d8"
+          ]
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
**Jira issue:**
[MOB-2953](https://glia.atlassian.net/browse/MOB-2953)

**What was solved?**
Added snapshot tests for visitor code dialog.
Unfortunately, the progress bar is not displayed on the screenshots. Because of this, the Loading state tests do not make a lot of sense. I skiped to add them.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**


[MOB-2953]: https://glia.atlassian.net/browse/MOB-2953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ