### PR TITLE
Migrate all permission requests in Chat screen to activity result api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,12 +2,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "30.0.3"
+  compileSdk 34
     defaultConfig {
         applicationId "com.glia.exampleapp"
         minSdkVersion 24
-        targetSdkVersion 33
+      targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,9 +108,9 @@ ext {
   mockitoKotlinVersion = '5.2.1'
   mockitoAndroidTestVersion = '5.8.0'
   mockkVersion = '1.13.9'
-  archCoreVersion = '2.1.0'
+  archCoreVersion = '2.2.0'
   testRulesVersion = '1.5.0'
-  robolectricVersion = '4.9.2'
+  robolectricVersion = '4.11.1'
   lintVersion = '31.3.0'
 
   //kotlin

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -4,8 +4,7 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: 'app.cash.paparazzi'
 
 android {
-  compileSdkVersion 33
-  buildToolsVersion "30.0.3"
+  compileSdk 33
   defaultPublishConfig "debug"
   namespace 'com.glia.widgets'
   defaultConfig {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.glia.widgets.GliaWidgets;
@@ -150,13 +149,6 @@ public final class ChatActivity extends FadeTransitionActivity {
     @Override
     public void onBackPressed() {
         chatView.onBackPressed();
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        GliaWidgets.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        chatView.onRequestPermissionsResult(requestCode, grantResults);
     }
 
     private GliaSdkConfiguration createConfiguration(Intent intent) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatContract.kt
@@ -80,5 +80,6 @@ internal interface ChatContract {
         fun navigateToWebBrowserActivity(title: String, url: String)
         fun showToast(message: String, duration: Int = Toast.LENGTH_SHORT)
         fun dispatchImageCapture(uri: Uri)
+        fun onFileDownload(attachmentFile: AttachmentFile)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -1,10 +1,8 @@
 package com.glia.widgets.chat
 
-import android.Manifest
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.content.res.TypedArray
 import android.net.Uri
 import android.provider.Settings
@@ -18,7 +16,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.app.ActivityOptionsCompat
-import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import androidx.core.view.ViewCompat
 import androidx.core.view.isGone
@@ -109,7 +106,6 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
 
     private var stringProvider = Dependencies.getStringProvider()
     private var isInBottom = true
-    private var downloadFileHolder: AttachmentFile? = null
     private var theme: UiTheme by Delegates.notNull()
 
     // needed for setting status bar color back when view is gone
@@ -749,11 +745,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
             attachmentPopup.show(binding.chatMessageLayout, {
                 getContentLauncher?.launch(Constants.MIME_TYPE_IMAGES)
             }, {
-                if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
-                    controller?.onTakePhotoClicked()
-                } else {
-                    context.asActivity()?.requestPermissions(arrayOf(Manifest.permission.CAMERA), CAMERA_PERMISSION_REQUEST)
-                }
+                controller?.onTakePhotoClicked()
             }, {
                 getContentLauncher?.launch(Constants.MIME_TYPE_ALL)
             })
@@ -814,24 +806,11 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
     }
 
     override fun onFileDownloadClick(file: AttachmentFile) {
-        if (ContextCompat.checkSelfPermission(
-                context, Manifest.permission.WRITE_EXTERNAL_STORAGE
-            ) == PackageManager.PERMISSION_GRANTED
-        ) {
-            onFileDownload(file)
-        } else {
-            context.asActivity()?.requestPermissions(
-                arrayOf(
-                    Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE
-                ), WRITE_PERMISSION_REQUEST
-            )
-            downloadFileHolder = file
-        }
+        controller?.onFileDownloadClicked(file)
     }
 
-    private fun onFileDownload(attachmentFile: AttachmentFile) {
+    override fun onFileDownload(attachmentFile: AttachmentFile) {
         submitUpdatedItems(attachmentFile, isDownloading = true, isFileExists = false)
-        controller?.onFileDownloadClicked(attachmentFile)
     }
 
     override fun fileDownloadError(attachmentFile: AttachmentFile, error: Throwable) {
@@ -879,15 +858,6 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
 
     override fun onImageItemClick(item: AttachmentFile, view: View) {
         controller?.onImageItemClick(item, view)
-    }
-
-    fun onRequestPermissionsResult(requestCode: Int, grantResults: IntArray) {
-        if (grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED) {
-            when (requestCode) {
-                CAMERA_PERMISSION_REQUEST -> controller?.onTakePhotoClicked()
-                WRITE_PERMISSION_REQUEST -> downloadFileHolder?.also(::onFileDownload)
-            }
-        }
     }
 
     fun setConfiguration(configuration: GliaSdkConfiguration?) {
@@ -955,11 +925,6 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
 
     override fun post(action: Runnable?): Boolean {
         return executor?.execute(action)?.let { true } ?: super.post(action)
-    }
-
-    companion object {
-        private const val CAMERA_PERMISSION_REQUEST = 1010
-        private const val WRITE_PERMISSION_REQUEST = 1001001
     }
 
     fun interface OnBackClickedListener {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/WithCameraPermissionUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/WithCameraPermissionUseCase.kt
@@ -1,0 +1,22 @@
+package com.glia.widgets.core.permissions.domain
+
+import android.Manifest
+import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.permissions.PermissionsGrantedCallback
+
+internal interface WithCameraPermissionUseCase {
+    operator fun invoke(permissionGrantedCallback: () -> Unit)
+}
+
+internal class WithCameraPermissionUseCaseImpl(private val permissionManager: PermissionManager) : WithCameraPermissionUseCase {
+    override fun invoke(permissionGrantedCallback: () -> Unit) = requestPermission {
+        if (it) permissionGrantedCallback()
+    }
+
+    private fun requestPermission(permissionsGrantedCallback: PermissionsGrantedCallback) {
+        permissionManager.handlePermissions(
+            necessaryPermissions = listOf(Manifest.permission.CAMERA),
+            necessaryPermissionsGrantedCallback = permissionsGrantedCallback
+        )
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/WithReadWritePermissionsUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/WithReadWritePermissionsUseCase.kt
@@ -1,0 +1,26 @@
+package com.glia.widgets.core.permissions.domain
+
+import android.Manifest
+import android.os.Build
+import com.glia.widgets.core.permissions.PermissionManager
+
+internal interface WithReadWritePermissionsUseCase {
+    operator fun invoke(permissionGrantedCallback: () -> Unit)
+}
+
+internal class WithReadWritePermissionsUseCaseImpl(private val permissionManager: PermissionManager) : WithReadWritePermissionsUseCase {
+    override fun invoke(permissionGrantedCallback: () -> Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            permissionGrantedCallback()
+            return
+        }
+
+        permissionManager.handlePermissions(
+            necessaryPermissions = listOf(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE),
+            necessaryPermissionsGrantedCallback = {
+                if (it) permissionGrantedCallback()
+            }
+        )
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -134,7 +134,9 @@ public class ControllerFactory {
                 useCaseFactory.getDecideOnQueueingUseCase(),
                 useCaseFactory.getScreenSharingUseCase(),
                 useCaseFactory.getTakePictureUseCase(),
-                useCaseFactory.getUriToFileAttachmentUseCase()
+                useCaseFactory.getUriToFileAttachmentUseCase(),
+                useCaseFactory.getWithCameraPermissionUseCase(),
+                useCaseFactory.getWithReadWritePermissionsUseCase()
             );
         }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -101,6 +101,10 @@ import com.glia.widgets.core.notification.domain.ShowScreenSharingNotificationUs
 import com.glia.widgets.core.permissions.PermissionManager;
 import com.glia.widgets.core.permissions.domain.HasCallNotificationChannelEnabledUseCase;
 import com.glia.widgets.core.permissions.domain.HasScreenSharingNotificationChannelEnabledUseCase;
+import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCase;
+import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCaseImpl;
+import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCase;
+import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCaseImpl;
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileAttachmentsObserverUseCase;
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileToAttachmentAndUploadUseCase;
 import com.glia.widgets.core.secureconversations.domain.GetSecureFileAttachmentsUseCase;
@@ -1030,5 +1034,15 @@ public class UseCaseFactory {
             getUriToFileAttachmentUseCase(),
             getFixCapturedPictureRotationUseCase()
         );
+    }
+
+    @NonNull
+    public WithCameraPermissionUseCase getWithCameraPermissionUseCase() {
+        return new WithCameraPermissionUseCaseImpl(permissionManager);
+    }
+
+    @NonNull
+    WithReadWritePermissionsUseCase getWithReadWritePermissionsUseCase() {
+        return new WithReadWritePermissionsUseCaseImpl(permissionManager);
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -31,6 +31,8 @@ import com.glia.widgets.core.fileupload.domain.RemoveFileAttachmentObserverUseCa
 import com.glia.widgets.core.fileupload.domain.RemoveFileAttachmentUseCase
 import com.glia.widgets.core.fileupload.domain.SupportedFileCountCheckUseCase
 import com.glia.widgets.core.notification.domain.CallNotificationUseCase
+import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCase
+import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCase
 import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase
 import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCase
 import com.glia.widgets.engagement.domain.DeclineMediaUpgradeOfferUseCase
@@ -102,6 +104,8 @@ class ChatControllerTest {
     private lateinit var screenSharingUseCase: ScreenSharingUseCase
     private lateinit var takePictureUseCase: TakePictureUseCase
     private lateinit var uriToFileAttachmentUseCase: UriToFileAttachmentUseCase
+    private lateinit var withCameraPermissionUseCase: WithCameraPermissionUseCase
+    private lateinit var withReadWritePermissionsUseCase: WithReadWritePermissionsUseCase
 
     private lateinit var chatController: ChatController
     private lateinit var isAuthenticatedUseCase: IsAuthenticatedUseCase
@@ -166,6 +170,8 @@ class ChatControllerTest {
 
         takePictureUseCase = mock()
         uriToFileAttachmentUseCase = mock()
+        withCameraPermissionUseCase = mock()
+        withReadWritePermissionsUseCase = mock()
 
         chatController = ChatController(
             callTimer = callTimer,
@@ -208,7 +214,9 @@ class ChatControllerTest {
             decideOnQueueingUseCase = decideOnQueueingUseCase,
             screenSharingUseCase = screenSharingUseCase,
             takePictureUseCase = takePictureUseCase,
-            uriToFileAttachmentUseCase = uriToFileAttachmentUseCase
+            uriToFileAttachmentUseCase = uriToFileAttachmentUseCase,
+            withCameraPermissionUseCase = withCameraPermissionUseCase,
+            withReadWritePermissionsUseCase = withReadWritePermissionsUseCase
         )
         chatController.setView(chatView)
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/WithCameraPermissionUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/WithCameraPermissionUseCaseTest.kt
@@ -1,0 +1,68 @@
+package com.glia.widgets.core.permissions.domain
+
+import android.Manifest
+import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.permissions.PermissionsGrantedCallback
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class WithCameraPermissionUseCaseTest {
+    private lateinit var permissionManager: PermissionManager
+    private lateinit var useCase: WithCameraPermissionUseCase
+    private lateinit var callback: () -> Unit
+
+    @Before
+    fun setUp() {
+        permissionManager = mockk(relaxUnitFun = true)
+        callback = mockk(relaxed = true)
+        useCase = WithCameraPermissionUseCaseImpl(permissionManager)
+    }
+
+    @After
+    fun tearDown() {
+        confirmVerified(permissionManager, callback)
+    }
+
+    @Test
+    fun `invoke invokes callback when camera permission is granted`() {
+        useCase(callback)
+        verify(exactly = 0) { callback.invoke() }
+        val permissionsGrantedCallbackSlot = slot<PermissionsGrantedCallback>()
+
+        verify {
+            permissionManager.handlePermissions(
+                eq(listOf(Manifest.permission.CAMERA)),
+                isNull(),
+                capture(permissionsGrantedCallbackSlot),
+                isNull(),
+                isNull()
+            )
+        }
+        permissionsGrantedCallbackSlot.captured.invoke(true)
+        verify { callback.invoke() }
+    }
+
+    @Test
+    fun `invoke does nothing when camera permission is not granted`() {
+        useCase(callback)
+        verify(exactly = 0) { callback.invoke() }
+        val permissionsGrantedCallbackSlot = slot<PermissionsGrantedCallback>()
+
+        verify {
+            permissionManager.handlePermissions(
+                eq(listOf(Manifest.permission.CAMERA)),
+                isNull(),
+                capture(permissionsGrantedCallbackSlot),
+                isNull(),
+                isNull()
+            )
+        }
+        permissionsGrantedCallbackSlot.captured.invoke(false)
+        verify(exactly = 0) { callback.invoke() }
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/WithReadWritePermissionsUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/WithReadWritePermissionsUseCaseTest.kt
@@ -1,0 +1,96 @@
+package com.glia.widgets.core.permissions.domain
+
+import android.Manifest
+import android.os.Build
+import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.permissions.PermissionsGrantedCallback
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.util.ReflectionHelpers
+
+
+@RunWith(RobolectricTestRunner::class)
+class WithReadWritePermissionsUseCaseTest {
+    private lateinit var permissionManager: PermissionManager
+    private lateinit var useCase: WithReadWritePermissionsUseCase
+    private lateinit var callback: () -> Unit
+
+    @Before
+    fun setUp() {
+        permissionManager = mockk(relaxUnitFun = true)
+        callback = mockk(relaxed = true)
+        useCase = WithReadWritePermissionsUseCaseImpl(permissionManager)
+    }
+
+    @After
+    fun tearDown() {
+        confirmVerified(permissionManager, callback)
+    }
+
+    @Test
+    fun `invoke invokes callback when API version is higher than 29`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 34)
+        useCase(callback)
+        verify { callback.invoke() }
+
+        verify(exactly = 0) { permissionManager.handlePermissions(any(), any()) }
+    }
+
+    @Test
+    fun `invoke invokes callback when API version is 29`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 29)
+        useCase(callback)
+        verify { callback.invoke() }
+
+        verify(exactly = 0) { permissionManager.handlePermissions(any(), any()) }
+    }
+
+    @Test
+    fun `invoke invokes callback when read and write permission is granted API version less then 29`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 28)
+        useCase(callback)
+        verify(exactly = 0) { callback.invoke() }
+        val permissionsGrantedCallbackSlot = slot<PermissionsGrantedCallback>()
+
+        verify {
+            permissionManager.handlePermissions(
+                eq(
+                    listOf(
+                        Manifest.permission.READ_EXTERNAL_STORAGE,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    )
+                ), null, capture(permissionsGrantedCallbackSlot), null, null
+            )
+        }
+        permissionsGrantedCallbackSlot.captured.invoke(true)
+        verify { callback.invoke() }
+    }
+
+    @Test
+    fun `invoke does nothing when read and write permission is not granted API version less then 29`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 28)
+        useCase(callback)
+        verify(exactly = 0) { callback.invoke() }
+        val permissionsGrantedCallbackSlot = slot<PermissionsGrantedCallback>()
+
+        verify {
+            permissionManager.handlePermissions(
+                eq(
+                    listOf(
+                        Manifest.permission.READ_EXTERNAL_STORAGE,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    )
+                ), null, capture(permissionsGrantedCallbackSlot), null, null
+            )
+        }
+        permissionsGrantedCallbackSlot.captured.invoke(false)
+        verify(exactly = 0) { callback.invoke() }
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3210

**What was solved?**
Migrate all permission requests in the Chat screen to the activity result API

**Release notes:**
 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**
 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
