### PR TITLE
Do not hardcode the FORBIDDEN_DURING_ENGAGEMENT behavior in IsAuthenticatedUseCase

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -16,6 +16,7 @@ import com.glia.androidsdk.visitor.Authentication;
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest;
 import com.glia.widgets.chat.adapter.CustomCardAdapter;
 import com.glia.widgets.chat.adapter.WebViewCardAdapter;
+import com.glia.widgets.core.authentication.AuthenticationManager;
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer;
 import com.glia.widgets.core.visitor.GliaVisitorInfo;
 import com.glia.widgets.core.visitor.GliaWidgetException;
@@ -296,7 +297,9 @@ public class GliaWidgets {
      * {@link GliaException.Cause#INVALID_INPUT} - when SDK is not initialized
      */
     public static Authentication getAuthentication(@NonNull Authentication.Behavior behavior) {
-        return Dependencies.glia().getAuthentication(behavior);
+        AuthenticationManager authentication = Dependencies.glia().getAuthenticationManager(behavior);
+        Dependencies.setAuthenticationManager(authentication);
+        return authentication;
     }
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/IsAuthenticatedUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/IsAuthenticatedUseCase.kt
@@ -2,6 +2,6 @@ package com.glia.widgets.chat.domain
 
 import com.glia.androidsdk.visitor.Authentication
 
-internal class IsAuthenticatedUseCase(private val authentication: Authentication) {
-    operator fun invoke(): Boolean = authentication.isAuthenticated
+internal class IsAuthenticatedUseCase(private val authentication: Authentication?) {
+    operator fun invoke(): Boolean = authentication?.isAuthenticated == true
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import androidx.lifecycle.Lifecycle;
@@ -14,6 +15,7 @@ import com.glia.widgets.StringProviderImpl;
 import com.glia.widgets.callvisualizer.CallVisualizerActivityWatcher;
 import com.glia.widgets.core.audio.AudioControlManager;
 import com.glia.widgets.core.audio.domain.OnAudioStartedUseCase;
+import com.glia.widgets.core.authentication.AuthenticationManager;
 import com.glia.widgets.core.callvisualizer.CallVisualizerManager;
 import com.glia.widgets.core.chathead.ChatHeadManager;
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager;
@@ -44,6 +46,8 @@ public class Dependencies {
     private static ControllerFactory controllerFactory;
     private static INotificationManager notificationManager;
     private static CallVisualizerManager callVisualizerManager;
+    @Nullable
+    private static AuthenticationManager authenticationManager;
     private static UseCaseFactory useCaseFactory;
     private static ManagerFactory managerFactory;
     private static GliaCore gliaCore = new GliaCoreImpl();
@@ -76,6 +80,7 @@ public class Dependencies {
             sdkConfigurationManager,
             new ChatHeadManager(application),
             audioControlManager,
+            authenticationManager,
             schedulers,
             stringProvider,
             gliaCore
@@ -221,6 +226,10 @@ public class Dependencies {
     @VisibleForTesting
     public static void setRepositoryFactory(RepositoryFactory repositoryFactory) {
         Dependencies.repositoryFactory = repositoryFactory;
+    }
+
+    public static void setAuthenticationManager(@NonNull AuthenticationManager authenticationManager) {
+        Dependencies.authenticationManager = authenticationManager;
     }
 
     private static void initApplicationLifecycleObserver(

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -20,6 +20,7 @@ import com.glia.androidsdk.site.SiteInfo
 import com.glia.androidsdk.visitor.Authentication
 import com.glia.androidsdk.visitor.VisitorInfo
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest
+import com.glia.widgets.core.authentication.AuthenticationManager
 import java.io.InputStream
 import java.util.Optional
 import java.util.function.Consumer
@@ -61,5 +62,5 @@ internal interface GliaCore {
     fun clearVisitorSession()
     fun getSiteInfo(callback: RequestCallback<SiteInfo?>)
     fun getOperator(operatorId: String, callback: RequestCallback<Operator?>)
-    fun getAuthentication(behavior: Authentication.Behavior): Authentication
+    fun getAuthenticationManager(behavior: Authentication.Behavior): AuthenticationManager
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -129,7 +129,7 @@ internal class GliaCoreImpl : GliaCore {
         Glia.getOperator(operatorId, callback)
     }
 
-    override fun getAuthentication(behavior: Authentication.Behavior): Authentication {
+    override fun getAuthenticationManager(behavior: Authentication.Behavior): AuthenticationManager {
         return AuthenticationManager(Glia.getAuthentication(behavior))
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -2,7 +2,6 @@ package com.glia.widgets.di;
 
 import androidx.annotation.NonNull;
 
-import com.glia.androidsdk.visitor.Authentication;
 import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.StringProvider;
 import com.glia.widgets.call.domain.HandleCallPermissionsUseCase;
@@ -55,6 +54,7 @@ import com.glia.widgets.chat.domain.gva.ParseGvaGalleryCardsUseCase;
 import com.glia.widgets.core.audio.AudioControlManager;
 import com.glia.widgets.core.audio.domain.OnAudioStartedUseCase;
 import com.glia.widgets.core.audio.domain.TurnSpeakerphoneUseCase;
+import com.glia.widgets.core.authentication.AuthenticationManager;
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase;
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeViewBuilderUseCase;
 import com.glia.widgets.core.chathead.ChatHeadManager;
@@ -179,6 +179,7 @@ public class UseCaseFactory {
     private final INotificationManager notificationManager;
     private final ChatHeadManager chatHeadManager;
     private final AudioControlManager audioControlManager;
+    private final AuthenticationManager authenticationManager;
     private final Schedulers schedulers;
     private final StringProvider stringProvider;
     private final GliaCore gliaCore;
@@ -192,6 +193,7 @@ public class UseCaseFactory {
                           GliaSdkConfigurationManager gliaSdkConfigurationManager,
                           ChatHeadManager chatHeadManager,
                           AudioControlManager audioControlManager,
+                          AuthenticationManager authenticationManager,
                           Schedulers schedulers,
                           StringProvider stringProvider,
                           GliaCore gliaCore) {
@@ -205,6 +207,7 @@ public class UseCaseFactory {
         this.schedulers = schedulers;
         this.stringProvider = stringProvider;
         this.gliaCore = gliaCore;
+        this.authenticationManager = authenticationManager;
     }
 
     @NonNull
@@ -590,7 +593,7 @@ public class UseCaseFactory {
 
     @NonNull
     public IsAuthenticatedUseCase createIsAuthenticatedUseCase() {
-        return new IsAuthenticatedUseCase(gliaCore.getAuthentication(Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT));
+        return new IsAuthenticatedUseCase(authenticationManager);
     }
 
     @NonNull


### PR DESCRIPTION
**Jira issue:**
[Save Authentication object with a specified behavior](https://glia.atlassian.net/browse/MOB-3153)

**What was solved?**
Since we have more than one behavior, it's not okay to hardcode behavior in IsAuthenticatedUseCase now. Let's save `Authentication` object with a specified behavior when an integrator creates it.

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

