### PR TITLE
Bugfix/mob 3186 bubble on hold

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -333,6 +333,7 @@ internal class EngagementRepositoryImpl(private val core: GliaCore, private val 
         currentEngagement?.also {
             unsubscribeFromEvents(it)
             currentEngagement = null
+            resetState()
         } ?: _engagementState.onNext(State.StartedOmniCore)
 
         currentEngagement = engagement
@@ -350,6 +351,7 @@ internal class EngagementRepositoryImpl(private val core: GliaCore, private val 
         currentEngagement?.also {
             unsubscribeFromEvents(it)
             currentEngagement = null
+            resetState()
         } ?: _engagementState.onNext(State.StartedCallVisualizer)
 
         currentEngagement = engagement

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -127,6 +127,7 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     private fun engagementEnded() {
+        isOnHold = false
         state = State.ENDED
         operatorProfileImgUrl = null
         unreadMessagesCount = 0
@@ -169,6 +170,7 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     private fun onNewEngagementLoaded() {
+        isOnHold = false
         state = State.ENGAGEMENT
         chatHeadLayout?.show()
         updateChatHeadView()

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
@@ -147,6 +147,7 @@ internal class ServiceChatHeadController(
 
     private fun engagementEnded() {
         toggleChatHeadServiceUseCase.onDestroy()
+        isOnHold = false
         state = State.ENDED
         operatorProfileImgUrl = null
         unreadMessagesCount = 0
@@ -155,6 +156,7 @@ internal class ServiceChatHeadController(
     }
 
     private fun newEngagementLoaded() {
+        isOnHold = false
         state = State.ENGAGEMENT
         toggleChatHeadServiceUseCase.invoke(resumedViewName)
         if (sdkConfiguration == null) setSdkConfiguration(


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3186

**What was solved?**
On some devices "On Hold" indicator remained after engagement was restarted due to auth.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)
