### PR TITLE
Remove resetting EngagementRepository from SetEngagementConfigUseCase

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/SetEngagementConfigUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/domain/SetEngagementConfigUseCase.kt
@@ -2,19 +2,10 @@ package com.glia.widgets.core.engagement.domain
 
 import com.glia.widgets.chat.ChatType
 import com.glia.widgets.core.engagement.GliaEngagementConfigRepository
-import com.glia.widgets.engagement.EngagementRepository
 
-internal class SetEngagementConfigUseCase(
-    private val engagementConfigRepository: GliaEngagementConfigRepository,
-    private val engagementRepository: EngagementRepository
-) {
+internal class SetEngagementConfigUseCase(private val engagementConfigRepository: GliaEngagementConfigRepository) {
     operator fun invoke(chatType: ChatType, queueIds: Array<String>) {
         engagementConfigRepository.chatType = chatType
         engagementConfigRepository.queueIds = queueIds
-
-        // Resetting just in case there is a pending Survey
-        if (chatType == ChatType.SECURE_MESSAGING) {
-            engagementRepository.reset()
-        }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -594,10 +594,7 @@ public class UseCaseFactory {
 
     @NonNull
     public SetEngagementConfigUseCase createSetEngagementConfigUseCase() {
-        return new SetEngagementConfigUseCase(
-            repositoryFactory.getEngagementConfigRepository(),
-            repositoryFactory.getEngagementRepository()
-        );
+        return new SetEngagementConfigUseCase(repositoryFactory.getEngagementConfigRepository());
     }
 
     @NonNull


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3035

**What was solved?**
Will fix cases 3 and 4 from the `Exploratory Testing Session`.

Currently, there is no chance to have a `pending` survey at the point we're trying to reset the `EngagementRepository`.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
