### PR TITLE
Fix CV confirmation dialog absence when returning from WebBrowser

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcher.kt
@@ -32,9 +32,10 @@ internal class CallVisualizerActivityWatcher(
             event.consumed -> Logger.d(TAG, "skipping.., event is already consumed")
             activity == null || activity.isFinishing -> Logger.d(TAG, "skipping.. activity is null or finishing")
             activity is WebBrowserActivity && state is ControllerState.DisplayConfirmationDialog -> Logger.d(TAG, "skipping.. WebBrowser is open")
-            activity is WebBrowserActivity && state !is ControllerState.DisplayConfirmationDialog -> event.consume { controller.onWebBrowserOpened() }
+            activity is WebBrowserActivity && state is ControllerState.OpenWebBrowserScreen -> event.consume { controller.onWebBrowserOpened() }
             state is ControllerState.DismissDialog -> event.consume { dismissAlertDialogSilently() }
-            state is ControllerState.OpenWebBrowserScreen -> event.consume { openWebBrowser(activity, state.title, state.url) }
+            //Ensure this state remains unconsumed until the opening of the WebBrowserActivity.
+            state is ControllerState.OpenWebBrowserScreen -> openWebBrowser(activity, state.title, state.url)
             state is ControllerState.CloseHolderActivity -> event.consume { closeHolderActivity(activity) }
             state is ControllerState.DisplayVisitorCodeDialog -> displayVisitorCodeDialog(activity)
             state is ControllerState.DisplayConfirmationDialog -> displayConfirmationDialog(

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcherTest.kt
@@ -71,9 +71,9 @@ class CallVisualizerActivityWatcherTest {
     }
 
     @Test
-    fun `resuming WebBrowserActivity will notify web browser opened when current state is not DisplayConfirmationDialog`() {
+    fun `resuming WebBrowserActivity will notify web browser opened when current state is OpenWebBrowserScreen`() {
         emitActivity<WebBrowserActivity>()
-        val event = createMockEvent(CallVisualizerContract.State.DismissDialog)
+        val event = createMockEvent(CallVisualizerContract.State.OpenWebBrowserScreen("Title", "url"))
         emitState(event)
 
         verify { event.consume(any()) }
@@ -324,7 +324,8 @@ class CallVisualizerActivityWatcherTest {
         verify { activity.isFinishing }
         verify { event.consumed }
         verify { event.value }
-        verify { event.consume(any()) }
+        verify(exactly = 0) { event.consume(any()) }
+        verify(exactly = 0) { event.markConsumed() }
         verify { activity.startActivity(eq(intent)) }
 
         confirmVerified(activity, event)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3140

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
