### PR TITLE
Request notification permission in chat and messaging screens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects {
   }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
   delete rootProject.buildDir
 }
 
@@ -107,7 +107,7 @@ ext {
   androidXTestVersion = '1.1.5'
   mockitoKotlinVersion = '5.2.1'
   mockitoAndroidTestVersion = '5.8.0'
-  mockkVersion = '1.13.9'
+  mockkVersion = '1.13.10'
   archCoreVersion = '2.2.0'
   testRulesVersion = '1.5.0'
   robolectricVersion = '4.11.1'

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -50,6 +50,7 @@ import com.glia.widgets.core.fileupload.domain.RemoveFileAttachmentUseCase
 import com.glia.widgets.core.fileupload.domain.SupportedFileCountCheckUseCase
 import com.glia.widgets.core.fileupload.model.FileAttachment
 import com.glia.widgets.core.notification.domain.CallNotificationUseCase
+import com.glia.widgets.core.permissions.domain.RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCase
 import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCase
 import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase
@@ -126,7 +127,8 @@ internal class ChatController(
     private val takePictureUseCase: TakePictureUseCase,
     private val uriToFileAttachmentUseCase: UriToFileAttachmentUseCase,
     private val withCameraPermissionUseCase: WithCameraPermissionUseCase,
-    private val withReadWritePermissionsUseCase: WithReadWritePermissionsUseCase
+    private val withReadWritePermissionsUseCase: WithReadWritePermissionsUseCase,
+    private val requestNotificationPermissionIfPushNotificationsSetUpUseCase: RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 ) : ChatContract.Controller {
     private var backClickedListener: ChatView.OnBackClickedListener? = null
     private var view: ChatContract.View? = null
@@ -283,7 +285,9 @@ internal class ChatController(
     }
 
     private fun enqueueForEngagement() {
-        enqueueForEngagementUseCase(queueId = chatState.queueId!!, visitorContextAssetId = chatState.visitorContextAssetId)
+        requestNotificationPermissionIfPushNotificationsSetUpUseCase {
+            enqueueForEngagementUseCase(queueId = chatState.queueId!!, visitorContextAssetId = chatState.visitorContextAssetId)
+        }
     }
 
     @Synchronized

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/PermissionDialogManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/PermissionDialogManager.kt
@@ -22,4 +22,5 @@ internal class PermissionDialogManager(context: Context) {
     }
 
     fun hasEnableCallNotificationChannelRequestShown(): Boolean = sharedPreferences.getBoolean(CALL_CHANNEL_NOTIFICATION_DIALOG_SHOWN_KEY, false)
+
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/domain/IsShowEnableCallNotificationChannelDialogUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/domain/IsShowEnableCallNotificationChannelDialogUseCase.kt
@@ -1,17 +1,17 @@
 package com.glia.widgets.core.dialog.domain
 
 import com.glia.widgets.core.dialog.PermissionDialogManager
-import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.core.permissions.domain.HasCallNotificationChannelEnabledUseCase
 
 internal interface IsShowEnableCallNotificationChannelDialogUseCase {
     operator fun invoke(): Boolean
 }
 
 internal class IsShowEnableCallNotificationChannelDialogUseCaseImpl(
-    private val permissionManager: PermissionManager,
+    private val hasCallNotificationChannelEnabledUseCase: HasCallNotificationChannelEnabledUseCase,
     private val permissionDialogManager: PermissionDialogManager
 ) : IsShowEnableCallNotificationChannelDialogUseCase {
-    private val isCallNotificationChannelNotEnabled: Boolean get() = !permissionManager.hasCallNotificationChannelEnabled()
+    private val isCallNotificationChannelNotEnabled: Boolean get() = !hasCallNotificationChannelEnabledUseCase()
     private val hasNotShownCallNotificationNotEnabledRequest: Boolean get() = !permissionDialogManager.hasEnableCallNotificationChannelRequestShown()
 
     override fun invoke(): Boolean = isCallNotificationChannelNotEnabled && hasNotShownCallNotificationNotEnabledRequest

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
@@ -10,8 +10,6 @@ import androidx.annotation.VisibleForTesting
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.comms.MediaDirection
 import com.glia.androidsdk.comms.MediaUpgradeOffer
-import com.glia.widgets.core.notification.NotificationFactory
-import com.glia.widgets.core.notification.areNotificationsEnabledForChannel
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.permissions.Permissions
@@ -30,13 +28,7 @@ internal class PermissionManager(
 
     fun hasOverlayPermission(): Boolean = Settings.canDrawOverlays(applicationContext)
 
-    fun hasCallNotificationChannelEnabled(): Boolean =
-        applicationContext.areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID)
-
-    fun hasScreenSharingNotificationChannelEnabled(): Boolean =
-        applicationContext.areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_SCREEN_SHARING_CHANNEL_ID)
-
-    private fun hasPermission(permission: String) = checkSelfPermission(applicationContext, permission) == PackageManager.PERMISSION_GRANTED
+    fun hasPermission(permission: String) = checkSelfPermission(applicationContext, permission) == PackageManager.PERMISSION_GRANTED
 
     @SuppressLint("InlinedApi")
     fun getPermissionsForMediaUpgradeOffer(offer: MediaUpgradeOffer): Permissions {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/HasCallNotificationChannelEnabledUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/HasCallNotificationChannelEnabledUseCase.kt
@@ -1,7 +1,9 @@
 package com.glia.widgets.core.permissions.domain
 
-import com.glia.widgets.core.permissions.PermissionManager
+import android.content.Context
+import com.glia.widgets.core.notification.NotificationFactory
+import com.glia.widgets.core.notification.areNotificationsEnabledForChannel
 
-internal class HasCallNotificationChannelEnabledUseCase(private val permissionManager: PermissionManager) {
-    operator fun invoke(): Boolean = permissionManager.hasCallNotificationChannelEnabled()
+internal class HasCallNotificationChannelEnabledUseCase(private val context: Context) {
+    operator fun invoke(): Boolean = context.areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/HasScreenSharingNotificationChannelEnabledUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/HasScreenSharingNotificationChannelEnabledUseCase.kt
@@ -1,7 +1,9 @@
 package com.glia.widgets.core.permissions.domain
 
-import com.glia.widgets.core.permissions.PermissionManager
+import android.content.Context
+import com.glia.widgets.core.notification.NotificationFactory
+import com.glia.widgets.core.notification.areNotificationsEnabledForChannel
 
-internal class HasScreenSharingNotificationChannelEnabledUseCase(private val permissionManager: PermissionManager) {
-    operator fun invoke(): Boolean = permissionManager.hasScreenSharingNotificationChannelEnabled()
+internal class HasScreenSharingNotificationChannelEnabledUseCase(private val context: Context) {
+    operator fun invoke(): Boolean = context.areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_SCREEN_SHARING_CHANNEL_ID)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/NotificationPermissions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/domain/NotificationPermissions.kt
@@ -1,0 +1,41 @@
+package com.glia.widgets.core.permissions.domain
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.os.Build
+import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.push.notifications.IsPushNotificationsSetUpUseCase
+
+internal interface RequestNotificationPermissionIfPushNotificationsSetUpUseCase {
+    operator fun invoke(doneCallback: () -> Unit)
+}
+
+internal class RequestNotificationPermissionIfPushNotificationsSetUpUseCaseImpl(
+    private val permissionManager: PermissionManager,
+    private val isNotificationPermissionGrantedUseCase: IsNotificationPermissionGrantedUseCase,
+    private val isPushNotificationsSetUpUseCase: IsPushNotificationsSetUpUseCase
+) : RequestNotificationPermissionIfPushNotificationsSetUpUseCase {
+    @SuppressLint("InlinedApi")
+    override fun invoke(doneCallback: () -> Unit) {
+        if (!isPushNotificationsSetUpUseCase() || isNotificationPermissionGrantedUseCase()) {
+            doneCallback()
+            return
+        }
+
+        permissionManager.handlePermissions(
+            additionalPermissions = listOf(Manifest.permission.POST_NOTIFICATIONS),
+            additionalPermissionsGrantedCallback = {
+                doneCallback()
+            }
+        )
+    }
+}
+
+internal interface IsNotificationPermissionGrantedUseCase {
+    operator fun invoke(): Boolean
+}
+
+internal class IsNotificationPermissionGrantedUseCaseImpl(private val permissionManager: PermissionManager) : IsNotificationPermissionGrantedUseCase {
+    override fun invoke(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || permissionManager.hasPermission(Manifest.permission.POST_NOTIFICATIONS)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -136,7 +136,8 @@ public class ControllerFactory {
                 useCaseFactory.getTakePictureUseCase(),
                 useCaseFactory.getUriToFileAttachmentUseCase(),
                 useCaseFactory.getWithCameraPermissionUseCase(),
-                useCaseFactory.getWithReadWritePermissionsUseCase()
+                useCaseFactory.getWithReadWritePermissionsUseCase(),
+                useCaseFactory.getRequestNotificationPermissionIfPushNotificationsSetUpUseCase()
             );
         }
 
@@ -306,7 +307,8 @@ public class ControllerFactory {
             useCaseFactory.createResetMessageCenterUseCase(),
             createDialogController(),
             useCaseFactory.getTakePictureUseCase(),
-            useCaseFactory.getUriToFileAttachmentUseCase()
+            useCaseFactory.getUriToFileAttachmentUseCase(),
+            useCaseFactory.getRequestNotificationPermissionIfPushNotificationsSetUpUseCase()
         );
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -101,6 +101,10 @@ import com.glia.widgets.core.notification.domain.ShowScreenSharingNotificationUs
 import com.glia.widgets.core.permissions.PermissionManager;
 import com.glia.widgets.core.permissions.domain.HasCallNotificationChannelEnabledUseCase;
 import com.glia.widgets.core.permissions.domain.HasScreenSharingNotificationChannelEnabledUseCase;
+import com.glia.widgets.core.permissions.domain.IsNotificationPermissionGrantedUseCase;
+import com.glia.widgets.core.permissions.domain.IsNotificationPermissionGrantedUseCaseImpl;
+import com.glia.widgets.core.permissions.domain.RequestNotificationPermissionIfPushNotificationsSetUpUseCase;
+import com.glia.widgets.core.permissions.domain.RequestNotificationPermissionIfPushNotificationsSetUpUseCaseImpl;
 import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCase;
 import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCaseImpl;
 import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCase;
@@ -420,7 +424,7 @@ public class UseCaseFactory {
 
     @NonNull
     public HasScreenSharingNotificationChannelEnabledUseCase createHasScreenSharingNotificationChannelEnabledUseCase() {
-        return new HasScreenSharingNotificationChannelEnabledUseCase(permissionManager);
+        return new HasScreenSharingNotificationChannelEnabledUseCase(applicationContext);
     }
 
     @NonNull
@@ -430,12 +434,12 @@ public class UseCaseFactory {
 
     @NonNull
     public HasCallNotificationChannelEnabledUseCase createHasCallNotificationChannelEnabledUseCase() {
-        return new HasCallNotificationChannelEnabledUseCase(permissionManager);
+        return new HasCallNotificationChannelEnabledUseCase(applicationContext);
     }
 
     @NonNull
     public IsShowEnableCallNotificationChannelDialogUseCase createIsShowEnableCallNotificationChannelDialogUseCase() {
-        return new IsShowEnableCallNotificationChannelDialogUseCaseImpl(permissionManager, permissionDialogManager);
+        return new IsShowEnableCallNotificationChannelDialogUseCaseImpl(createHasCallNotificationChannelEnabledUseCase(), permissionDialogManager);
     }
 
     @NonNull
@@ -988,7 +992,10 @@ public class UseCaseFactory {
 
     @NonNull
     public DecideOnQueueingUseCase getDecideOnQueueingUseCase() {
-        return new DecideOnQueueingUseCaseImpl(createIsShowOverlayPermissionRequestDialogUseCase(), createSetOverlayPermissionRequestDialogShownUseCase());
+        return new DecideOnQueueingUseCaseImpl(
+            createIsShowOverlayPermissionRequestDialogUseCase(),
+            createSetOverlayPermissionRequestDialogShownUseCase()
+        );
     }
 
     @NonNull
@@ -1042,7 +1049,21 @@ public class UseCaseFactory {
     }
 
     @NonNull
-    WithReadWritePermissionsUseCase getWithReadWritePermissionsUseCase() {
+    public WithReadWritePermissionsUseCase getWithReadWritePermissionsUseCase() {
         return new WithReadWritePermissionsUseCaseImpl(permissionManager);
+    }
+
+    @NonNull
+    public IsNotificationPermissionGrantedUseCase getIsNotificationPermissionGrantedUseCase() {
+        return new IsNotificationPermissionGrantedUseCaseImpl(permissionManager);
+    }
+
+    @NonNull
+    public RequestNotificationPermissionIfPushNotificationsSetUpUseCase getRequestNotificationPermissionIfPushNotificationsSetUpUseCase() {
+        return new RequestNotificationPermissionIfPushNotificationsSetUpUseCaseImpl(
+            permissionManager,
+            getIsNotificationPermissionGrantedUseCase(),
+            getIsPushNotificationsSetUpUseCase()
+        );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
@@ -17,6 +17,7 @@ import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.fileupload.domain.AddFileToAttachmentAndUploadUseCase
 import com.glia.widgets.core.fileupload.model.FileAttachment
+import com.glia.widgets.core.permissions.domain.RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileAttachmentsObserverUseCase
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileToAttachmentAndUploadUseCase
 import com.glia.widgets.core.secureconversations.domain.GetSecureFileAttachmentsUseCase
@@ -48,7 +49,8 @@ internal class MessageCenterController(
     private val resetMessageCenterUseCase: ResetMessageCenterUseCase,
     private val dialogController: DialogContract.Controller,
     private val takePictureUseCase: TakePictureUseCase,
-    private val uriToFileAttachmentUseCase: UriToFileAttachmentUseCase
+    private val uriToFileAttachmentUseCase: UriToFileAttachmentUseCase,
+    private val requestNotificationPermissionIfPushNotificationsSetUpUseCase: RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 ) : MessageCenterContract.Controller {
     private var view: MessageCenterContract.View? = null
     private val disposables = CompositeDisposable()
@@ -122,8 +124,11 @@ internal class MessageCenterController(
             )
         )
         view?.hideSoftKeyboard()
-        sendSecureMessageUseCase { _: VisitorMessage?, gliaException: GliaException? ->
-            handleSendMessageResult(gliaException)
+
+        requestNotificationPermissionIfPushNotificationsSetUpUseCase {
+            sendSecureMessageUseCase { _: VisitorMessage?, gliaException: GliaException? ->
+                handleSendMessageResult(gliaException)
+            }
         }
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -31,6 +31,7 @@ import com.glia.widgets.core.fileupload.domain.RemoveFileAttachmentObserverUseCa
 import com.glia.widgets.core.fileupload.domain.RemoveFileAttachmentUseCase
 import com.glia.widgets.core.fileupload.domain.SupportedFileCountCheckUseCase
 import com.glia.widgets.core.notification.domain.CallNotificationUseCase
+import com.glia.widgets.core.permissions.domain.RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCase
 import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCase
 import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase
@@ -106,6 +107,7 @@ class ChatControllerTest {
     private lateinit var uriToFileAttachmentUseCase: UriToFileAttachmentUseCase
     private lateinit var withCameraPermissionUseCase: WithCameraPermissionUseCase
     private lateinit var withReadWritePermissionsUseCase: WithReadWritePermissionsUseCase
+    private lateinit var requestNotificationPermissionIfPushNotificationsSetUpUseCase: RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 
     private lateinit var chatController: ChatController
     private lateinit var isAuthenticatedUseCase: IsAuthenticatedUseCase
@@ -172,6 +174,7 @@ class ChatControllerTest {
         uriToFileAttachmentUseCase = mock()
         withCameraPermissionUseCase = mock()
         withReadWritePermissionsUseCase = mock()
+        requestNotificationPermissionIfPushNotificationsSetUpUseCase = mock()
 
         chatController = ChatController(
             callTimer = callTimer,
@@ -216,7 +219,8 @@ class ChatControllerTest {
             takePictureUseCase = takePictureUseCase,
             uriToFileAttachmentUseCase = uriToFileAttachmentUseCase,
             withCameraPermissionUseCase = withCameraPermissionUseCase,
-            withReadWritePermissionsUseCase = withReadWritePermissionsUseCase
+            withReadWritePermissionsUseCase = withReadWritePermissionsUseCase,
+            requestNotificationPermissionIfPushNotificationsSetUpUseCase = requestNotificationPermissionIfPushNotificationsSetUpUseCase
         )
         chatController.setView(chatView)
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/IsNotificationPermissionGrantedUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/IsNotificationPermissionGrantedUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.glia.widgets.core.permissions.domain
+
+import android.Manifest
+import android.os.Build
+import com.glia.widgets.core.permissions.PermissionManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(RobolectricTestRunner::class)
+class IsNotificationPermissionGrantedUseCaseTest {
+    private lateinit var permissionManager: PermissionManager
+    private lateinit var useCase: IsNotificationPermissionGrantedUseCaseImpl
+
+    @Before
+    fun setUp() {
+        permissionManager = mockk(relaxed = true)
+        useCase = IsNotificationPermissionGrantedUseCaseImpl(permissionManager)
+    }
+
+    @Test
+    fun `invoke returns true when api version is lower than 33`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 32)
+        assertTrue(useCase())
+    }
+
+    @Test
+    fun `invoke returns true when api version is 33 or higher and permission is granted`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 33)
+        every { permissionManager.hasPermission(Manifest.permission.POST_NOTIFICATIONS) } returns true
+        assertTrue(useCase())
+    }
+
+    @Test
+    fun `invoke returns false when api version is 33 or higher and permission is not granted`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 33)
+        every { permissionManager.hasPermission(Manifest.permission.POST_NOTIFICATIONS) } returns false
+        assertFalse(useCase())
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/RequestNotificationPermissionIfPushNotificationsSetUpUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/permissions/domain/RequestNotificationPermissionIfPushNotificationsSetUpUseCaseTest.kt
@@ -1,0 +1,102 @@
+package com.glia.widgets.core.permissions.domain
+
+import android.Manifest
+import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.permissions.PermissionsGrantedCallback
+import com.glia.widgets.push.notifications.IsPushNotificationsSetUpUseCase
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class RequestNotificationPermissionIfPushNotificationsSetUpUseCaseTest {
+    private lateinit var permissionManager: PermissionManager
+    private lateinit var isNotificationPermissionGrantedUseCase: IsNotificationPermissionGrantedUseCase
+    private lateinit var pushNotificationsSetUpUseCase: IsPushNotificationsSetUpUseCase
+    private lateinit var callback: () -> Unit
+    private lateinit var useCase: RequestNotificationPermissionIfPushNotificationsSetUpUseCase
+
+    @Before
+    fun setUp() {
+        permissionManager = mockk(relaxUnitFun = true)
+        isNotificationPermissionGrantedUseCase = mockk()
+        pushNotificationsSetUpUseCase = mockk()
+        callback = mockk(relaxed = true)
+
+        useCase = RequestNotificationPermissionIfPushNotificationsSetUpUseCaseImpl(
+            permissionManager,
+            isNotificationPermissionGrantedUseCase,
+            pushNotificationsSetUpUseCase
+        )
+    }
+
+    @After
+    fun tearDown() {
+        confirmVerified(
+            permissionManager,
+            isNotificationPermissionGrantedUseCase,
+            pushNotificationsSetUpUseCase,
+            callback
+        )
+    }
+
+    @Test
+    fun `invoke invokes callback when notification push notifications is setUp`() {
+        every { pushNotificationsSetUpUseCase() } returns false
+        useCase(callback)
+        verify { pushNotificationsSetUpUseCase() }
+        verify { callback() }
+        verify(exactly = 0) {
+            permissionManager.handlePermissions(
+                additionalPermissions = listOf(Manifest.permission.POST_NOTIFICATIONS),
+                additionalPermissionsGrantedCallback = any()
+            )
+        }
+        verify(exactly = 0) { isNotificationPermissionGrantedUseCase() }
+    }
+
+
+    @Test
+    fun `invoke invokes callback when notification permission is granted`() {
+        every { pushNotificationsSetUpUseCase() } returns true
+        every { isNotificationPermissionGrantedUseCase() } returns true
+        useCase(callback)
+        verify { isNotificationPermissionGrantedUseCase() }
+        verify { pushNotificationsSetUpUseCase() }
+        verify { callback() }
+        verify(exactly = 0) {
+            permissionManager.handlePermissions(
+                additionalPermissions = listOf(Manifest.permission.POST_NOTIFICATIONS),
+                additionalPermissionsGrantedCallback = any()
+            )
+        }
+    }
+
+    @Test
+    fun `invoke invokes callback when permission request result is received`() {
+        every { pushNotificationsSetUpUseCase() } returns true
+        every { isNotificationPermissionGrantedUseCase() } returns false
+        every {
+            permissionManager.handlePermissions(
+                additionalPermissions = listOf(Manifest.permission.POST_NOTIFICATIONS),
+                additionalPermissionsGrantedCallback = captureLambda()
+            )
+        } answers {
+            arg<PermissionsGrantedCallback>(3).invoke(true)
+        }
+        useCase(callback)
+        verify { pushNotificationsSetUpUseCase() }
+        verify { isNotificationPermissionGrantedUseCase() }
+        verify { callback() }
+        verify {
+            permissionManager.handlePermissions(
+                additionalPermissions = listOf(Manifest.permission.POST_NOTIFICATIONS),
+                additionalPermissionsGrantedCallback = any()
+            )
+        }
+    }
+
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
@@ -9,6 +9,7 @@ import com.glia.widgets.chat.domain.UriToFileAttachmentUseCase
 import com.glia.widgets.core.configuration.GliaSdkConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.fileupload.model.FileAttachment
+import com.glia.widgets.core.permissions.domain.RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileAttachmentsObserverUseCase
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileToAttachmentAndUploadUseCase
 import com.glia.widgets.core.secureconversations.domain.GetSecureFileAttachmentsUseCase
@@ -50,6 +51,7 @@ internal class MessageCenterControllerTest {
     private lateinit var dialogController: DialogContract.Controller
     private lateinit var takePictureUseCase: TakePictureUseCase
     private lateinit var uriToFileAttachmentUseCase: UriToFileAttachmentUseCase
+    private lateinit var requestNotificationPermissionIfPushNotificationsSetUpUseCase: RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 
     @Before
     fun setUp() {
@@ -70,6 +72,7 @@ internal class MessageCenterControllerTest {
         dialogController = mock()
         takePictureUseCase = mock()
         uriToFileAttachmentUseCase = mock()
+        requestNotificationPermissionIfPushNotificationsSetUpUseCase = mock()
         messageCenterController = MessageCenterController(
             serviceChatHeadController = serviceChatHeadController,
             sendSecureMessageUseCase = sendSecureMessageUseCase,
@@ -86,7 +89,8 @@ internal class MessageCenterControllerTest {
             resetMessageCenterUseCase = resetMessageCenterUseCase,
             dialogController = dialogController,
             takePictureUseCase = takePictureUseCase,
-            uriToFileAttachmentUseCase = uriToFileAttachmentUseCase
+            uriToFileAttachmentUseCase = uriToFileAttachmentUseCase,
+            requestNotificationPermissionIfPushNotificationsSetUpUseCase = requestNotificationPermissionIfPushNotificationsSetUpUseCase
         )
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3212

**What was solved?**
Request notification permission in chat and messaging screens when push notifications are set up
- Chat screen — right before the first engagement request
- Secure messaging — before sending the first message
- Fix warning — Consider using 'tasks.register' to avoid unnecessary configuration

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
