### PR TITLE
Fix Widgets SDK does not apply the XML theme to the Call Visualizer dialogs

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/ActivityWatcherForCallVisualizer.kt
@@ -34,8 +34,7 @@ import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.Utils
 import com.glia.widgets.helper.WeakReferenceDelegate
-import com.glia.widgets.helper.getFullHybridTheme
-import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
+import com.glia.widgets.helper.withRuntimeTheme
 import com.glia.widgets.view.Dialogs
 import com.glia.widgets.webbrowser.WebBrowserActivity
 
@@ -241,7 +240,7 @@ internal class ActivityWatcherForCallVisualizer(
     }
 
     override fun showAllowNotificationsDialog() {
-        showAlertDialogOnUiThreadWithStyledContext("Show allow notifications dialog", UiTheme.UiThemeBuilder().build()) { context, uiTheme, _ ->
+        showAlertDialogOnUiThreadWithStyledContext("Show allow notifications dialog") { context, uiTheme, _ ->
             Dialogs.showAllowNotificationsDialog(
                 context = context,
                 uiTheme = uiTheme,
@@ -264,8 +263,7 @@ internal class ActivityWatcherForCallVisualizer(
 
     override fun showAllowScreenSharingNotificationsAndStartSharingDialog() {
         showAlertDialogOnUiThreadWithStyledContext(
-            "Show screen sharing and notifications dialog",
-            UiTheme.UiThemeBuilder().build()
+            "Show screen sharing and notifications dialog"
         ) { context, uiTheme, _ ->
             Dialogs.showAllowScreenSharingNotificationsAndStartSharingDialog(
                 context = context,
@@ -285,7 +283,7 @@ internal class ActivityWatcherForCallVisualizer(
     }
 
     override fun showOverlayPermissionsDialog() {
-        showAlertDialogOnUiThreadWithStyledContext("Show overlay permissions dialog", UiTheme.UiThemeBuilder().build()) { context, uiTheme, _ ->
+        showAlertDialogOnUiThreadWithStyledContext("Show overlay permissions dialog") { context, uiTheme, _ ->
             Dialogs.showOverlayPermissionsDialog(
                 context = context,
                 uiTheme = uiTheme,
@@ -332,14 +330,15 @@ internal class ActivityWatcherForCallVisualizer(
 
     private fun showAlertDialogOnUiThreadWithStyledContext(
         logMessage: String? = null,
-        uiTheme: UiTheme? = null,
         callback: (Context, UiTheme, Activity) -> AlertDialog
     ) {
         resumedActivity?.apply {
             runOnUiThread {
                 logMessage?.let { Logger.d(TAG, it) }
                 dismissAlertDialogSilently()
-                alertDialog = callback(wrapWithMaterialThemeOverlay(), uiTheme ?: getRuntimeTheme(this), this)
+                withRuntimeTheme { themedContext, uiTheme ->
+                    alertDialog = callback(themedContext, uiTheme, this)
+                }
             }
         }
     }
@@ -373,12 +372,6 @@ internal class ActivityWatcherForCallVisualizer(
         showAlertDialogOnUiThreadWithStyledContext("Show visitor code dialog") { context, _, _ ->
             Dialogs.showVisitorCodeDialog(context)
         }
-    }
-
-    private fun getRuntimeTheme(activity: Activity): UiTheme {
-        val themeFromIntent: UiTheme? = activity.intent?.getParcelableExtra(GliaWidgets.UI_THEME)
-        val themeFromGlobalSetting = Dependencies.getSdkConfigurationManager().uiTheme
-        return themeFromGlobalSetting.getFullHybridTheme(themeFromIntent)
     }
 
     override fun isSupportActivityOpen(): Boolean {

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -15,6 +15,7 @@ import com.glia.androidsdk.chat.MessageAttachment
 import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.androidsdk.queuing.Queue
 import com.glia.widgets.UiTheme
+import com.glia.widgets.di.Dependencies
 import com.glia.widgets.view.unifiedui.deepMerge
 import kotlin.jvm.optionals.getOrNull
 
@@ -41,6 +42,9 @@ internal val Operator.imageUrl: String? get() = picture?.url?.getOrNull()
 internal fun UiTheme?.isAlertDialogButtonUseVerticalAlignment(): Boolean = this?.gliaAlertDialogButtonUseVerticalAlignment ?: false
 
 internal fun UiTheme?.getFullHybridTheme(newTheme: UiTheme?): UiTheme = deepMerge(newTheme) ?: UiTheme.UiThemeBuilder().build()
+
+internal val UiTheme?.withConfigurationTheme: UiTheme
+    get() = Dependencies.getSdkConfigurationManager().uiTheme.getFullHybridTheme(this)
 
 /**
  * Returns styled text from the provided HTML string. Replaces \n to <br> regardless of the operating system where the string was created.

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ContextExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ContextExtensions.kt
@@ -10,7 +10,10 @@ import androidx.annotation.AttrRes
 import androidx.annotation.DimenRes
 import androidx.annotation.IntRange
 import androidx.annotation.StyleRes
+import androidx.core.content.withStyledAttributes
+import com.glia.widgets.GliaWidgets
 import com.glia.widgets.R
+import com.glia.widgets.UiTheme
 import com.google.android.material.theme.overlay.MaterialThemeOverlay
 
 internal fun Context.asActivity(): Activity? = (this as? ContextWrapper)?.let {
@@ -47,3 +50,13 @@ internal fun Context.showToast(
 
 internal val Activity.rootView: View
     get() = findViewById(android.R.id.content) ?: window.decorView.findViewById(android.R.id.content)
+
+internal fun Activity.withRuntimeTheme(callback: (themedContext: Context, uiTheme: UiTheme) -> Unit) {
+    val themedContext = wrapWithMaterialThemeOverlay()
+
+    intent.getParcelableExtra<UiTheme>(GliaWidgets.UI_THEME)?.also {
+        callback(themedContext, it.withConfigurationTheme)
+    } ?: themedContext.withStyledAttributes(R.style.Application_Glia_Chat, R.styleable.GliaView) {
+        callback(themedContext, Utils.getThemeFromTypedArray(this, themedContext).withConfigurationTheme)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/VisitorCodeView.kt
@@ -32,6 +32,7 @@ import com.glia.widgets.helper.getFontCompat
 import com.glia.widgets.helper.getFullHybridTheme
 import com.glia.widgets.helper.layoutInflater
 import com.glia.widgets.helper.separateStringWithSymbol
+import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
 import com.glia.widgets.view.button.GliaPositiveButton
 import com.glia.widgets.view.unifiedui.applyButtonTheme
 import com.glia.widgets.view.unifiedui.applyImageColorTheme
@@ -39,7 +40,6 @@ import com.glia.widgets.view.unifiedui.applyLayerTheme
 import com.glia.widgets.view.unifiedui.applyProgressColorTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
-import com.google.android.material.theme.overlay.MaterialThemeOverlay
 import java.util.concurrent.Executor
 
 /**
@@ -52,7 +52,7 @@ import java.util.concurrent.Executor
 class VisitorCodeView internal constructor(
     context: Context,
     private val uiThreadExecutor: Executor? = null
-) : FrameLayout(MaterialThemeOverlay.wrap(context, null, 0, R.style.Application_Glia_Chat), null, 0), VisitorCodeContract.View {
+) : FrameLayout(context.wrapWithMaterialThemeOverlay(), null, 0), VisitorCodeContract.View {
     private lateinit var controller: VisitorCodeContract.Controller
     private var theme: UiTheme? = null
 


### PR DESCRIPTION
- Fix VisitorCodeView to apply the default XML theme
- Fix getting a runtime theme for non-glia activities

**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
