### PR TITLE
Fixed java ambiguous reference error for GliaWidgetsConfig

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -121,12 +121,16 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
             private set
         var uiJsonRemoteConfig: String? = null
             private set
-
         var companyName: String? = null
+            private set
         var screenSharingMode: ScreenSharing.Mode? = null
+            private set
         var useOverlay: Boolean? = null
+            private set
         var uiTheme: UiTheme? = null
+            private set
         var manualLocaleOverride: String? = null
+            private set
 
         /**
          * @param siteId - your site ID


### PR DESCRIPTION
**Jira issue:**
This was referenced during caretaking in this issue https://glia.atlassian.net/browse/SSD-42186

**What was solved?**
Calling GliaWidgetsConfig from Java classes some values were not able to set due to ambiguous reference error originating from an incomplete Java to Kotlin conversion of a builder class.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)