### PR TITLE
Undo the 'De-authenticate' button renaming in testing app to keep int…

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
     <string name="visitor_info">Visitor info</string>
     <string name="main_init_glia">Init Glia Widgets SDK</string>
     <string name="main_authenticate">Authenticate</string>
-    <string name="main_deauthenticate">Unauthenticate</string>
+    <string name="main_deauthenticate">De-authenticate</string>
     <string name="main_clear_visitor_session">Clear Session</string>
     <string name="main_show_visitor_code">Show Visitor Code</string>
 


### PR DESCRIPTION
**What was solved?**
I was too quick yesterday with renaming. After the recent sync with Igor we agreed to rename ONLY logs sent to Kibana and keep 'as is' all the rest.

That's why I'm rolling back this minor change.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

