### PR TITLE
Migrate all capture image and get content actions to activity result api

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/Constants.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/Constants.kt
@@ -2,21 +2,6 @@ package com.glia.widgets
 
 internal object Constants {
     /**
-     * Used by the sdk to differentiate between CHAT and CALL and CALL and IMAGE_PREVIEW activities.
-     */
-    const val CHAT_ACTIVITY = "chat_activity"
-
-    /**
-     * Used by the sdk to differentiate between CHAT and CALL and CALL and IMAGE_PREVIEW activities.
-     */
-    const val CALL_ACTIVITY = "call_activity"
-
-    /**
-     * Used by the sdk to differentiate between CHAT and CALL and IMAGE_PREVIEW activities.
-     */
-    const val IMAGE_PREVIEW_ACTIVITY = "image_preview_activity"
-
-    /**
      * Global media timer delay value
      */
     const val CALL_TIMER_DELAY = 0
@@ -30,4 +15,19 @@ internal object Constants {
      * Needed to overlap existing app bar in existing view with this view's app bar.
      */
     const val WIDGETS_SDK_LAYER_ELEVATION = 100f
+
+    /**
+     * MIME type for ActivityResultLauncher to show only images
+     */
+    const val MIME_TYPE_IMAGES = "image/*"
+
+    /**
+     * MIME type for ActivityResultLauncher to show all files
+     */
+    const val MIME_TYPE_ALL = "*/*"
+
+    /**
+     * Delay for WebView initialization
+     */
+    const val WEB_VIEW_INITIALIZATION_DELAY = 100L
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -17,7 +17,6 @@ import com.glia.widgets.call.Configuration;
 import com.glia.widgets.core.configuration.GliaSdkConfiguration;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
-import com.glia.widgets.helper.Utils;
 
 import java.util.Objects;
 
@@ -86,7 +85,6 @@ public final class ChatActivity extends FadeTransitionActivity {
             .putExtra(GliaWidgets.CONTEXT_ASSET_ID, contextId)
             .putExtra(GliaWidgets.QUEUE_ID, queueId)
             .putExtra(GliaWidgets.COMPANY_NAME, "Legacy company")
-            .putExtra(GliaWidgets.COMPANY_NAME, "Legacy company")
             .putExtra(GliaWidgets.CHAT_TYPE, (Parcelable) chatType);
     }
 
@@ -152,13 +150,6 @@ public final class ChatActivity extends FadeTransitionActivity {
     @Override
     public void onBackPressed() {
         chatView.onBackPressed();
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        GliaWidgets.onActivityResult(requestCode, resultCode, data);
-        chatView.onActivityResult(requestCode, resultCode, data);
-        super.onActivityResult(requestCode, resultCode, data);
     }
 
     @Override

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatContract.kt
@@ -18,7 +18,6 @@ import com.glia.widgets.core.fileupload.model.FileAttachment
 internal interface ChatContract {
     interface Controller : BaseController {
         val isChatVisible: Boolean
-        var photoCaptureFileUri: Uri?
 
         fun setView(view: View)
         fun onDestroy(retain: Boolean)
@@ -26,7 +25,6 @@ internal interface ChatContract {
         fun onGvaButtonClicked(button: GvaButton)
         fun isCallVisualizerOngoing(): Boolean
         fun onFileDownloadClicked(attachmentFile: AttachmentFile)
-        fun onAttachmentReceived(file: FileAttachment)
         fun onRemoveAttachment(attachment: FileAttachment)
         fun notificationDialogDismissed()
         fun newMessagesIndicatorClicked()
@@ -55,10 +53,12 @@ internal interface ChatContract {
         fun onPause()
         fun onResume()
         fun onForceStopScreenSharing()
+        fun onTakePhotoClicked()
+        fun onImageCaptured(result: Boolean)
+        fun onContentChosen(uri: Uri)
     }
 
     interface View : BaseView<Controller> {
-        fun clearTempFile()
         fun emitUploadAttachments(attachments: List<FileAttachment>)
         fun emitState(chatState: ChatState)
         fun emitItems(items: List<ChatItem>)
@@ -79,5 +79,6 @@ internal interface ChatContract {
         fun showEngagementConfirmationDialog()
         fun navigateToWebBrowserActivity(title: String, url: String)
         fun showToast(message: String, duration: Int = Toast.LENGTH_SHORT)
+        fun dispatchImageCapture(uri: Uri)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/FileProviderUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/FileProviderUseCase.kt
@@ -1,0 +1,16 @@
+package com.glia.widgets.chat.domain
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.glia.widgets.helper.fileProviderAuthority
+import java.io.File
+
+internal interface FileProviderUseCase {
+    fun getUriForFile(file: File): Uri
+}
+
+internal class FileProviderUseCaseImpl(private val context: Context) : FileProviderUseCase {
+    private val authority: String by lazy { context.fileProviderAuthority }
+    override fun getUriForFile(file: File): Uri = FileProvider.getUriForFile(context, authority, file)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/FixCapturedPictureRotationUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/FixCapturedPictureRotationUseCase.kt
@@ -1,0 +1,39 @@
+package com.glia.widgets.chat.domain
+
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+
+internal interface FixCapturedPictureRotationUseCase {
+    operator fun invoke(imageUri: Uri)
+}
+
+internal class FixCapturedPictureRotationUseCaseImpl(context: Context) : FixCapturedPictureRotationUseCase {
+    private val contentResolver: ContentResolver by lazy { context.contentResolver }
+    override fun invoke(imageUri: Uri) {
+        val matrix: Matrix = contentResolver.openInputStream(imageUri)?.use {
+            val orientation = ExifInterface(it).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+
+            val rotation = when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> 90f
+                ExifInterface.ORIENTATION_ROTATE_180 -> 180f
+                ExifInterface.ORIENTATION_ROTATE_270 -> 270f
+                else -> 0f
+            }
+
+            Matrix().apply { postRotate(rotation) }
+        } ?: Matrix()
+
+        val bitmap: Bitmap = contentResolver.openInputStream(imageUri)?.use {
+            val rawBitmap: Bitmap = BitmapFactory.decodeStream(it) ?: return
+
+            Bitmap.createBitmap(rawBitmap, 0, 0, rawBitmap.width, rawBitmap.height, matrix, true)
+        } ?: return
+
+        contentResolver.openOutputStream(imageUri)?.use { bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it) }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/TakePictureUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/TakePictureUseCase.kt
@@ -1,0 +1,62 @@
+package com.glia.widgets.chat.domain
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import com.glia.widgets.core.fileupload.model.FileAttachment
+import java.io.File
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private const val FILE_SUFFIX = ".jpg"
+private const val PATTERN = "yyyyMMdd_HHmmss_"
+
+internal interface TakePictureUseCase {
+    fun prepare(onFileCreated: (Uri) -> Unit)
+
+    fun onImageCaptured(captured: Boolean, onFileReady: (FileAttachment) -> Unit)
+    fun deleteCurrent()
+}
+
+internal class TakePictureUseCaseImpl(
+    private val context: Context,
+    private val fileProviderUseCase: FileProviderUseCase,
+    private val uriToFileAttachmentUseCase: UriToFileAttachmentUseCase,
+    private val fixCapturedPictureRotationUseCase: FixCapturedPictureRotationUseCase
+) : TakePictureUseCase {
+    private val contentResolver: ContentResolver by lazy { context.contentResolver }
+    private val dateFormat: DateFormat by lazy { SimpleDateFormat(PATTERN, Locale.getDefault()) }
+    private val fileName: String get() = "IMG_${dateFormat.format(Date())}"
+
+    private var uri: Uri? = null
+
+    override fun prepare(onFileCreated: (Uri) -> Unit) {
+        uri = fileProviderUseCase.getUriForFile(createTempPhotoFile()).also(onFileCreated)
+    }
+
+    override fun onImageCaptured(captured: Boolean, onFileReady: (FileAttachment) -> Unit) {
+        if (!captured) {
+            deleteCurrent()
+            return
+        }
+
+        fixCapturedPictureRotationUseCase(uri ?: return)
+        uriToFileAttachmentUseCase(uri ?: return)?.also(onFileReady)
+    }
+
+    override fun deleteCurrent() {
+        uri?.also {
+            contentResolver.delete(it, null, null)
+            uri = null
+        }
+    }
+
+    private fun createTempPhotoFile(): File = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES).let {
+        it?.deleteOnExit()
+        File.createTempFile(fileName, FILE_SUFFIX, it)
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/UriToFileAttachmentUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/UriToFileAttachmentUseCase.kt
@@ -1,0 +1,26 @@
+package com.glia.widgets.chat.domain
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.glia.widgets.core.fileupload.model.FileAttachment
+
+internal interface UriToFileAttachmentUseCase {
+    operator fun invoke(uri: Uri): FileAttachment?
+}
+
+internal class UriToFileAttachmentUseCaseImpl(context: Context) : UriToFileAttachmentUseCase {
+    private val contentResolver: ContentResolver by lazy { context.contentResolver }
+    override fun invoke(uri: Uri): FileAttachment? = contentResolver.query(uri, null, null, null, null)?.use {
+        if (it.count == 0) return@use null
+
+        val nameIndex = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        val sizeIndex = it.getColumnIndex(OpenableColumns.SIZE)
+        it.moveToFirst()
+        val displayName = it.getString(nameIndex)
+        val mimeType = contentResolver.getType(uri)
+        val size = it.getLong(sizeIndex)
+        FileAttachment(uri, mimeType, displayName, size)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -132,7 +132,9 @@ public class ControllerFactory {
                 useCaseFactory.getIsQueueingOrEngagementUseCase(),
                 useCaseFactory.getQueueForEngagementUseCase(),
                 useCaseFactory.getDecideOnQueueingUseCase(),
-                useCaseFactory.getScreenSharingUseCase()
+                useCaseFactory.getScreenSharingUseCase(),
+                useCaseFactory.getTakePictureUseCase(),
+                useCaseFactory.getUriToFileAttachmentUseCase()
             );
         }
 
@@ -300,7 +302,9 @@ public class ControllerFactory {
             useCaseFactory.createEnableSendMessageButtonUseCase(),
             useCaseFactory.createShowMessageLimitErrorUseCase(),
             useCaseFactory.createResetMessageCenterUseCase(),
-            createDialogController()
+            createDialogController(),
+            useCaseFactory.getTakePictureUseCase(),
+            useCaseFactory.getUriToFileAttachmentUseCase()
         );
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -25,7 +25,11 @@ import com.glia.widgets.chat.domain.CustomCardTypeUseCase;
 import com.glia.widgets.chat.domain.DecideOnQueueingUseCase;
 import com.glia.widgets.chat.domain.DecideOnQueueingUseCaseImpl;
 import com.glia.widgets.chat.domain.DecodeSampledBitmapFromInputStreamUseCase;
+import com.glia.widgets.chat.domain.FileProviderUseCase;
+import com.glia.widgets.chat.domain.FileProviderUseCaseImpl;
 import com.glia.widgets.chat.domain.FindNewMessagesDividerIndexUseCase;
+import com.glia.widgets.chat.domain.FixCapturedPictureRotationUseCase;
+import com.glia.widgets.chat.domain.FixCapturedPictureRotationUseCaseImpl;
 import com.glia.widgets.chat.domain.GliaLoadHistoryUseCase;
 import com.glia.widgets.chat.domain.GliaOnMessageUseCase;
 import com.glia.widgets.chat.domain.GliaSendMessagePreviewUseCase;
@@ -41,7 +45,11 @@ import com.glia.widgets.chat.domain.MapResponseCardUseCase;
 import com.glia.widgets.chat.domain.MapVisitorAttachmentUseCase;
 import com.glia.widgets.chat.domain.SendUnsentMessagesUseCase;
 import com.glia.widgets.chat.domain.SiteInfoUseCase;
+import com.glia.widgets.chat.domain.TakePictureUseCase;
+import com.glia.widgets.chat.domain.TakePictureUseCaseImpl;
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase;
+import com.glia.widgets.chat.domain.UriToFileAttachmentUseCase;
+import com.glia.widgets.chat.domain.UriToFileAttachmentUseCaseImpl;
 import com.glia.widgets.chat.domain.gva.DetermineGvaButtonTypeUseCase;
 import com.glia.widgets.chat.domain.gva.DetermineGvaUrlTypeUseCase;
 import com.glia.widgets.chat.domain.gva.GetGvaTypeUseCase;
@@ -189,8 +197,8 @@ public class UseCaseFactory {
     private final Schedulers schedulers;
     private final StringProvider stringProvider;
     private final GliaCore gliaCore;
-    private Gson gvaGson;
     private final Context applicationContext;
+    private Gson gvaGson;
 
     UseCaseFactory(RepositoryFactory repositoryFactory,
                    PermissionManager permissionManager,
@@ -997,5 +1005,30 @@ public class UseCaseFactory {
     @NonNull
     public IsPushNotificationsSetUpUseCase getIsPushNotificationsSetUpUseCase() {
         return new IsPushNotificationsSetUpUseCaseImpl(applicationContext);
+    }
+
+    @NonNull
+    public FileProviderUseCase getFileProviderUseCase() {
+        return new FileProviderUseCaseImpl(applicationContext);
+    }
+
+    @NonNull
+    public FixCapturedPictureRotationUseCase getFixCapturedPictureRotationUseCase() {
+        return new FixCapturedPictureRotationUseCaseImpl(applicationContext);
+    }
+
+    @NonNull
+    public UriToFileAttachmentUseCase getUriToFileAttachmentUseCase() {
+        return new UriToFileAttachmentUseCaseImpl(applicationContext);
+    }
+
+    @NonNull
+    public TakePictureUseCase getTakePictureUseCase() {
+        return new TakePictureUseCaseImpl(
+            applicationContext,
+            getFileProviderUseCase(),
+            getUriToFileAttachmentUseCase(),
+            getFixCapturedPictureRotationUseCase()
+        );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/Files.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/Files.kt
@@ -2,34 +2,23 @@
 
 package com.glia.widgets.helper
 
-import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Matrix
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import android.provider.OpenableColumns
 import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
-import androidx.exifinterface.media.ExifInterface
 import com.glia.androidsdk.chat.AttachmentFile
-import com.glia.widgets.core.fileupload.model.FileAttachment
 import java.io.File
-import java.io.IOException
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 internal fun String?.toFileExtensionOrEmpty() = this?.let { File(it) }?.extension.orEmpty()
 
-internal val AttachmentFile.fileName: String
-    get() = toFileName(id, name)
-internal fun AttachmentFile.isDownloaded(context: Context): Boolean =
-    isDownloaded(context, this)
+internal val AttachmentFile.fileName: String get() = toFileName(id, name)
+
+internal fun AttachmentFile.isDownloaded(context: Context): Boolean = isDownloaded(context, this)
+
 internal fun isDownloaded(context: Context, attachmentFile: AttachmentFile): Boolean =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         getContentUriApi29(attachmentFile.fileName, context) != null
@@ -50,43 +39,6 @@ internal fun toFileName(fileId: String?, name: String?): String {
 internal val Context.fileProviderAuthority: String
     get() = "$packageName.com.glia.widgets.fileprovider"
 
-internal fun fixCapturedPhotoRotation(uri: Uri, context: Context) {
-    with(context.contentResolver) {
-        val matrix: Matrix = openInputStream(uri)?.use {
-            val orientation = ExifInterface(it).getAttributeInt(
-                ExifInterface.TAG_ORIENTATION,
-                ExifInterface.ORIENTATION_NORMAL
-            )
-            val rotation = when (orientation) {
-                ExifInterface.ORIENTATION_ROTATE_90 -> 90f
-                ExifInterface.ORIENTATION_ROTATE_180 -> 180f
-                ExifInterface.ORIENTATION_ROTATE_270 -> 270f
-                else -> 0f
-            }
-
-            Matrix().apply { postRotate(rotation) }
-        } ?: Matrix()
-
-        val bitmap: Bitmap = openInputStream(uri)?.use {
-            val rawBitmap: Bitmap = BitmapFactory.decodeStream(it) ?: return@with
-
-            Bitmap.createBitmap(
-                rawBitmap,
-                0,
-                0,
-                rawBitmap.width,
-                rawBitmap.height,
-                matrix,
-                true
-            )
-        } ?: return@with
-
-        openOutputStream(uri)?.use {
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it)
-        }
-    }
-}
-
 @RequiresApi(Build.VERSION_CODES.Q)
 private fun getContentUriApi29(fileName: String, context: Context): Uri? {
     val downloadsContentUri = MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL)
@@ -99,22 +51,15 @@ private fun getContentUriApi29(fileName: String, context: Context): Uri? {
     val selectionArgs = arrayOf(fileName)
     val sortOrder = MediaStore.Downloads.DISPLAY_NAME + " ASC"
 
-    return context.contentResolver.query(
-        downloadsContentUri,
-        projection,
-        selection,
-        selectionArgs,
-        sortOrder
-    )
-        ?.use {
-            if (it.count == 0) {
-                return@use null
-            }
-            val idColumn = it.getColumnIndexOrThrow(MediaStore.Downloads._ID)
-            it.moveToFirst()
-            val id = it.getLong(idColumn)
-            ContentUris.withAppendedId(downloadsContentUri, id)
+    return context.contentResolver.query(downloadsContentUri, projection, selection, selectionArgs, sortOrder)?.use {
+        if (it.count == 0) {
+            return@use null
         }
+        val idColumn = it.getColumnIndexOrThrow(MediaStore.Downloads._ID)
+        it.moveToFirst()
+        val id = it.getLong(idColumn)
+        ContentUris.withAppendedId(downloadsContentUri, id)
+    }
 }
 
 private fun getContentUri(fileName: String, context: Context): Uri =
@@ -130,29 +75,4 @@ internal fun getContentUriCompat(fileName: String, context: Context): Uri =
         getContentUriApi29(fileName, context) ?: Uri.EMPTY
     } else {
         getContentUri(fileName, context)
-    }
-
-@Throws(IOException::class)
-internal fun createTempPhotoFile(context: Context): File {
-    val directoryStorage = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-    directoryStorage?.deleteOnExit()
-    return File.createTempFile(generatePhotoFileName(), ".jpg", directoryStorage)
-}
-
-private fun generatePhotoFileName(): String =
-    SimpleDateFormat("yyyyMMdd_HHmmss_", Locale.getDefault()).run {
-        "IMG_${format(Date())}"
-    }
-
-internal fun mapUriToFileAttachment(contentResolver: ContentResolver, uri: Uri): FileAttachment? =
-    contentResolver.query(uri, null, null, null, null)?.use {
-        if (it.count == 0) return@use null
-
-        val nameIndex = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-        val sizeIndex = it.getColumnIndex(OpenableColumns.SIZE)
-        it.moveToFirst()
-        val displayName = it.getString(nameIndex)
-        val mimeType = contentResolver.getType(uri)
-        val size = it.getLong(sizeIndex)
-        FileAttachment(uri, mimeType, displayName, size)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
@@ -10,7 +10,6 @@ import com.glia.widgets.core.fileupload.model.FileAttachment
 
 internal interface MessageCenterContract {
     interface Controller : BaseController {
-        var photoCaptureFileUri: Uri?
         fun setConfiguration(uiTheme: UiTheme?, configuration: GliaSdkConfiguration?)
         fun setView(view: View)
         fun onCheckMessagesClicked()
@@ -23,12 +22,13 @@ internal interface MessageCenterContract {
         fun onBrowseClicked()
         fun onTakePhotoClicked()
         fun ensureMessageCenterAvailability()
-        fun onAttachmentReceived(file: FileAttachment)
         fun onRemoveAttachment(file: FileAttachment)
         fun addCallback(dialogCallback: DialogContract.Controller.Callback)
         fun removeCallback(dialogCallback: DialogContract.Controller.Callback)
         fun dismissDialogs()
         fun dismissCurrentDialog()
+        fun onImageCaptured(result: Boolean)
+        fun onContentChosen(uri: Uri)
     }
 
     interface View : BaseView<Controller> {
@@ -36,12 +36,11 @@ internal interface MessageCenterContract {
         fun onStateUpdated(state: MessageCenterState)
         fun emitUploadAttachments(attachments: List<FileAttachment>)
         fun selectAttachmentFile(type: String)
-        fun takePhoto()
+        fun takePhoto(uri: Uri)
         fun finish()
         fun navigateToMessaging()
         fun showAttachmentPopup()
         fun showConfirmationScreen()
         fun hideSoftKeyboard()
-        fun clearTemporaryFile(uri: Uri?)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -12,7 +12,9 @@ import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.IsSecureConversationsChatAvailableUseCase
 import com.glia.widgets.chat.domain.IsShowSendButtonUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
+import com.glia.widgets.chat.domain.TakePictureUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
+import com.glia.widgets.chat.domain.UriToFileAttachmentUseCase
 import com.glia.widgets.chat.domain.gva.DetermineGvaButtonTypeUseCase
 import com.glia.widgets.chat.model.Gva
 import com.glia.widgets.chat.model.GvaButton
@@ -98,6 +100,8 @@ class ChatControllerTest {
     private lateinit var enqueueForEngagementUseCase: EnqueueForEngagementUseCase
     private lateinit var decideOnQueueingUseCase: DecideOnQueueingUseCase
     private lateinit var screenSharingUseCase: ScreenSharingUseCase
+    private lateinit var takePictureUseCase: TakePictureUseCase
+    private lateinit var uriToFileAttachmentUseCase: UriToFileAttachmentUseCase
 
     private lateinit var chatController: ChatController
     private lateinit var isAuthenticatedUseCase: IsAuthenticatedUseCase
@@ -160,6 +164,9 @@ class ChatControllerTest {
             on { invoke() } doReturn Flowable.empty()
         }
 
+        takePictureUseCase = mock()
+        uriToFileAttachmentUseCase = mock()
+
         chatController = ChatController(
             callTimer = callTimer,
             minimizeHandler = minimizeHandler,
@@ -199,7 +206,9 @@ class ChatControllerTest {
             isQueueingOrEngagementUseCase = isQueueingOrEngagementUseCase,
             enqueueForEngagementUseCase = enqueueForEngagementUseCase,
             decideOnQueueingUseCase = decideOnQueueingUseCase,
-            screenSharingUseCase = screenSharingUseCase
+            screenSharingUseCase = screenSharingUseCase,
+            takePictureUseCase = takePictureUseCase,
+            uriToFileAttachmentUseCase = uriToFileAttachmentUseCase
         )
         chatController.setView(chatView)
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
@@ -4,6 +4,8 @@ import com.glia.androidsdk.GliaException
 import com.glia.widgets.UiTheme
 import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
+import com.glia.widgets.chat.domain.TakePictureUseCase
+import com.glia.widgets.chat.domain.UriToFileAttachmentUseCase
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.fileupload.model.FileAttachment
@@ -46,6 +48,8 @@ internal class MessageCenterControllerTest {
     private lateinit var showMessageLimitErrorUseCase: ShowMessageLimitErrorUseCase
     private lateinit var resetMessageCenterUseCase: ResetMessageCenterUseCase
     private lateinit var dialogController: DialogContract.Controller
+    private lateinit var takePictureUseCase: TakePictureUseCase
+    private lateinit var uriToFileAttachmentUseCase: UriToFileAttachmentUseCase
 
     @Before
     fun setUp() {
@@ -64,23 +68,26 @@ internal class MessageCenterControllerTest {
         showMessageLimitErrorUseCase = mock()
         resetMessageCenterUseCase = mock()
         dialogController = mock()
-        messageCenterController =
-            MessageCenterController(
-                serviceChatHeadController = serviceChatHeadController,
-                sendSecureMessageUseCase = sendSecureMessageUseCase,
-                isMessageCenterAvailableUseCase = isMessageCenterAvailableUseCase,
-                addFileAttachmentsObserverUseCase = addFileAttachmentsObserverUseCase,
-                addFileToAttachmentAndUploadUseCase = addFileToAttachmentAndUploadUseCase,
-                getFileAttachmentsUseCase = getFileAttachmentsUseCase,
-                removeFileAttachmentUseCase = removeFileAttachmentUseCase,
-                isAuthenticatedUseCase = isAuthenticatedUseCase,
-                siteInfoUseCase = siteInfoUseCase,
-                onNextMessageUseCase = onNextMessageUseCase,
-                sendMessageButtonStateUseCase = sendMessageButtonStateUseCase,
-                showMessageLimitErrorUseCase = showMessageLimitErrorUseCase,
-                resetMessageCenterUseCase = resetMessageCenterUseCase,
-                dialogController = dialogController
-            )
+        takePictureUseCase = mock()
+        uriToFileAttachmentUseCase = mock()
+        messageCenterController = MessageCenterController(
+            serviceChatHeadController = serviceChatHeadController,
+            sendSecureMessageUseCase = sendSecureMessageUseCase,
+            isMessageCenterAvailableUseCase = isMessageCenterAvailableUseCase,
+            addFileAttachmentsObserverUseCase = addFileAttachmentsObserverUseCase,
+            addFileToAttachmentAndUploadUseCase = addFileToAttachmentAndUploadUseCase,
+            getFileAttachmentsUseCase = getFileAttachmentsUseCase,
+            removeFileAttachmentUseCase = removeFileAttachmentUseCase,
+            isAuthenticatedUseCase = isAuthenticatedUseCase,
+            siteInfoUseCase = siteInfoUseCase,
+            onNextMessageUseCase = onNextMessageUseCase,
+            sendMessageButtonStateUseCase = sendMessageButtonStateUseCase,
+            showMessageLimitErrorUseCase = showMessageLimitErrorUseCase,
+            resetMessageCenterUseCase = resetMessageCenterUseCase,
+            dialogController = dialogController,
+            takePictureUseCase = takePictureUseCase,
+            uriToFileAttachmentUseCase = uriToFileAttachmentUseCase
+        )
     }
 
     @Test


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3220

**What was solved?**
Migrated all the image capture and got content/open document requests to the new activity result api.
- Moved some functions from the Files.kt file to the use cases to make them testable.
- Aligned functionality between Chat and MessageCenter layers.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
