### PR TITLE
Fix Dialogs don't apply custom icons

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
@@ -11,8 +11,10 @@ import com.glia.widgets.view.configuration.ButtonConfiguration
 import com.glia.widgets.view.configuration.ChatHeadConfiguration
 import com.glia.widgets.view.configuration.TextConfiguration
 import com.glia.widgets.view.configuration.survey.SurveyStyle
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 import com.glia.widgets.view.unifiedui.theme.ColorPallet
+import com.glia.widgets.view.unifiedui.theme.Icons
+import com.glia.widgets.view.unifiedui.theme.Properties
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.defaulttheme.AlertTheme
 import kotlinx.parcelize.Parcelize
@@ -440,12 +442,21 @@ data class UiTheme(
         )
     }
 
-    internal fun alertTheme(context: Context): AlertThemeWrapper = AlertThemeWrapper(
-        AlertTheme(toColorPallet(context)).copy(isVerticalAxis = isAlertDialogButtonUseVerticalAlignment()),
-        fontRes?.let { ResourcesCompat.getFont(context, it) },
-        whiteLabel,
-        iconLeaveQueue
-    )
+    internal fun alertTheme(context: Context): AlertDialogConfiguration {
+        val theme = toColorPallet(context).run(::AlertTheme).copy(isVerticalAxis = isAlertDialogButtonUseVerticalAlignment())
+
+        val properties = Properties(
+            typeface = fontRes?.let { ResourcesCompat.getFont(context, it) },
+            whiteLabel = whiteLabel
+        )
+
+        val icons = Icons(
+            iconLeaveQueue = iconLeaveQueue,
+            iconScreenSharingDialog = iconScreenSharingDialog
+        )
+
+        return AlertDialogConfiguration(theme, properties, icons)
+    }
 
     class UiThemeBuilder {
         /**

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -44,7 +44,7 @@ internal fun UiTheme?.isAlertDialogButtonUseVerticalAlignment(): Boolean = this?
 internal fun UiTheme?.getFullHybridTheme(newTheme: UiTheme?): UiTheme = deepMerge(newTheme) ?: UiTheme.UiThemeBuilder().build()
 
 internal val UiTheme?.withConfigurationTheme: UiTheme
-    get() = Dependencies.getSdkConfigurationManager().uiTheme.getFullHybridTheme(this)
+    get() = getFullHybridTheme(Dependencies.getSdkConfigurationManager().uiTheme)
 
 /**
  * Returns styled text from the provided HTML string. Replaces \n to <br> regardless of the operating system where the string was created.

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/alert/AlertDialogViewInflater.kt
@@ -5,25 +5,25 @@ import androidx.core.view.isVisible
 import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogViewInflater
 import com.glia.widgets.view.unifiedui.applyImageColorTheme
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 
 internal class AlertDialogViewInflater(
     layoutInflater: LayoutInflater,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.AlertDialog
 ) : DialogViewInflater<AlertDialogViewBinding, DialogPayload.AlertDialog>(
     AlertDialogViewBinding(layoutInflater),
     themeWrapper,
     payload
 ) {
-    override fun setup(binding: AlertDialogViewBinding, themeWrapper: AlertThemeWrapper, payload: DialogPayload.AlertDialog) {
-        val theme = themeWrapper.theme
+    override fun setup(binding: AlertDialogViewBinding, configuration: AlertDialogConfiguration, payload: DialogPayload.AlertDialog) {
+        val theme = configuration.theme
 
-        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+        setupText(binding.messageTv, payload.message, theme.message, configuration.properties.typeface)
         binding.closeBtn.applyImageColorTheme(theme.closeButtonColor)
         binding.closeBtn.isVisible = payload.buttonVisible
         payload.buttonClickListener?.also(binding.closeBtn::setOnClickListener)
         payload.buttonDescription?.also { binding.closeBtn.contentDescription = it }
-        themeWrapper.iconLeaveQueue?.also { binding.closeBtn.setImageResource(it) }
+        configuration.icons.iconLeaveQueue?.also { binding.closeBtn.setImageResource(it) }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
@@ -17,32 +17,32 @@ import com.glia.widgets.view.dialog.screensharing.VerticalScreenSharingDialogVie
 import com.glia.widgets.view.dialog.update.UpgradeDialogViewInflater
 import com.glia.widgets.view.dialog.update.VerticalUpgradeDialogViewInflater
 import com.glia.widgets.view.unifiedui.deepMerge
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 
 internal class DialogViewFactory(context: Context, uiTheme: UiTheme, unifiedTheme: UnifiedTheme?) {
-    private val themeWrapper: AlertThemeWrapper = uiTheme.alertTheme(context).run {
+    private val configuration: AlertDialogConfiguration = uiTheme.alertTheme(context).run {
         copy(theme = this.theme.deepMerge(unifiedTheme?.alertTheme)!!)
     }
 
     private val layoutInflater: LayoutInflater = LayoutInflater.from(context)
-    private val isVerticalAxis: Boolean = themeWrapper.theme.isVerticalAxis ?: false
+    private val isVerticalAxis: Boolean = configuration.theme.isVerticalAxis ?: false
 
     fun createView(type: DialogType): View = getInflater(type).view
 
     private fun getInflater(type: DialogType): DialogViewInflater<*, *> = when {
-        type is DialogType.Option && isVerticalAxis -> VerticalOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.Option -> OptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.ReversedOption && isVerticalAxis -> VerticalReversedOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.ReversedOption -> ReversedOptionDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.Confirmation && isVerticalAxis -> VerticalConfirmationDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.Confirmation -> ConfirmationDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.Upgrade && isVerticalAxis -> VerticalUpgradeDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.Upgrade -> UpgradeDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.ScreenSharing && isVerticalAxis -> VerticalScreenSharingDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.ScreenSharing -> ScreenSharingDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.OperatorEndedEngagement -> OperatorEndedEngagementDialogViewInflater(layoutInflater, themeWrapper, type.payload)
-        type is DialogType.AlertDialog -> AlertDialogViewInflater(layoutInflater, themeWrapper, type.payload)
+        type is DialogType.Option && isVerticalAxis -> VerticalOptionDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.Option -> OptionDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.ReversedOption && isVerticalAxis -> VerticalReversedOptionDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.ReversedOption -> ReversedOptionDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.Confirmation && isVerticalAxis -> VerticalConfirmationDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.Confirmation -> ConfirmationDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.Upgrade && isVerticalAxis -> VerticalUpgradeDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.Upgrade -> UpgradeDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.ScreenSharing && isVerticalAxis -> VerticalScreenSharingDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.ScreenSharing -> ScreenSharingDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.OperatorEndedEngagement -> OperatorEndedEngagementDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.AlertDialog -> AlertDialogViewInflater(layoutInflater, configuration, type.payload)
         else -> throw UnsupportedOperationException("Dialog of unsupported -> $type type was requested")
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
@@ -7,14 +7,14 @@ import androidx.viewbinding.ViewBinding
 import com.glia.widgets.view.unifiedui.applyButtonTheme
 import com.glia.widgets.view.unifiedui.applyColorTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.google.android.material.button.MaterialButton
 
 internal abstract class DialogViewInflater<T : DialogViewBinding<out ViewBinding>, R : DialogPayload>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: R
 ) {
 
@@ -24,14 +24,14 @@ internal abstract class DialogViewInflater<T : DialogViewBinding<out ViewBinding
         initialSetup(binding, themeWrapper, payload)
     }
 
-    private fun initialSetup(binding: T, themeWrapper: AlertThemeWrapper, payload: R) {
-        val alertTheme = themeWrapper.theme
+    private fun initialSetup(binding: T, configuration: AlertDialogConfiguration, payload: R) {
+        val alertTheme = configuration.theme
         view.applyColorTheme(alertTheme.backgroundColor)
-        setupText(binding.titleTv, payload.title, alertTheme.title, themeWrapper.typeface)
-        setup(binding, themeWrapper, payload)
+        setupText(binding.titleTv, payload.title, alertTheme.title, configuration.properties.typeface)
+        setup(binding, configuration, payload)
     }
 
-    abstract fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: R)
+    abstract fun setup(binding: T, configuration: AlertDialogConfiguration, payload: R)
 
     private fun setupTypeface(tv: TextView, typeface: Typeface?) {
         typeface?.also { tv.typeface = it }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
@@ -5,91 +5,98 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogViewInflater
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 
 internal abstract class BaseConfirmationDialogViewInflater<T : BaseConfirmationDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Confirmation
 ) : DialogViewInflater<T, DialogPayload.Confirmation>(binding, themeWrapper, payload) {
-    override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) {
-        val theme = themeWrapper.theme
+    override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.Confirmation) {
+        val theme = configuration.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = configuration.properties.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
 
-        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+        setupText(binding.messageTv, payload.message, theme.message, configuration.properties.typeface)
     }
 }
 
 internal open class DefaultConfirmationDialogViewInflater<T : DefaultConfirmationDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Confirmation
 ) : BaseConfirmationDialogViewInflater<T>(binding, themeWrapper, payload) {
-    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) {
-        super.setup(binding, themeWrapper, payload)
-        val theme = themeWrapper.theme
+    final override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.Confirmation) {
+        super.setup(binding, configuration, payload)
+        val theme = configuration.theme
         setupButton(
             binding.link1Button,
             payload.link1Text,
             theme.linkButton,
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.link1ClickListener
         )
         setupButton(
             binding.link2Button,
             payload.link2Text,
             theme.linkButton,
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.link2ClickListener
         )
         setupButton(
             binding.positiveButton,
             payload.positiveButtonText,
             theme.positiveButton,
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.positiveButtonClickListener
         )
         setupButton(
             binding.negativeButton,
             payload.negativeButtonText,
             theme.negativeButton,
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.negativeButtonClickListener
         )
         binding.additionalButtonsSpace.isGone = binding.link1Button.isVisible || binding.link2Button.isVisible
     }
 }
 
-internal class ConfirmationDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) :
+internal class ConfirmationDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertDialogConfiguration,
+    payload: DialogPayload.Confirmation
+) :
     DefaultConfirmationDialogViewInflater<ConfirmationDialogViewBinding>(ConfirmationDialogViewBinding(layoutInflater), themeWrapper, payload)
 
-internal class VerticalConfirmationDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) :
+internal class VerticalConfirmationDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertDialogConfiguration,
+    payload: DialogPayload.Confirmation
+) :
     DefaultConfirmationDialogViewInflater<VerticalConfirmationDialogViewBinding>(VerticalConfirmationDialogViewBinding(layoutInflater), themeWrapper, payload)
 
 internal open class DefaultReversedConfirmationDialogViewInflater<T : DefaultReversedConfirmationDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Confirmation
 ) : BaseConfirmationDialogViewInflater<T>(binding, themeWrapper, payload) {
-    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Confirmation) {
-        super.setup(binding, themeWrapper, payload)
-        val theme = themeWrapper.theme
+    final override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.Confirmation) {
+        super.setup(binding, configuration, payload)
+        val theme = configuration.theme
         setupButton(
             binding.positiveButton,
             payload.positiveButtonText,
             theme.negativeButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.positiveButtonClickListener
         )
         setupButton(
             binding.negativeButton,
             payload.negativeButtonText,
             theme.positiveButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.negativeButtonClickListener
         )
     }
 }
-

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/operatorendedengagement/OperatorEndedEngagementDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/operatorendedengagement/OperatorEndedEngagementDialogViewInflater.kt
@@ -3,24 +3,24 @@ package com.glia.widgets.view.dialog.operatorendedengagement
 import android.view.LayoutInflater
 import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogViewInflater
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 
 internal class OperatorEndedEngagementDialogViewInflater(
     layoutInflater: LayoutInflater,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.OperatorEndedEngagement
 ) : DialogViewInflater<OperatorEndedEngagementDialogViewBinding, DialogPayload.OperatorEndedEngagement>(
     OperatorEndedEngagementDialogViewBinding(layoutInflater), themeWrapper, payload
 ) {
     override fun setup(
         binding: OperatorEndedEngagementDialogViewBinding,
-        themeWrapper: AlertThemeWrapper,
+        configuration: AlertDialogConfiguration,
         payload: DialogPayload.OperatorEndedEngagement
     ) {
-        val theme = themeWrapper.theme
+        val theme = configuration.theme
 
-        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
-        setupButton(binding.button, payload.buttonText, theme.positiveButton, themeWrapper.typeface, payload.buttonClickListener)
+        setupText(binding.messageTv, payload.message, theme.message, configuration.properties.typeface)
+        setupButton(binding.button, payload.buttonText, theme.positiveButton, configuration.properties.typeface, payload.buttonClickListener)
     }
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
@@ -4,85 +4,93 @@ import android.view.LayoutInflater
 import androidx.core.view.isGone
 import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogViewInflater
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 
 internal abstract class BaseOptionDialogViewInflater<T : BaseOptionDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Option
 ) : DialogViewInflater<T, DialogPayload.Option>(binding, themeWrapper, payload) {
-    override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) {
-        val theme = themeWrapper.theme
+    override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.Option) {
+        val theme = configuration.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = configuration.properties.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
 
-        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
+        setupText(binding.messageTv, payload.message, theme.message, configuration.properties.typeface)
     }
 }
 
 internal open class DefaultOptionDialogViewInflater<T : DefaultOptionDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Option
 ) : BaseOptionDialogViewInflater<T>(binding, themeWrapper, payload) {
-    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) {
-        super.setup(binding, themeWrapper, payload)
-        val theme = themeWrapper.theme
+    final override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.Option) {
+        super.setup(binding, configuration, payload)
+        val theme = configuration.theme
         setupButton(
             binding.positiveButton,
             payload.positiveButtonText,
             theme.positiveButton,
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.positiveButtonClickListener
         )
         setupButton(
             binding.negativeButton,
             payload.negativeButtonText,
             theme.negativeButton,
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.negativeButtonClickListener
         )
     }
 }
 
-internal class OptionDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) :
+internal class OptionDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertDialogConfiguration, payload: DialogPayload.Option) :
     DefaultOptionDialogViewInflater<OptionDialogViewBinding>(OptionDialogViewBinding(layoutInflater), themeWrapper, payload)
 
-internal class VerticalOptionDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) :
+internal class VerticalOptionDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertDialogConfiguration,
+    payload: DialogPayload.Option
+) :
     DefaultOptionDialogViewInflater<VerticalOptionDialogViewBinding>(VerticalOptionDialogViewBinding(layoutInflater), themeWrapper, payload)
 
 internal open class DefaultReversedOptionDialogViewInflater<T : DefaultReversedOptionDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Option
 ) : BaseOptionDialogViewInflater<T>(binding, themeWrapper, payload) {
-    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) {
-        super.setup(binding, themeWrapper, payload)
-        val theme = themeWrapper.theme
+    final override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.Option) {
+        super.setup(binding, configuration, payload)
+        val theme = configuration.theme
         setupButton(
             binding.positiveButton,
             payload.positiveButtonText,
             theme.negativeButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.positiveButtonClickListener
         )
         setupButton(
             binding.negativeButton,
             payload.negativeButtonText,
             theme.positiveButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
-            themeWrapper.typeface,
+            configuration.properties.typeface,
             payload.negativeButtonClickListener
         )
     }
 }
 
-internal class ReversedOptionDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Option) :
+internal class ReversedOptionDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertDialogConfiguration,
+    payload: DialogPayload.Option
+) :
     DefaultReversedOptionDialogViewInflater<ReversedOptionDialogViewBinding>(ReversedOptionDialogViewBinding(layoutInflater), themeWrapper, payload)
 
 internal class VerticalReversedOptionDialogViewInflater(
     layoutInflater: LayoutInflater,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Option
 ) : DefaultReversedOptionDialogViewInflater<VerticalReversedOptionDialogViewBinding>(
     VerticalReversedOptionDialogViewBinding(layoutInflater),

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/screensharing/ScreenSharingDialogViewInflater.kt
@@ -5,36 +5,49 @@ import androidx.core.view.isGone
 import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogViewInflater
 import com.glia.widgets.view.unifiedui.applyImageColorTheme
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 
 internal open class BaseScreenSharingDialogViewInflater<T : BaseScreenSharingDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.ScreenSharing
 ) : DialogViewInflater<T, DialogPayload.ScreenSharing>(binding, themeWrapper, payload) {
-    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.ScreenSharing) {
-        val theme = themeWrapper.theme
+    final override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.ScreenSharing) {
+        val theme = configuration.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = configuration.properties.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
+        configuration.icons.iconScreenSharingDialog?.also { binding.icon.setImageResource(it) }
         binding.icon.applyImageColorTheme(theme.titleImageColor)
 
-        setupText(binding.messageTv, payload.message, theme.message, themeWrapper.typeface)
-        setupButton(binding.positiveBtn, payload.positiveButtonText, theme.positiveButton, themeWrapper.typeface, payload.positiveButtonClickListener)
-        setupButton(binding.negativeBtn, payload.negativeButtonText, theme.negativeButton, themeWrapper.typeface, payload.negativeButtonClickListener)
+        setupText(binding.messageTv, payload.message, theme.message, configuration.properties.typeface)
+        setupButton(
+            binding.positiveBtn,
+            payload.positiveButtonText,
+            theme.positiveButton,
+            configuration.properties.typeface,
+            payload.positiveButtonClickListener
+        )
+        setupButton(
+            binding.negativeBtn,
+            payload.negativeButtonText,
+            theme.negativeButton,
+            configuration.properties.typeface,
+            payload.negativeButtonClickListener
+        )
     }
 
 }
 
 internal class ScreenSharingDialogViewInflater(
     layoutInflater: LayoutInflater,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.ScreenSharing
 ) : BaseScreenSharingDialogViewInflater<ScreenSharingDialogViewBinding>(ScreenSharingDialogViewBinding(layoutInflater), themeWrapper, payload)
 
 internal class VerticalScreenSharingDialogViewInflater(
     layoutInflater: LayoutInflater,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.ScreenSharing
 ) : BaseScreenSharingDialogViewInflater<VerticalScreenSharingDialogViewBinding>(
     VerticalScreenSharingDialogViewBinding(layoutInflater),

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/update/UpgradeDialogViewInflater.kt
@@ -5,21 +5,33 @@ import androidx.core.view.isGone
 import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogViewInflater
 import com.glia.widgets.view.unifiedui.applyImageColorTheme
-import com.glia.widgets.view.unifiedui.theme.AlertThemeWrapper
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 
 internal open class BaseUpgradeDialogViewInflater<T : BaseUpgradeDialogViewBinding<*>>(
     binding: T,
-    themeWrapper: AlertThemeWrapper,
+    themeWrapper: AlertDialogConfiguration,
     payload: DialogPayload.Upgrade
 ) : DialogViewInflater<T, DialogPayload.Upgrade>(binding, themeWrapper, payload) {
-    final override fun setup(binding: T, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Upgrade) {
-        val theme = themeWrapper.theme
+    final override fun setup(binding: T, configuration: AlertDialogConfiguration, payload: DialogPayload.Upgrade) {
+        val theme = configuration.theme
 
-        binding.logoContainer.isGone = themeWrapper.whiteLabel ?: false
+        binding.logoContainer.isGone = configuration.properties.whiteLabel ?: false
         binding.poweredByTv.text = payload.poweredByText
 
-        setupButton(binding.positiveBtn, payload.positiveButtonText, theme.positiveButton, themeWrapper.typeface, payload.positiveButtonClickListener)
-        setupButton(binding.negativeBtn, payload.negativeButtonText, theme.negativeButton, themeWrapper.typeface, payload.negativeButtonClickListener)
+        setupButton(
+            binding.positiveBtn,
+            payload.positiveButtonText,
+            theme.positiveButton,
+            configuration.properties.typeface,
+            payload.positiveButtonClickListener
+        )
+        setupButton(
+            binding.negativeBtn,
+            payload.negativeButtonText,
+            theme.negativeButton,
+            configuration.properties.typeface,
+            payload.negativeButtonClickListener
+        )
         binding.titleIcon.apply {
             setImageResource(payload.iconRes)
             applyImageColorTheme(theme.titleImageColor)
@@ -28,8 +40,12 @@ internal open class BaseUpgradeDialogViewInflater<T : BaseUpgradeDialogViewBindi
 }
 
 
-internal class UpgradeDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Upgrade) :
+internal class UpgradeDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertDialogConfiguration, payload: DialogPayload.Upgrade) :
     BaseUpgradeDialogViewInflater<UpgradeDialogViewBinding>(UpgradeDialogViewBinding(layoutInflater), themeWrapper, payload)
 
-internal class VerticalUpgradeDialogViewInflater(layoutInflater: LayoutInflater, themeWrapper: AlertThemeWrapper, payload: DialogPayload.Upgrade) :
+internal class VerticalUpgradeDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertDialogConfiguration,
+    payload: DialogPayload.Upgrade
+) :
     BaseUpgradeDialogViewInflater<VerticalUpgradeDialogViewBinding>(VerticalUpgradeDialogViewBinding(layoutInflater), themeWrapper, payload)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/ThemeWrapper.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/ThemeWrapper.kt
@@ -4,14 +4,18 @@ import android.graphics.Typeface
 import androidx.annotation.DrawableRes
 import com.glia.widgets.view.unifiedui.theme.alert.AlertTheme
 
-internal interface TypefaceThemeWrapper<T : Any> {
-    val theme: T
-    val typeface: Typeface?
-}
+internal data class AlertDialogConfiguration(
+    val theme: AlertTheme,
+    val properties: Properties,
+    val icons: Icons
+)
 
-internal data class AlertThemeWrapper(
-    override val theme: AlertTheme,
-    override val typeface: Typeface?,
-    val whiteLabel: Boolean?,
-    @DrawableRes val iconLeaveQueue: Int?
-) : TypefaceThemeWrapper<AlertTheme>
+internal data class Icons(
+    @DrawableRes val iconLeaveQueue: Int?,
+    @DrawableRes val iconScreenSharingDialog: Int?,
+)
+
+internal data class Properties(
+    val typeface: Typeface?,
+    val whiteLabel: Boolean?
+)

--- a/widgetssdk/src/main/res/layout/screensharing_dialog.xml
+++ b/widgetssdk/src/main/res/layout/screensharing_dialog.xml
@@ -24,7 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_large"
-        android:src="@drawable/ic_screensharing"
+        android:src="?attr/gliaIconScreenSharingDialog"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"

--- a/widgetssdk/src/main/res/layout/screensharing_dialog_vertical.xml
+++ b/widgetssdk/src/main/res/layout/screensharing_dialog_vertical.xml
@@ -24,7 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_large"
-        android:src="@drawable/ic_screensharing"
+        android:src="?attr/gliaIconScreenSharingDialog"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"

--- a/widgetssdk/src/main/res/values/themes.xml
+++ b/widgetssdk/src/main/res/values/themes.xml
@@ -129,6 +129,7 @@
         <item name="gliaIconPlaceholder">@drawable/ic_person</item>
         <item name="gliaIconOnHold">@drawable/ic_pause_circle</item>
         <item name="gliaIconEndScreenShare">@drawable/ic_screensharing_off</item>
+        <item name="gliaIconScreenSharingDialog">@drawable/ic_screensharing</item>
 
         <item name="gliaSendMessageButtonTintColor">?attr/gliaBrandPrimaryColor</item>
 

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_ScreenSharingDialogTest_withGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_ScreenSharingDialogTest_withGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7badad318c0592976440c772ef39cf899bdaed69e759cfd29477beb8e09027df
-size 46836
+oid sha256:eb1da4b9d26ba05446d375faf5356315dcfd92b90e8418ae6fd7d1924473359e
+size 46132

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_ScreenSharingDialogTest_withUiTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_ScreenSharingDialogTest_withUiTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fc4f49637a68bfc78aef3280776d35af9ef20bbb381f6e64d099e4d34af8b6c
-size 48714
+oid sha256:ac4b1a671a88beeaf702cb1c3c7e3e1979953a00fbc67e8df784d7f2fdf0d458
+size 48032

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_ScreenSharingDialogTest_withUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_ScreenSharingDialogTest_withUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54fc67987ad0aae53c626c4f3bbcd356120366377e9c38502028a095cac8fdfa
-size 53842
+oid sha256:f14a51dc9eb928b1b1a50007f6065933dd3c18987f1a635b3e8304d80b93982d
+size 52622

--- a/widgetssdk/src/testSnapshot/res/values/themes_material.xml
+++ b/widgetssdk/src/testSnapshot/res/values/themes_material.xml
@@ -29,6 +29,7 @@
         <item name="gliaIconPlaceholder">@drawable/ic_person</item>
         <item name="gliaIconOnHold">@drawable/ic_pause_circle</item>
         <item name="gliaIconEndScreenShare">@drawable/ic_screensharing_off</item>
+        <item name="gliaIconScreenSharingDialog">@drawable/ic_screensharing</item>
 
         <item name="gliaSendMessageButtonTintColor">?attr/gliaBrandPrimaryColor</item>
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3067

**What was solved?**
Fix - Defining `gliaIconScreenSharingDialog` did not affect the screen-sharing dialog icon.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
