### PR TITLE
Added missing configurability to chathead screen sharing icon

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -25,6 +25,7 @@
         <item name="gliaIconCallMinimize">@drawable/ic_person</item>
         <item name="gliaEndScreenShareTintColor">@color/color_pure_yellow</item>
         <item name="gliaIconEndScreenShare">@drawable/ic_screensharing</item>
+        <item name="gliaIconScreenSharingDialog">@drawable/ic_screensharing_off</item>
         <item name="gliaBrandPrimaryColor">@color/color_pure_yellow</item>
         <item name="gliaVisitorCodeStyle">@style/TextAppearance.AppCompat</item>
         <item name="gliaAlertDialogButtonUseVerticalAlignment">true</item>

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -252,7 +252,7 @@ internal class ActivityWatcherForCallVisualizer(
 
     override fun showAllowScreenSharingNotificationsAndStartSharingDialog() {
         showAlertDialogOnUiThreadWithStyledContext(
-            "Show screen sharing and notifications dialog"
+            "Show screen sharing and notifications dialog",
         ) { context, uiTheme, _ ->
             Dialogs.showAllowScreenSharingNotificationsAndStartSharingDialog(
                 context = context,
@@ -268,7 +268,9 @@ internal class ActivityWatcherForCallVisualizer(
     }
 
     override fun showOverlayPermissionsDialog() {
-        showAlertDialogOnUiThreadWithStyledContext("Show overlay permissions dialog") { context, uiTheme, _ ->
+        showAlertDialogOnUiThreadWithStyledContext(
+            "Show overlay permissions dialog"
+        ) { context, uiTheme, _ ->
             Dialogs.showOverlayPermissionsDialog(
                 context = context,
                 uiTheme = uiTheme,

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -252,7 +252,7 @@ internal class ActivityWatcherForCallVisualizer(
 
     override fun showAllowScreenSharingNotificationsAndStartSharingDialog() {
         showAlertDialogOnUiThreadWithStyledContext(
-            "Show screen sharing and notifications dialog",
+            "Show screen sharing and notifications dialog"
         ) { context, uiTheme, _ ->
             Dialogs.showAllowScreenSharingNotificationsAndStartSharingDialog(
                 context = context,
@@ -268,9 +268,7 @@ internal class ActivityWatcherForCallVisualizer(
     }
 
     override fun showOverlayPermissionsDialog() {
-        showAlertDialogOnUiThreadWithStyledContext(
-            "Show overlay permissions dialog"
-        ) { context, uiTheme, _ ->
+        showAlertDialogOnUiThreadWithStyledContext("Show overlay permissions dialog") { context, uiTheme, _ ->
             Dialogs.showOverlayPermissionsDialog(
                 context = context,
                 uiTheme = uiTheme,
@@ -300,10 +298,10 @@ internal class ActivityWatcherForCallVisualizer(
         }
     }
 
-    override fun showUpgradeDialog(mediaUpgradeState: DialogState.MediaUpgrade) {
+    override fun showUpgradeDialog(mediaUpgrade: DialogState.MediaUpgrade) {
         showAlertDialogOnUiThreadWithStyledContext("Show upgrade dialog") { context, uiTheme, _ ->
-            Dialogs.showUpgradeDialog(context, uiTheme, mediaUpgradeState, {
-                controller.onMediaUpgradeReceived(mediaUpgradeState.mediaUpgradeOffer)
+            Dialogs.showUpgradeDialog(context, uiTheme, mediaUpgrade, {
+                controller.onMediaUpgradeReceived(mediaUpgrade.mediaUpgradeOffer)
                 dialogController.dismissCurrentDialog()
             }) {
                 controller.onNegativeDialogButtonClicked()

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingView.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.callvisualizer
 import android.content.Context
 import android.util.AttributeSet
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.content.withStyledAttributes
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
@@ -76,6 +77,9 @@ internal class EndScreenSharingView(
         context.withStyledAttributes(attrs, R.styleable.GliaView, defStyleAttr, defStyleRes) {
             defaultStatusBarColor = context.asActivity()?.window?.statusBarColor
             var theme = Utils.getThemeFromTypedArray(this, context)
+            theme.iconEndScreenShare?.let {
+                binding.endSharingButton.icon = ResourcesCompat.getDrawable(context.resources, it, null)
+            }
             theme = theme.getFullHybridTheme(Dependencies.getSdkConfigurationManager().uiTheme)
             applyRuntimeTheme(theme)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -710,7 +710,6 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         binding.addAttachmentQueue.adapter = uploadAttachmentAdapter
         binding.appBarView.setTheme(theme)
         binding.appBarView.setTitle(stringProvider.getRemoteString(R.string.engagement_chat_title))
-
         // icons
         theme.iconSendMessage?.also(binding.sendButton::setImageResource)
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ContextExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ContextExtensions.kt
@@ -11,8 +11,8 @@ import androidx.annotation.DimenRes
 import androidx.annotation.IntRange
 import androidx.annotation.StyleRes
 import androidx.core.content.withStyledAttributes
-import com.glia.widgets.BuildConfig
 import com.glia.widgets.GliaWidgets
+import com.glia.widgets.BuildConfig
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.google.android.material.theme.overlay.MaterialThemeOverlay
@@ -52,12 +52,6 @@ internal fun Context.showToast(
 internal val Activity.rootView: View
     get() = findViewById(android.R.id.content) ?: window.decorView.findViewById(android.R.id.content)
 
-internal val Activity.qualifiedName: String
-    get() = this::class.qualifiedName!!
-
-internal val Activity.isGlia: Boolean
-    get() = qualifiedName.startsWith(BuildConfig.LIBRARY_PACKAGE_NAME)
-
 internal fun Activity.withRuntimeTheme(callback: (themedContext: Context, uiTheme: UiTheme) -> Unit) {
     val themedContext = wrapWithMaterialThemeOverlay()
 
@@ -67,3 +61,9 @@ internal fun Activity.withRuntimeTheme(callback: (themedContext: Context, uiThem
         callback(themedContext, Utils.getThemeFromTypedArray(this, themedContext).withConfigurationTheme)
     }
 }
+
+internal val Activity.qualifiedName: String
+    get() = this::class.qualifiedName!!
+
+internal val Activity.isGlia: Boolean
+    get() = qualifiedName.startsWith(BuildConfig.LIBRARY_PACKAGE_NAME)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ChatHeadConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ChatHeadConfiguration.java
@@ -15,6 +15,7 @@ public class ChatHeadConfiguration implements Parcelable {
     private final Integer backgroundColorRes;
     private final Integer iconOnHold;
     private final Integer iconOnHoldTintList;
+    private final Integer iconScreenSharingDialog;
 
     private ChatHeadConfiguration(
             Builder builder
@@ -27,6 +28,7 @@ public class ChatHeadConfiguration implements Parcelable {
         backgroundColorRes = builder.backgroundColorRes;
         iconOnHold = builder.iconOnHold;
         iconOnHoldTintList = builder.iconOnHoldTintList;
+        iconScreenSharingDialog = builder.iconScreenSharingDialog;
     }
 
     protected ChatHeadConfiguration(Parcel in) {
@@ -69,6 +71,11 @@ public class ChatHeadConfiguration implements Parcelable {
             iconOnHoldTintList = null;
         } else {
             iconOnHoldTintList = in.readInt();
+        }
+        if (in.readByte() == 0) {
+            iconScreenSharingDialog = null;
+        } else {
+            iconScreenSharingDialog = in.readInt();
         }
     }
 
@@ -122,6 +129,12 @@ public class ChatHeadConfiguration implements Parcelable {
             dest.writeByte((byte) 1);
             dest.writeInt(iconOnHoldTintList);
         }
+        if (iconScreenSharingDialog == null) {
+            dest.writeByte((byte) 0);
+        } else {
+            dest.writeByte((byte) 1);
+            dest.writeInt(iconScreenSharingDialog);
+        }
     }
 
     @Override
@@ -173,6 +186,10 @@ public class ChatHeadConfiguration implements Parcelable {
         return iconOnHoldTintList;
     }
 
+    public Integer getIconScreenSharingDialog() {
+        return iconScreenSharingDialog;
+    }
+
     @Deprecated
     public static class Builder {
         private final String TAG = ChatHeadConfiguration.Builder.class.getSimpleName();
@@ -185,6 +202,7 @@ public class ChatHeadConfiguration implements Parcelable {
         private Integer backgroundColorRes;
         private Integer iconOnHold;
         private Integer iconOnHoldTintList;
+        private Integer iconScreenSharingDialog;
 
         public Builder() {
         }
@@ -198,6 +216,7 @@ public class ChatHeadConfiguration implements Parcelable {
             backgroundColorRes = buildTime.backgroundColorRes;
             iconOnHold = buildTime.iconOnHold;
             iconOnHoldTintList = buildTime.iconOnHoldTintList;
+            iconScreenSharingDialog = buildTime.iconScreenSharingDialog;
         }
 
         public Builder operatorPlaceholderBackgroundColor(Integer operatorPlaceholderBackgroundColor) {
@@ -237,6 +256,11 @@ public class ChatHeadConfiguration implements Parcelable {
 
         public Builder iconOnHoldTintList(Integer iconOnHoldTintList) {
             this.iconOnHoldTintList = iconOnHoldTintList;
+            return this;
+        }
+
+        public Builder iconScreenSharingDialog(Integer iconScreenSharingDialog) {
+            this.iconScreenSharingDialog = iconScreenSharingDialog;
             return this;
         }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
@@ -148,7 +148,7 @@ internal class ChatHeadView @JvmOverloads constructor(
                 placeholderView.visibility = GONE
                 profilePictureView.setImageDrawable(null)
                 profilePictureView.backgroundTintList = getColorStateListCompat(configuration.backgroundColorRes)
-                placeholderView.setImageResource(R.drawable.ic_screensharing)
+                placeholderView.setImageResource(configuration.iconScreenSharingDialog)
                 placeholderView.visibility = VISIBLE
             }
         }
@@ -219,6 +219,7 @@ internal class ChatHeadView @JvmOverloads constructor(
             .backgroundColorRes(buildTimeTheme.brandPrimaryColor)
             .iconOnHold(buildTimeTheme.iconOnHold)
             .iconOnHoldTintList(buildTimeTheme.baseLightColor)
+            .iconScreenSharingDialog(buildTimeTheme.iconScreenSharingDialog)
             .build()
     }
 
@@ -227,7 +228,6 @@ internal class ChatHeadView @JvmOverloads constructor(
         sdkConfiguration: GliaSdkConfiguration?
     ) {
         configuration = createBuildTimeConfiguration(buildTimeTheme)
-
         val runTimeTheme = sdkConfiguration?.runTimeTheme ?: return
 
         val builder = ChatHeadConfiguration.builder(configuration)
@@ -241,6 +241,7 @@ internal class ChatHeadView @JvmOverloads constructor(
             backgroundColorRes?.also(builder::backgroundColorRes)
             iconOnHold?.also(builder::iconOnHold)
             iconOnHoldTintList?.also(builder::iconOnHoldTintList)
+            iconScreenSharingDialog?.also(builder::iconScreenSharingDialog)
         }
         configuration = builder.build()
     }
@@ -265,7 +266,7 @@ internal class ChatHeadView @JvmOverloads constructor(
 
     private fun updatePlaceholderImageView() {
         val placeholderIcon = if (isCallVisualizerScreenSharingUseCase()) {
-            R.drawable.ic_screensharing // TODO: 14.03.2023 MOB-1942 add this icon to UiTheme the same way as operatorPlaceholderIcon
+            configuration.iconScreenSharingDialog
         } else {
             configuration.operatorPlaceholderIcon
         }

--- a/widgetssdk/src/main/res/values/attrs.xml
+++ b/widgetssdk/src/main/res/values/attrs.xml
@@ -38,7 +38,7 @@
         <attr name="iconChatVideoUpgrade" format="reference" />
         <!-- The icon resId used in the header of an video upgrade dialog -->
         <attr name="iconUpgradeVideoDialog" format="reference" />
-        <!-- The icon resId used in the header of of a screen sharing upgrade dialog -->
+        <!-- The icon resId used in the header of a screen sharing upgrade dialog and in the call visualizer screen sharing bubble-->
         <attr name="iconScreenSharingDialog" format="reference" />
         <!-- The icon resId used to set the call's video on -->
         <attr name="iconCallVideoOn" format="reference" />

--- a/widgetssdk/src/main/res/values/themes.xml
+++ b/widgetssdk/src/main/res/values/themes.xml
@@ -29,7 +29,7 @@
         <item name="iconPlaceholder">?attr/gliaIconPlaceholder</item>
         <item name="iconOnHold">?attr/gliaIconOnHold</item>
         <item name="iconEndScreenShare">?attr/gliaIconEndScreenShare</item>
-
+        <item name="iconScreenSharingDialog">?attr/gliaIconScreenSharingDialog</item>
         <item name="chatSendMessageButtonTintColor">?attr/gliaSendMessageButtonTintColor</item>
 
         <item name="gliaChatBackgroundColor">?attr/gliaChatBackgroundColor</item>

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/view/head/ChatHeadViewSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/view/head/ChatHeadViewSnapshotTest.kt
@@ -353,6 +353,7 @@ class ChatHeadViewSnapshotTest : SnapshotTest(
         .backgroundColorRes(R.color.glia_system_negative_color)
         .iconOnHold(R.drawable.ic_pause_circle)
         .iconOnHoldTintList(R.color.call_fab_icon_color_states)
+        .iconScreenSharingDialog(R.drawable.ic_screensharing)
         .build()
 
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3038

**What was solved?**
Fixed the missed support for configurable screen sharing bubble icoon 

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)
