### PR TITLE
Fix access modifiers in Kotlin

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/StringProviderImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/StringProviderImpl.kt
@@ -6,7 +6,7 @@ import com.glia.androidsdk.GliaException
 import com.glia.widgets.helper.Logger
 import java.lang.Exception
 
-class StringProviderImpl(private val resourceProvider: ResourceProvider) : StringProvider {
+internal class StringProviderImpl(private val resourceProvider: ResourceProvider) : StringProvider {
 
     private val regex = "(\\{[a-zA-Z\\d]*\\})".toRegex()
     private var shouldLog = true

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallButtonLabelView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallButtonLabelView.kt
@@ -5,7 +5,7 @@ import android.util.AttributeSet
 import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.call.BarButtonStatesTheme
 
-class CallButtonLabelView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+internal class CallButtonLabelView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     ThemedStateText(context, attrs) {
 
     private var barButtonStatesTheme: BarButtonStatesTheme? = null

--- a/widgetssdk/src/main/java/com/glia/widgets/call/ThemedStateText.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/ThemedStateText.kt
@@ -9,7 +9,7 @@ import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
-open class ThemedStateText @JvmOverloads constructor(
+internal open class ThemedStateText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : AppCompatTextView(context, attrs) {

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerSupportActivity.kt
@@ -12,7 +12,7 @@ class CallVisualizerSupportActivity : AppCompatActivity() {
 }
 
 @Parcelize
-sealed class PermissionType : Parcelable
-object ScreenSharing : PermissionType()
-object Camera : PermissionType()
-object None : PermissionType()
+internal sealed class PermissionType : Parcelable
+internal object ScreenSharing : PermissionType()
+internal object Camera : PermissionType()
+internal object None : PermissionType()

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/GvaChip.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/GvaChip.kt
@@ -20,7 +20,7 @@ import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.android.material.transition.MaterialFadeThrough
 
-class GvaChip @JvmOverloads constructor(
+internal class GvaChip @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = com.google.android.material.R.attr.chipStyle
@@ -64,7 +64,7 @@ class GvaChip @JvmOverloads constructor(
     }
 }
 
-class GvaChipGroup @JvmOverloads constructor(
+internal class GvaChipGroup @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = com.google.android.material.R.attr.chipGroupStyle

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/UploadAttachmentAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/UploadAttachmentAdapter.kt
@@ -38,7 +38,7 @@ import com.google.android.material.R as Material_R
 /**
  * [DiffUtil.ItemCallback] for [FileAttachment] type
  */
-class UploadAttachmentItemCallback : DiffUtil.ItemCallback<FileAttachment>() {
+internal class UploadAttachmentItemCallback : DiffUtil.ItemCallback<FileAttachment>() {
     override fun areItemsTheSame(oldItem: FileAttachment, newItem: FileAttachment): Boolean =
         oldItem.uri == newItem.uri
 
@@ -49,7 +49,7 @@ class UploadAttachmentItemCallback : DiffUtil.ItemCallback<FileAttachment>() {
 /**
  * Upload File Attachment Adapter
  */
-class UploadAttachmentAdapter(private val isMessageCenter: Boolean = false) :
+internal class UploadAttachmentAdapter(private val isMessageCenter: Boolean = false) :
     ListAdapter<FileAttachment, ViewHolder>(UploadAttachmentItemCallback()) {
     private var callback: ItemCallback? = null
     private val stringProvider = Dependencies.getStringProvider()
@@ -74,7 +74,7 @@ class UploadAttachmentAdapter(private val isMessageCenter: Boolean = false) :
 /**
  * ViewHolder
  */
-class ViewHolder(
+internal class ViewHolder(
     private val binding: ChatAttachmentUploadedItemBinding,
     isMessageCenter: Boolean
 ) : RecyclerView.ViewHolder(binding.root) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/CustomCardAdapterTypeUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/CustomCardAdapterTypeUseCase.kt
@@ -3,7 +3,7 @@ package com.glia.widgets.chat.domain
 import com.glia.androidsdk.chat.ChatMessage
 import com.glia.widgets.chat.adapter.CustomCardAdapter
 
-class CustomCardAdapterTypeUseCase(private val adapter: CustomCardAdapter?) {
+internal class CustomCardAdapterTypeUseCase(private val adapter: CustomCardAdapter?) {
     operator fun invoke(message: ChatMessage): Int? = when {
         adapter == null || message.metadata == null || message.metadata!!.length() == 0 -> null
         else -> adapter.getChatAdapterViewType(message)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/IsAuthenticatedUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/IsAuthenticatedUseCase.kt
@@ -2,6 +2,6 @@ package com.glia.widgets.chat.domain
 
 import com.glia.androidsdk.visitor.Authentication
 
-class IsAuthenticatedUseCase(private val authentication: Authentication) {
+internal class IsAuthenticatedUseCase(private val authentication: Authentication) {
     operator fun invoke(): Boolean = authentication.isAuthenticated
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/SendMessagePayload.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/SendMessagePayload.kt
@@ -4,7 +4,7 @@ import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.widgets.core.fileupload.model.FileAttachment
 
-class SendMessagePayload private constructor(
+internal class SendMessagePayload private constructor(
     val content: String,
     val fileAttachments: List<FileAttachment>?,
     val payload: com.glia.androidsdk.chat.SendMessagePayload

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/VisitorCodeRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/domain/VisitorCodeRepository.kt
@@ -5,7 +5,7 @@ import com.glia.androidsdk.omnibrowse.VisitorCode
 import com.glia.widgets.di.GliaCore
 import io.reactivex.Observable
 
-class VisitorCodeRepository(private val gliaCore: GliaCore) {
+internal class VisitorCodeRepository(private val gliaCore: GliaCore) {
 
     fun getVisitorCode(): Observable<VisitorCode> {
         if (!gliaCore.isInitialized) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/domain/ConfirmationDialogLinksUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/domain/ConfirmationDialogLinksUseCase.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.StringProvider
 import com.glia.widgets.core.dialog.model.Link
 import com.glia.widgets.core.dialog.model.ConfirmationDialogLinks
 
-class ConfirmationDialogLinksUseCase(
+internal class ConfirmationDialogLinksUseCase(
     private val stringProvider: StringProvider
 ) {
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/model/ConfirmationDialogLinks.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/model/ConfirmationDialogLinks.kt
@@ -1,11 +1,11 @@
 package com.glia.widgets.core.dialog.model
 
-data class ConfirmationDialogLinks(
+internal data class ConfirmationDialogLinks(
     val link1: Link? = null,
     val link2: Link? = null
 )
 
-data class Link(
+internal data class Link(
     val title: String,
     val url: String
 )

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementConfigRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaEngagementConfigRepository.kt
@@ -2,7 +2,7 @@ package com.glia.widgets.core.engagement
 
 import com.glia.widgets.chat.ChatType
 
-class GliaEngagementConfigRepository {
+internal class GliaEngagementConfigRepository {
     var queueIds = emptyArray<String>()
     var chatType = ChatType.LIVE_CHAT
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/INotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/INotificationManager.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.core.notification.device
 
-interface INotificationManager {
+internal interface INotificationManager {
     fun showAudioCallNotification()
     fun showVideoCallNotification(isTwoWayVideo: Boolean, hasAudio: Boolean)
     fun removeCallNotification()

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/CallNotificationUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/CallNotificationUseCase.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.core.notification.device.INotificationManager
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
 
-class CallNotificationUseCase(
+internal class CallNotificationUseCase(
     private val notificationManager: INotificationManager
 ) {
     operator fun invoke(visitorMedia: MediaState? = null, operatorMedia: MediaState? = null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/ShowScreenSharingNotificationUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/ShowScreenSharingNotificationUseCase.kt
@@ -2,6 +2,6 @@ package com.glia.widgets.core.notification.domain
 
 import com.glia.widgets.core.notification.device.INotificationManager
 
-class ShowScreenSharingNotificationUseCase(private val notificationManager: INotificationManager) {
+internal class ShowScreenSharingNotificationUseCase(private val notificationManager: INotificationManager) {
     operator fun invoke() = notificationManager.showScreenSharingNotification()
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
@@ -19,6 +19,8 @@ import com.glia.widgets.permissions.PermissionsGrantedCallback
 import com.glia.widgets.permissions.PermissionsRequestRepository
 import com.glia.widgets.permissions.PermissionsRequestResult
 
+internal typealias CheckSelfPermission = (context: Context, permission: String) -> Int
+
 internal class PermissionManager(
     private val applicationContext: Context,
     private val checkSelfPermission: CheckSelfPermission,
@@ -130,5 +132,3 @@ internal class PermissionManager(
         permissionsRequestRepository.requestPermissions(permissions, callback)
     }
 }
-
-typealias CheckSelfPermission = (context: Context, permission: String) -> Int

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SendMessageRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SendMessageRepository.kt
@@ -3,7 +3,7 @@ package com.glia.widgets.core.secureconversations
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 
-class SendMessageRepository {
+internal class SendMessageRepository {
     private val _observable = BehaviorSubject.createDefault("")
 
     val observable: Observable<String> = _observable

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCase.kt
@@ -16,7 +16,7 @@ private const val TAG = "GetUnreadMessagesCountUseCase"
  * @see [GetUnreadMessagesCountWithTimeoutUseCase.invoke]
  */
 @VisibleForTesting
-const val TIMEOUT_SEC = 3L
+internal const val TIMEOUT_SEC = 3L
 
 internal const val NO_UNREAD_MESSAGES = 0
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/OnNextMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/OnNextMessageUseCase.kt
@@ -2,7 +2,7 @@ package com.glia.widgets.core.secureconversations.domain
 
 import com.glia.widgets.core.secureconversations.SendMessageRepository
 
-class OnNextMessageUseCase(private val sendMessageRepository: SendMessageRepository) {
+internal class OnNextMessageUseCase(private val sendMessageRepository: SendMessageRepository) {
     operator fun invoke(message: String) {
         sendMessageRepository.onNextMessage(message)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/ShowMessageLimitErrorUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/ShowMessageLimitErrorUseCase.kt
@@ -4,7 +4,7 @@ import com.glia.widgets.core.secureconversations.SendMessageRepository
 import com.glia.widgets.helper.rx.Schedulers
 import io.reactivex.Observable
 
-class ShowMessageLimitErrorUseCase(
+internal class ShowMessageLimitErrorUseCase(
     private val sendMessageRepository: SendMessageRepository,
     private val schedulers: Schedulers
 ) {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -24,7 +24,7 @@ import java.io.InputStream
 import java.util.Optional
 import java.util.function.Consumer
 
-interface GliaCore {
+internal interface GliaCore {
     val isInitialized: Boolean
     val pushNotifications: PushNotifications
     val currentEngagement: Optional<Engagement>

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/data/GliaFileRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/data/GliaFileRepository.kt
@@ -6,7 +6,7 @@ import io.reactivex.Completable
 import io.reactivex.Maybe
 import java.io.InputStream
 
-interface GliaFileRepository {
+internal interface GliaFileRepository {
     fun isReadyForPreview(attachmentFile: AttachmentFile): Boolean
     fun loadImageFromCache(fileName: String): Maybe<Bitmap>
     fun putImageToCache(fileName: String, bitmap: Bitmap)

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/DownloadFileUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/DownloadFileUseCase.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.filepreview.domain.exception.FileNameMissingException
 import com.glia.widgets.filepreview.domain.exception.RemoteFileIsDeletedException
 import io.reactivex.Completable
 
-class DownloadFileUseCase(private val fileRepository: GliaFileRepository) {
+internal class DownloadFileUseCase(private val fileRepository: GliaFileRepository) {
     operator fun invoke(file: AttachmentFile): Completable = when {
         file.name.isEmpty() -> Completable.error(FileNameMissingException())
         file.isDeleted -> Completable.error(RemoteFileIsDeletedException())

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/GetImageFileFromCacheUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/GetImageFileFromCacheUseCase.kt
@@ -5,7 +5,7 @@ import com.glia.widgets.filepreview.data.GliaFileRepository
 import com.glia.widgets.filepreview.domain.exception.FileNameMissingException
 import io.reactivex.Maybe
 
-class GetImageFileFromCacheUseCase(private val gliaFileRepository: GliaFileRepository) {
+internal class GetImageFileFromCacheUseCase(private val gliaFileRepository: GliaFileRepository) {
     operator fun invoke(fileName: String?): Maybe<Bitmap> {
         return if (fileName.isNullOrEmpty()) {
             Maybe.error(FileNameMissingException())

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/GetImageFileFromDownloadsUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/domain/usecase/GetImageFileFromDownloadsUseCase.kt
@@ -5,7 +5,7 @@ import com.glia.widgets.filepreview.data.GliaFileRepository
 import com.glia.widgets.filepreview.domain.exception.FileNameMissingException
 import io.reactivex.Maybe
 
-class GetImageFileFromDownloadsUseCase(private val gliaFileRepository: GliaFileRepository) {
+internal class GetImageFileFromDownloadsUseCase(private val gliaFileRepository: GliaFileRepository) {
     operator fun invoke(fileName: String?): Maybe<Bitmap> {
         return if (fileName.isNullOrEmpty()) {
             Maybe.error(FileNameMissingException())

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/FilePreviewView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/FilePreviewView.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.widget.AppCompatImageView
 import com.glia.widgets.R
 import com.glia.widgets.di.Dependencies
 
-class FilePreviewView @JvmOverloads constructor(
+internal class FilePreviewView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : AppCompatImageView(context, attrs) {

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/State.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/State.kt
@@ -3,7 +3,7 @@ package com.glia.widgets.filepreview.ui
 import android.graphics.Bitmap
 import com.glia.widgets.helper.toFileName
 
-data class State(
+internal data class State(
     val imageLoadingState: ImageLoadingState = ImageLoadingState.INITIAL,
     val isShowShareButton: Boolean = false,
     val isShowDownloadButton: Boolean = false,

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Data.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Data.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.helper
 
-sealed class Data<out T> {
+internal sealed class Data<out T> {
     val hasValue: Boolean get() = this is Value
 
     data class Value<out T>(val result: T) : Data<T>()

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Files.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Files.kt
@@ -133,7 +133,7 @@ internal fun getContentUriCompat(fileName: String, context: Context): Uri =
     }
 
 @Throws(IOException::class)
-fun createTempPhotoFile(context: Context): File {
+internal fun createTempPhotoFile(context: Context): File {
     val directoryStorage = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
     directoryStorage?.deleteOnExit()
     return File.createTempFile(generatePhotoFileName(), ".jpg", directoryStorage)
@@ -144,7 +144,7 @@ private fun generatePhotoFileName(): String =
         "IMG_${format(Date())}"
     }
 
-fun mapUriToFileAttachment(contentResolver: ContentResolver, uri: Uri): FileAttachment? =
+internal fun mapUriToFileAttachment(contentResolver: ContentResolver, uri: Uri): FileAttachment? =
     contentResolver.query(uri, null, null, null, null)?.use {
         if (it.count == 0) return@use null
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/WeakReferenceDelegate.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/WeakReferenceDelegate.kt
@@ -3,7 +3,7 @@ package com.glia.widgets.helper
 import java.lang.ref.WeakReference
 import kotlin.reflect.KProperty
 
-class WeakReferenceDelegate<T>(initializer: () -> T? = { null }) {
+internal class WeakReferenceDelegate<T>(initializer: () -> T? = { null }) {
 
     private var weakReference: WeakReference<T> = WeakReference(initializer())
 

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/ConfirmationScreenView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/ConfirmationScreenView.kt
@@ -23,7 +23,7 @@ import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.secureconversations.SecureConversationsConfirmationScreenTheme
 import com.google.android.material.transition.MaterialFadeThrough
 
-class ConfirmationScreenView(
+internal class ConfirmationScreenView(
     context: Context,
     attrs: AttributeSet?,
     defStyleAttr: Int,

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterState.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterState.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.messagecenter
 
-data class MessageCenterState(
+internal data class MessageCenterState(
     val addAttachmentButtonVisible: Boolean = false,
     val addAttachmentButtonEnabled: Boolean = true,
     val messageEditTextEnabled: Boolean = true,

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageView.kt
@@ -39,7 +39,7 @@ import com.google.android.material.button.MaterialButton
 import java.util.concurrent.Executor
 import kotlin.properties.Delegates
 
-class MessageView(
+internal class MessageView(
     context: Context,
     attrs: AttributeSet?,
     defStyleAttr: Int,

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/ProgressButton.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/ProgressButton.kt
@@ -26,7 +26,7 @@ import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.google.android.material.transition.MaterialFade
 
-class ProgressButton @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+internal class ProgressButton @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     FrameLayout(context, attrs) {
 
     private val adapterCallback: StatefulWidgetAdapterCallback<State, ButtonTheme> =

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/StatefulEditText.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/StatefulEditText.kt
@@ -15,7 +15,7 @@ import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextInputTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
-class StatefulEditText @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+internal class StatefulEditText @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     AppCompatEditText(context, attrs) {
     private val adapterCallback: StatefulWidgetAdapterCallback<State, TextInputTheme> =
         StatefulWidgetAdapterCallback { updateTheme(it) }

--- a/widgetssdk/src/main/java/com/glia/widgets/permissions/PermissionsRequestCallbacks.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/permissions/PermissionsRequestCallbacks.kt
@@ -2,6 +2,6 @@ package com.glia.widgets.permissions
 
 import com.glia.androidsdk.GliaException
 
-typealias PermissionsRequestResult = (result: Map<String, Boolean>?, exception: GliaException?) -> Unit
+internal typealias PermissionsRequestResult = (result: Map<String, Boolean>?, exception: GliaException?) -> Unit
 
-typealias PermissionsGrantedCallback = (granted: Boolean) -> Unit
+internal typealias PermissionsGrantedCallback = (granted: Boolean) -> Unit

--- a/widgetssdk/src/main/java/com/glia/widgets/permissions/PermissionsRequestContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/permissions/PermissionsRequestContract.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.permissions
 
-class PermissionsRequestContract {
+internal class PermissionsRequestContract {
     interface Controller {
         fun setWatcher(watcher: Watcher)
         fun onActivityResumed()

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyAdapter.kt
@@ -16,7 +16,7 @@ import com.glia.widgets.survey.viewholder.SingleQuestionViewHolder
 import com.glia.widgets.survey.viewholder.SurveyViewHolder
 import com.glia.widgets.view.configuration.survey.SurveyStyle
 
-class SurveyAdapter(private val listener: SurveyAdapterListener) :
+internal class SurveyAdapter(private val listener: SurveyAdapterListener) :
     RecyclerView.Adapter<SurveyViewHolder>() {
     interface SurveyAdapterListener {
         fun onAnswer(answer: Survey.Answer)

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyView.kt
@@ -37,7 +37,7 @@ import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
 import kotlin.properties.Delegates
 
-class SurveyView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) :
+internal class SurveyView(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) :
     FrameLayout(
         context.wrapWithMaterialThemeOverlay(attrs, defStyleAttr, defStyleRes),
         attrs,

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/BooleanQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/BooleanQuestionViewHolder.kt
@@ -14,7 +14,7 @@ import com.glia.widgets.view.unifiedui.applyOptionButtonTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyBooleanQuestionTheme
 
-class BooleanQuestionViewHolder(
+internal class BooleanQuestionViewHolder(
     private val binding: SurveyBooleanQuestionItemBinding,
     style: SurveyStyle
 ) : SurveyViewHolder(binding.root, binding.tvTitle, binding.requiredError) {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/InputQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/InputQuestionViewHolder.kt
@@ -24,7 +24,7 @@ import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.glia.widgets.view.unifiedui.theme.survey.OptionButtonTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyInputQuestionTheme
 
-class InputQuestionViewHolder(
+internal class InputQuestionViewHolder(
     val binding: SurveyInputQuestionItemBinding,
     val style: SurveyStyle
 ) : SurveyViewHolder(binding.root, binding.tvTitle, binding.requiredError) {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/ScaleQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/ScaleQuestionViewHolder.kt
@@ -12,7 +12,7 @@ import com.glia.widgets.view.unifiedui.applyOptionButtonTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyScaleQuestionTheme
 
-class ScaleQuestionViewHolder(
+internal class ScaleQuestionViewHolder(
     private val binding: SurveyScaleQuestionItemBinding,
     private var style: SurveyStyle
 ) : SurveyViewHolder(binding.root, binding.tvTitle, binding.requiredError) {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SingleQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SingleQuestionViewHolder.kt
@@ -23,7 +23,7 @@ import com.glia.widgets.view.unifiedui.theme.survey.SurveySingleQuestionTheme
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 
-class SingleQuestionViewHolder(
+internal class SingleQuestionViewHolder(
     private val binding: SurveySingleQuestionItemBinding,
     var style: SurveyStyle
 ) : SurveyViewHolder(binding.root, binding.tvTitle, binding.requiredError) {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SurveyViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SurveyViewHolder.kt
@@ -13,7 +13,7 @@ import com.glia.widgets.survey.QuestionItem
 import com.glia.widgets.survey.SurveyAdapter
 import com.glia.widgets.survey.SurveyController
 
-abstract class SurveyViewHolder(
+internal abstract class SurveyViewHolder(
     itemView: View,
     val title: TextView,
     private val requiredError: View

--- a/widgetssdk/src/main/java/com/glia/widgets/view/OperatorStatusView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/OperatorStatusView.kt
@@ -24,7 +24,7 @@ import com.google.android.material.imageview.ShapeableImageView
 import com.squareup.picasso.Picasso
 import kotlin.properties.Delegates
 
-class OperatorStatusView @JvmOverloads constructor(
+internal class OperatorStatusView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,

--- a/widgetssdk/src/main/java/com/glia/widgets/view/SingleChoiceCardView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/SingleChoiceCardView.kt
@@ -29,7 +29,7 @@ import com.glia.widgets.view.unifiedui.theme.chat.ResponseCardTheme
 import com.google.android.material.button.MaterialButton
 import kotlin.properties.Delegates
 
-class SingleChoiceCardView @JvmOverloads constructor(
+internal class SingleChoiceCardView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewBinding.kt
@@ -7,7 +7,7 @@ import android.widget.TextView
 import com.glia.widgets.databinding.AlertDialogBinding
 import com.glia.widgets.view.dialog.base.DialogViewBinding
 
-class AlertDialogViewBinding(layoutInflater: LayoutInflater) : DialogViewBinding<AlertDialogBinding> {
+internal class AlertDialogViewBinding(layoutInflater: LayoutInflater) : DialogViewBinding<AlertDialogBinding> {
     override val binding: AlertDialogBinding = AlertDialogBinding.inflate(layoutInflater)
     override val root: View
         get() = binding.root

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/BadgeTextView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/BadgeTextView.kt
@@ -17,7 +17,7 @@ import com.google.android.material.textview.MaterialTextView
 import kotlin.math.max
 import com.google.android.material.R as Material_R
 
-class BadgeTextView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+internal class BadgeTextView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     MaterialTextView(context, attrs) {
 
     init {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
@@ -33,7 +33,7 @@ import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.google.android.material.appbar.AppBarLayout
 
-class AppBarView @JvmOverloads constructor(
+internal class AppBarView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.gliaChatStyle

--- a/widgetssdk/src/main/java/com/glia/widgets/webbrowser/WebBrowserView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/webbrowser/WebBrowserView.kt
@@ -28,7 +28,7 @@ import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
 import com.google.android.material.theme.overlay.MaterialThemeOverlay
 import kotlin.properties.Delegates
 
-class WebBrowserView(
+internal class WebBrowserView(
     context: Context,
     attrs: AttributeSet?,
     defStyleAttr: Int,


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/GR-553

**What was solved?**
Reviewed all Kotlin classes and limited access to 'internal' for classes/properties are not supposed to be used by integrators or declared in Manifest.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Hiden a ton of SDK internal classes making them less visible to the integrators.)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

