### PR TITLE
Fix DialogHolder Activity crashes when the app is in the background

### DIFF
--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -72,7 +72,6 @@
         <activity
             android:name=".helper.DialogHolderActivity"
             android:launchMode="singleTask"
-            android:noHistory="true"
             android:theme="@style/Application.Glia.Translucent.Activity" />
 
         <service

--- a/widgetssdk/src/main/java/com/glia/widgets/base/BaseActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/base/BaseActivityWatcher.kt
@@ -12,6 +12,7 @@ import com.glia.widgets.helper.DialogHolderActivity
 import com.glia.widgets.helper.GliaActivityManager
 import com.glia.widgets.helper.asStateFlowable
 import com.glia.widgets.helper.isGlia
+import com.glia.widgets.helper.parentActivity
 import com.glia.widgets.helper.withRuntimeTheme
 import io.reactivex.Flowable
 import io.reactivex.Observable
@@ -95,6 +96,11 @@ internal open class BaseSingleActivityWatcher(private val gliaActivityManager: G
 
     @CallSuper
     final override fun onActivityDestroyed(activity: Activity) {
+
+        if (activity == alertDialog?.parentActivity) {
+            dismissAlertDialogSilently()
+        }
+
         gliaActivityManager.onActivityDestroyed(activity)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ContextExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ContextExtensions.kt
@@ -10,9 +10,10 @@ import androidx.annotation.AttrRes
 import androidx.annotation.DimenRes
 import androidx.annotation.IntRange
 import androidx.annotation.StyleRes
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.withStyledAttributes
-import com.glia.widgets.GliaWidgets
 import com.glia.widgets.BuildConfig
+import com.glia.widgets.GliaWidgets
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.google.android.material.theme.overlay.MaterialThemeOverlay
@@ -67,3 +68,5 @@ internal val Activity.qualifiedName: String
 
 internal val Activity.isGlia: Boolean
     get() = qualifiedName.startsWith(BuildConfig.LIBRARY_PACKAGE_NAME)
+
+internal val AlertDialog.parentActivity: Activity? get() = context.asActivity()


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-MOB 3171

**What was solved?**
There were two issues
- I removed the `noHistory` because it was destroying activity when the application went to the background.
- And added the dismissing dialog logic in case the activity that holds the dialog is destroyed to not leak the `window` and crash the application.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
