### PR TITLE
Fix screen sharing state doesn’t change after an engagement end

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -143,6 +143,14 @@ internal class EngagementRepositoryImpl(private val core: GliaCore, private val 
         currentEngagement?.let { endEngagement(true) } ?: cancelQueuing()
     }
 
+    private fun resetState() {
+        _operatorMediaState.onNext(Data.Empty)
+        _visitorMediaState.onNext(Data.Empty)
+        _currentOperator.onNext(Data.Empty)
+        _onHoldState.onNext(false)
+        markScreenSharingEnded()
+    }
+
     override fun endEngagement(silently: Boolean) {
         currentEngagement?.also {
             currentEngagement = null
@@ -155,10 +163,7 @@ internal class EngagementRepositoryImpl(private val core: GliaCore, private val 
             } else {
                 fetchSurvey(it, false)
             }
-            _operatorMediaState.onNext(Data.Empty)
-            _visitorMediaState.onNext(Data.Empty)
-            _currentOperator.onNext(Data.Empty)
-            _onHoldState.onNext(false)
+            resetState()
         }
     }
 
@@ -421,10 +426,7 @@ internal class EngagementRepositoryImpl(private val core: GliaCore, private val 
             currentEngagement = null
             unsubscribeFromEvents(it)
             notifyEngagementEnded(it)
-            _operatorMediaState.onNext(Data.Empty)
-            _visitorMediaState.onNext(Data.Empty)
-            _currentOperator.onNext(Data.Empty)
-            _onHoldState.onNext(false)
+            resetState()
 
             if (it is OmnicoreEngagement) {
                 fetchSurvey(it, true)
@@ -540,6 +542,10 @@ internal class EngagementRepositoryImpl(private val core: GliaCore, private val 
 
     private fun onScreenSharingEnded() {
         Logger.i(TAG, "Screen sharing ended")
+        markScreenSharingEnded()
+    }
+
+    private fun markScreenSharingEnded() {
         _screenSharingState.onNext(ScreenSharingState.Ended)
         currentScreenSharingScreen = null
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
@@ -312,6 +312,9 @@ class EngagementRepositoryTest {
             visitorMediaState.test().assertNotComplete().assertValue(Data.Empty)
             onHoldState.test().assertNotComplete().assertValue(false)
             operatorMediaState.test().assertNotComplete().assertValue(Data.Empty)
+            if (ongoingEngagement) {
+                screenSharingState.test().assertNotComplete().assertValue(ScreenSharingState.Ended)
+            }
             assertNull(operatorCurrentMediaState)
             assertNull(currentOperatorValue)
         }


### PR DESCRIPTION
MOB 3169

**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
