### PR TITLE
Fix Dialogs don't apply custom icons

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
@@ -442,9 +442,7 @@ data class UiTheme(
 
     internal fun alertTheme(context: Context): AlertThemeWrapper = AlertThemeWrapper(
         AlertTheme(toColorPallet(context)).copy(isVerticalAxis = isAlertDialogButtonUseVerticalAlignment()),
-        fontRes?.let { ResourcesCompat.getFont(context, it) },
-        whiteLabel,
-        iconLeaveQueue
+        fontRes?.let { ResourcesCompat.getFont(context, it) }
     )
 
     class UiThemeBuilder {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -14,10 +14,10 @@ import com.glia.widgets.StringKeyPair
 import com.glia.widgets.StringProvider
 import com.glia.widgets.UiTheme
 import com.glia.widgets.callvisualizer.CallVisualizerSupportActivity
-import com.glia.widgets.core.dialog.model.Link
 import com.glia.widgets.core.dialog.model.ConfirmationDialogLinks
 import com.glia.widgets.core.dialog.model.DialogState.MediaUpgrade
 import com.glia.widgets.core.dialog.model.DialogState.OperatorName
+import com.glia.widgets.core.dialog.model.Link
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.asActivity
 import com.glia.widgets.view.dialog.base.DialogPayload
@@ -46,6 +46,7 @@ internal object Dialogs {
             message = stringProvider.getRemoteString(R.string.engagement_queue_closed_message),
             buttonVisible = true,
             buttonDescription = closeBtnAccessibility,
+            iconLeaveQueue = uiTheme.iconLeaveQueue,
             buttonClickListener = buttonClickListener
         )
 
@@ -58,6 +59,7 @@ internal object Dialogs {
             message = stringProvider.getRemoteString(R.string.engagement_queue_reconnection_failed),
             buttonVisible = true,
             buttonDescription = closeBtnAccessibility,
+            iconLeaveQueue = uiTheme.iconLeaveQueue,
             buttonClickListener = buttonClickListener
         )
         return dialogService.showDialog(context, uiTheme, DialogType.AlertDialog(payload))
@@ -69,6 +71,7 @@ internal object Dialogs {
             message = stringProvider.getRemoteString(R.string.android_permissions_message),
             buttonVisible = true,
             buttonDescription = closeBtnAccessibility,
+            iconLeaveQueue = uiTheme.iconLeaveQueue,
             buttonClickListener = buttonClickListener
         )
         return dialogService.showDialog(context, uiTheme, DialogType.AlertDialog(payload))
@@ -87,6 +90,7 @@ internal object Dialogs {
             positiveButtonText = ok,
             negativeButtonText = no,
             poweredByText = poweredByText,
+            whiteLabel = uiTheme.whiteLabel,
             positiveButtonClickListener = positiveButtonClickListener,
             negativeButtonClickListener = negativeButtonClickListener
 
@@ -110,6 +114,7 @@ internal object Dialogs {
             positiveButtonText = yes,
             negativeButtonText = no,
             poweredByText = poweredByText,
+            whiteLabel = uiTheme.whiteLabel,
             positiveButtonClickListener = positiveButtonClickListener,
             negativeButtonClickListener = negativeButtonClickListener
         )
@@ -132,6 +137,7 @@ internal object Dialogs {
             positiveButtonText = yes,
             negativeButtonText = no,
             poweredByText = poweredByText,
+            whiteLabel = uiTheme.whiteLabel,
             positiveButtonClickListener = positiveButtonClickListener,
             negativeButtonClickListener = negativeButtonClickListener
 
@@ -155,6 +161,7 @@ internal object Dialogs {
             positiveButtonText = yes,
             negativeButtonText = no,
             poweredByText = poweredByText,
+            whiteLabel = uiTheme.whiteLabel,
             positiveButtonClickListener = positiveButtonClickListener,
             negativeButtonClickListener = negativeButtonClickListener
         )
@@ -177,6 +184,7 @@ internal object Dialogs {
             positiveButtonText = yes,
             negativeButtonText = no,
             poweredByText = poweredByText,
+            whiteLabel = uiTheme.whiteLabel,
             positiveButtonClickListener = positiveButtonClickListener,
             negativeButtonClickListener = negativeButtonClickListener
 
@@ -193,6 +201,7 @@ internal object Dialogs {
             message = stringProvider.getRemoteString(R.string.message_center_not_authenticated_message),
             buttonVisible = true,
             buttonDescription = closeBtnAccessibility,
+            iconLeaveQueue = uiTheme.iconLeaveQueue,
             buttonClickListener = buttonClickListener
         )
         return dialogService.showDialog(context, uiTheme, DialogType.AlertDialog(payload))
@@ -214,6 +223,7 @@ internal object Dialogs {
             positiveButtonText = allow,
             negativeButtonText = cancel,
             poweredByText = poweredByText,
+            whiteLabel = theme.whiteLabel,
             positiveButtonClickListener = positiveButtonClickListener,
             negativeButtonClickListener = negativeButtonClickListener,
             link1ClickListener = { links.link1?.let { linkClickListener(it) } },
@@ -255,6 +265,7 @@ internal object Dialogs {
             negativeButtonText = decline,
             poweredByText = poweredByText,
             iconRes = titleIconResPair.second,
+            whiteLabel = theme.whiteLabel,
             positiveButtonClickListener = onAcceptOfferClickListener,
             negativeButtonClickListener = onCloseClickListener
 
@@ -276,6 +287,8 @@ internal object Dialogs {
             positiveButtonText = accept,
             negativeButtonText = decline,
             poweredByText = poweredByText,
+            whiteLabel = theme.whiteLabel,
+            iconScreenSharingDialog = theme.iconScreenSharingDialog,
             positiveButtonClickListener = positiveButtonClickListener,
             negativeButtonClickListener = negativeButtonClickListener
         )
@@ -290,7 +303,8 @@ internal object Dialogs {
     ): AlertDialog {
         val payload = DialogPayload.AlertDialog(
             title = stringProvider.getRemoteString(R.string.message_center_unavailable_title),
-            message = stringProvider.getRemoteString(R.string.message_center_unavailable_message)
+            message = stringProvider.getRemoteString(R.string.message_center_unavailable_message),
+            iconLeaveQueue = theme.iconLeaveQueue,
         )
 
         return dialogService.showDialog(context, theme, DialogType.AlertDialog(payload), onShow = onShow) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewInflater.kt
@@ -24,6 +24,6 @@ internal class AlertDialogViewInflater(
         binding.closeBtn.isVisible = payload.buttonVisible
         payload.buttonClickListener?.also(binding.closeBtn::setOnClickListener)
         payload.buttonDescription?.also { binding.closeBtn.contentDescription = it }
-        themeWrapper.iconLeaveQueue?.also { binding.closeBtn.setImageResource(it) }
+        payload.iconLeaveQueue?.also { binding.closeBtn.setImageResource(it) }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
@@ -12,6 +12,7 @@ internal sealed interface DialogPayload {
         val positiveButtonText: String,
         val negativeButtonText: String,
         val poweredByText: String,
+        val whiteLabel: Boolean?,
         val positiveButtonClickListener: View.OnClickListener,
         val negativeButtonClickListener: View.OnClickListener,
     ) : DialogPayload
@@ -22,6 +23,7 @@ internal sealed interface DialogPayload {
         val positiveButtonText: String,
         val negativeButtonText: String,
         val poweredByText: String,
+        val whiteLabel: Boolean?,
         val positiveButtonClickListener: View.OnClickListener,
         val negativeButtonClickListener: View.OnClickListener,
         val link1Text: String? = null,
@@ -36,6 +38,9 @@ internal sealed interface DialogPayload {
         val positiveButtonText: String,
         val negativeButtonText: String,
         val poweredByText: String,
+        val whiteLabel: Boolean?,
+        @DrawableRes
+        val iconScreenSharingDialog: Int?,
         val positiveButtonClickListener: View.OnClickListener,
         val negativeButtonClickListener: View.OnClickListener,
     ) : DialogPayload
@@ -47,6 +52,7 @@ internal sealed interface DialogPayload {
         val poweredByText: String,
         @DrawableRes
         val iconRes: Int,
+        val whiteLabel: Boolean?,
         val positiveButtonClickListener: View.OnClickListener,
         val negativeButtonClickListener: View.OnClickListener,
     ) : DialogPayload
@@ -63,6 +69,8 @@ internal sealed interface DialogPayload {
         val message: String,
         val buttonVisible: Boolean = false,
         val buttonDescription: String? = null,
+        @DrawableRes
+        val iconLeaveQueue: Int?,
         val buttonClickListener: View.OnClickListener? = null
     ) : DialogPayload
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
@@ -15,7 +15,7 @@ internal abstract class BaseConfirmationDialogViewInflater<T : BaseConfirmationD
     override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) {
         val theme = themeWrapper.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = payload.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
 
         setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
@@ -92,4 +92,3 @@ internal open class DefaultReversedConfirmationDialogViewInflater<T : DefaultRev
         )
     }
 }
-

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
@@ -14,7 +14,7 @@ internal abstract class BaseOptionDialogViewInflater<T : BaseOptionDialogViewBin
     override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) {
         val theme = themeWrapper.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = payload.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
 
         setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewInflater.kt
@@ -15,9 +15,10 @@ internal open class BaseScreenSharingDialogViewInflater<T : BaseScreenSharingDia
     final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.ScreenSharing) {
         val theme = themeWrapper.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = payload.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
         binding.icon.applyImageColorTheme(theme.titleImageColor)
+        payload.iconScreenSharingDialog?.apply(binding.icon::setImageResource)
 
         setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
         setupButton(binding.positiveBtn, payload.positiveButtonText, theme.positiveButton, themeWrapper.typeface, payload.positiveButtonClickListener)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewInflater.kt
@@ -15,7 +15,7 @@ internal open class BaseUpgradeDialogViewInflater<T : BaseUpgradeDialogViewBindi
     final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Upgrade) {
         val theme = themeWrapper.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = payload.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
 
         setupButton(binding.positiveBtn, payload.positiveButtonText, theme.positiveButton, themeWrapper.typeface, payload.positiveButtonClickListener)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/ThemeWrapper.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/ThemeWrapper.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.view.unifiedui.theme
 
 import android.graphics.Typeface
-import androidx.annotation.DrawableRes
 import com.glia.widgets.view.unifiedui.theme.alert.AlertTheme
 
 internal interface TypefaceThemeWrapper<T : Any> {
@@ -11,7 +10,5 @@ internal interface TypefaceThemeWrapper<T : Any> {
 
 internal data class AlertThemeWrapper(
     override val theme: AlertTheme,
-    override val typeface: Typeface?,
-    val whiteLabel: Boolean?,
-    @DrawableRes val iconLeaveQueue: Int?
+    override val typeface: Typeface?
 ) : TypefaceThemeWrapper<AlertTheme>

--- a/widgetssdk/src/main/res/layout/screensharing_dialog.xml
+++ b/widgetssdk/src/main/res/layout/screensharing_dialog.xml
@@ -24,7 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_large"
-        android:src="@drawable/ic_screensharing"
+        android:src="?attr/gliaIconScreenSharingDialog"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"

--- a/widgetssdk/src/main/res/layout/screensharing_dialog_vertical.xml
+++ b/widgetssdk/src/main/res/layout/screensharing_dialog_vertical.xml
@@ -24,7 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_large"
-        android:src="@drawable/ic_screensharing"
+        android:src="?attr/gliaIconScreenSharingDialog"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"

--- a/widgetssdk/src/main/res/values/themes.xml
+++ b/widgetssdk/src/main/res/values/themes.xml
@@ -129,6 +129,7 @@
         <item name="gliaIconPlaceholder">@drawable/ic_person</item>
         <item name="gliaIconOnHold">@drawable/ic_pause_circle</item>
         <item name="gliaIconEndScreenShare">@drawable/ic_screensharing_off</item>
+        <item name="gliaIconScreenSharingDialog">@drawable/ic_screensharing</item>
 
         <item name="gliaSendMessageButtonTintColor">?attr/gliaBrandPrimaryColor</item>
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3067

**What was solved?**
Fix - Defining `gliaIconScreenSharingDialog` did not affect the screen-sharing dialog icon.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
