### PR TITLE
Make SimpleTextWatcher and GliaSdkConfigurations internal

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -21,6 +21,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.PreferenceManager
+import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.fcm.GliaPushMessage
@@ -28,12 +29,12 @@ import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.androidsdk.visitor.Authentication
 import com.glia.exampleapp.ExampleAppConfigManager.createDefaultConfig
 import com.glia.widgets.GliaWidgets
+import com.glia.widgets.GliaWidgetsConfig
 import com.glia.widgets.UiTheme
 import com.glia.widgets.call.CallActivity
 import com.glia.widgets.call.Configuration
 import com.glia.widgets.chat.ChatActivity
 import com.glia.widgets.chat.ChatType
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.messagecenter.MessageCenterActivity
 import com.google.android.material.appbar.MaterialToolbar
 import kotlin.concurrent.thread
@@ -41,19 +42,6 @@ import kotlin.concurrent.thread
 class MainFragment : Fragment() {
     private var containerView: ConstraintLayout? = null
     private var authentication: Authentication? = null
-
-    private val configuration: GliaSdkConfiguration
-        get() {
-            val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
-            return GliaSdkConfiguration.Builder()
-                .companyName(getCompanyNameFromPrefs(sharedPreferences))
-                .contextAssetId(getContextAssetIdFromPrefs(sharedPreferences))
-                .queueId(getQueueIdFromPrefs(sharedPreferences))
-                .runTimeTheme(getRuntimeThemeFromPrefs(sharedPreferences))
-                .screenSharingMode(getScreenSharingModeFromPrefs(sharedPreferences))
-                .useOverlay(getUseOverlay(sharedPreferences))
-                .build()
-        }
 
     private val authToken: String
         get() {
@@ -219,13 +207,15 @@ class MainFragment : Fragment() {
         startActivity(intent)
     }
 
-    private fun navigateToCall(mediaType: String?) {
-        val configBuilder = Configuration.Builder.builder()
-            .setWidgetsConfiguration(configuration)
-        if (!TextUtils.isEmpty(mediaType)) {
-            configBuilder.setMediaType(mediaType)
-        }
-        val intent = CallActivity.getIntent(requireContext(), configBuilder.build())
+    private fun navigateToCall(mediaType: String) {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        val intent = Intent(context, CallActivity::class.java)
+            .putExtra(GliaWidgets.QUEUE_ID, getQueueIdFromPrefs(sharedPreferences))
+            .putExtra(GliaWidgets.CONTEXT_ASSET_ID, getContextAssetIdFromPrefs(sharedPreferences))
+            .putExtra(GliaWidgets.UI_THEME, getRuntimeThemeFromPrefs(sharedPreferences))
+            .putExtra(GliaWidgets.USE_OVERLAY, getUseOverlay(sharedPreferences))
+            .putExtra(GliaWidgets.SCREEN_SHARING_MODE, getScreenSharingModeFromPrefs(sharedPreferences))
+            .putExtra(GliaWidgets.MEDIA_TYPE, Utils.toMediaType(mediaType))
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/glia/exampleapp/Utils.java
+++ b/app/src/main/java/com/glia/exampleapp/Utils.java
@@ -5,11 +5,14 @@ import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
 
+import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.screensharing.ScreenSharing;
+import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.view.configuration.ButtonConfiguration;
 import com.glia.widgets.view.configuration.ChatHeadConfiguration;
@@ -17,6 +20,8 @@ import com.glia.widgets.view.configuration.TextConfiguration;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.security.InvalidParameterException;
 
 class Utils {
 
@@ -300,6 +305,17 @@ class Utils {
             return ScreenSharing.Mode.APP_BOUNDED;
         } else {
             return ScreenSharing.Mode.UNBOUNDED;
+        }
+    }
+
+    public static Engagement.MediaType toMediaType(@NonNull String mediaType) {
+        switch (mediaType) {
+            case GliaWidgets.MEDIA_TYPE_VIDEO:
+                return Engagement.MediaType.VIDEO;
+            case GliaWidgets.MEDIA_TYPE_AUDIO:
+                return Engagement.MediaType.AUDIO;
+            default:
+                throw new InvalidParameterException("Invalid Media Type");
         }
     }
 }

--- a/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
@@ -17,7 +17,6 @@ import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.visitor.VisitorInfo
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest
-import com.glia.widgets.helper.SimpleTextWatcher
 import java.util.UUID
 
 class VisitorInfoFragment : Fragment() {
@@ -173,7 +172,15 @@ private class CustomAttributesAdapter: RecyclerView.Adapter<CustomAttributesAdap
         private var onTextChanged: (() -> Unit)? = null
 
         init {
-            val textWatcher: TextWatcher = object : SimpleTextWatcher() {
+            val textWatcher: TextWatcher = object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                    // Nothing to do
+                }
+
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                    // Nothing to do
+                }
+
                 override fun afterTextChanged(editable: Editable) {
                     onTextChanged?.let { it() }
                 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.kt
@@ -9,7 +9,7 @@ import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.Logger.logDeprecatedMethodUse
 import com.glia.widgets.helper.TAG
 
-class GliaSdkConfiguration private constructor(builder: Builder) {
+internal class GliaSdkConfiguration private constructor(builder: Builder) {
     val companyName: String?
     val queueId: String?
     val contextAssetId: String?

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/SimpleTextWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/SimpleTextWatcher.kt
@@ -3,7 +3,7 @@ package com.glia.widgets.helper
 import android.text.Editable
 import android.text.TextWatcher
 
-abstract class SimpleTextWatcher : TextWatcher {
+internal abstract class SimpleTextWatcher : TextWatcher {
     override fun beforeTextChanged(charSequence: CharSequence, start: Int, count: Int, after: Int) {}
 
     override fun onTextChanged(charSequence: CharSequence, start: Int, before: Int, count: Int) {}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/GR-553

**What was solved?**
Two classes were public and even used in the TestApp even though they are not supposed to be public
Unless integrators were using those undocumented classes this should not affect them

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes 
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
