### PR TITLE
Add setting for authentication behavior to the Settings screen of tes…

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/Utils.java
+++ b/app/src/main/java/com/glia/exampleapp/Utils.java
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat;
 
 import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.screensharing.ScreenSharing;
+import com.glia.androidsdk.visitor.Authentication;
 import com.glia.widgets.GliaWidgets;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.view.configuration.ButtonConfiguration;
@@ -305,6 +306,24 @@ class Utils {
             return ScreenSharing.Mode.APP_BOUNDED;
         } else {
             return ScreenSharing.Mode.UNBOUNDED;
+        }
+    }
+
+    public static Authentication.Behavior getAuthenticationBehaviorFromPrefs(
+        SharedPreferences sharedPreferences,
+        Resources resources
+    ) {
+        String forbiddenDuringEngagementValue = resources.getString(R.string.authentication_behavior_forbidden_during_engagement);
+        String allowedDuringEngagementValue = resources.getString(R.string.authentication_behavior_allowed_during_engagement);
+        String valueFromPrefs = sharedPreferences.getString(
+            resources.getString(R.string.pref_authentication_behavior),
+            forbiddenDuringEngagementValue
+        );
+
+        if (valueFromPrefs.equals(allowedDuringEngagementValue)) {
+            return Authentication.Behavior.ALLOWED_DURING_ENGAGEMENT;
+        } else {
+            return Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT;
         }
     }
 

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -50,6 +50,7 @@
     <string name="pref_chat_started_caption_text_color">chat_started_caption_text_color</string>
     <string name="pref_send_message_button_tint_color">send_message_button_tint_color</string>
     <string name="pref_screen_sharing_mode">screen_sharing_mode</string>
+    <string name="pref_authentication_behavior">authentication_behavior</string>
     <string name="default_value">default</string>
     <string name="color_blue_value">blue</string>
     <string name="color_grey_value">grey</string>
@@ -70,6 +71,8 @@
     <string name="font_size_large">large</string>
     <string name="screen_sharing_mode_unbounded">unbounded</string>
     <string name="screen_sharing_mode_app_bounded">app_bounded</string>
+    <string name="authentication_behavior_forbidden_during_engagement">forbidden_during_engagement</string>
+    <string name="authentication_behavior_allowed_during_engagement">allowed_during_engagement</string>
     <array name="colors">
         <item>@string/settings_value_default</item>
         <item>@string/settings_color_blue</item>
@@ -117,5 +120,13 @@
     <array name="screen_sharing_mode_values">
         <item>@string/screen_sharing_mode_unbounded</item>
         <item>@string/screen_sharing_mode_app_bounded</item>
+    </array>
+    <array name="authentication_behavior_keys">
+        <item>@string/settings_authentication_behavior_forbidden_during_engagement</item>
+        <item>@string/settings_authentication_behavior_allowed_during_engagement</item>
+    </array>
+    <array name="authentication_behavior_values">
+        <item>@string/authentication_behavior_forbidden_during_engagement</item>
+        <item>@string/authentication_behavior_allowed_during_engagement</item>
     </array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,9 @@
     <string name="settings_screen_sharing_mode_title">Screen sharing mode</string>
     <string name="settings_screen_sharing_mode_unbounded">Unbounded</string>
     <string name="settings_screen_sharing_mode_app_bounded">App bounded</string>
+    <string name="settings_authentication_behavior_title">Authentication behavior</string>
+    <string name="settings_authentication_behavior_forbidden_during_engagement">Forbidden during engagement</string>
+    <string name="settings_authentication_behavior_allowed_during_engagement">Allowed during engagement</string>
 
     <string name="main_open_settings">Open Settings</string>
     <string name="main_launch_activity">Launch Chat in Activity</string>

--- a/app/src/main/res/xml/sdk_basic_prefs.xml
+++ b/app/src/main/res/xml/sdk_basic_prefs.xml
@@ -57,6 +57,15 @@
             android:key="@string/pref_screen_sharing_mode"
             android:title="@string/settings_screen_sharing_mode_title"
             app:useSimpleSummaryProvider="true" />
+
+        <ListPreference
+            android:layout_height="wrap_content"
+            android:defaultValue="@string/authentication_behavior_forbidden_during_engagement"
+            android:entries="@array/authentication_behavior_keys"
+            android:entryValues="@array/authentication_behavior_values"
+            android:key="@string/pref_authentication_behavior"
+            android:title="@string/settings_authentication_behavior_title"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Engagement settings">


### PR DESCRIPTION
**Jira issue:**
[Developers want to set authentication behavior from the Settings screen of Widgets testing app](https://glia.atlassian.net/browse/MOB-3158)

Bitrise build fails because Core SDK release is needed for `ALLOWED_DURING_ENGAGEMENT` behavior import.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**

[Screen_recording_20240307_112547.webm](https://github.com/salemove/android-sdk-widgets/assets/57521863/ad0ed5ae-32f2-40c0-a636-6d632577b1de)
