### PR TITLE
Fix CV Screen-sharing bubble stays after end screen-sharing

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -233,7 +233,8 @@ public class ControllerFactory {
                 useCaseFactory.createIsCallVisualizerScreenSharingUseCase(),
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.getCurrentOperatorUseCase(),
-                useCaseFactory.getVisitorMediaUseCase()
+                useCaseFactory.getVisitorMediaUseCase(),
+                useCaseFactory.getScreenSharingUseCase()
             );
         }
         return serviceChatHeadController;
@@ -248,7 +249,8 @@ public class ControllerFactory {
                 useCaseFactory.createIsCallVisualizerScreenSharingUseCase(),
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.getCurrentOperatorUseCase(),
-                useCaseFactory.getVisitorMediaUseCase()
+                useCaseFactory.getVisitorMediaUseCase(),
+                useCaseFactory.getScreenSharingUseCase()
             );
         }
         return applicationChatHeadController;

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EngagementTypeUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EngagementTypeUseCase.kt
@@ -17,5 +17,5 @@ internal class EngagementTypeUseCaseImpl(
     private val hasAnyMedia: Boolean get() = visitorMediaUseCase.hasMedia || operatorMediaUseCase.hasMedia
     override val isMediaEngagement: Boolean get() = hasOngoingEngagement && isOperatorPresentUseCase() && hasAnyMedia
     override val isChatEngagement: Boolean get() = hasOngoingEngagement && !isCurrentEngagementCallVisualizerUseCase() && isOperatorPresentUseCase() && !hasAnyMedia
-    override val isCallVisualizerScreenSharing: Boolean get() = isCurrentEngagementCallVisualizerUseCase.invoke() && !hasAnyMedia
+    override val isCallVisualizerScreenSharing: Boolean get() = isCurrentEngagementCallVisualizerUseCase() && !hasAnyMedia
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -5,8 +5,10 @@ import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharing
 import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
+import com.glia.widgets.engagement.ScreenSharingState
 import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
+import com.glia.widgets.engagement.domain.ScreenSharingUseCase
 import com.glia.widgets.engagement.domain.VisitorMediaUseCase
 import com.glia.widgets.helper.imageUrl
 import com.glia.widgets.helper.unSafeSubscribe
@@ -21,7 +23,8 @@ internal class ApplicationChatHeadLayoutController(
     private val isCallVisualizerScreenSharingUseCase: IsCallVisualizerScreenSharingUseCase,
     private val engagementStateUseCase: EngagementStateUseCase,
     private val currentOperatorUseCase: CurrentOperatorUseCase,
-    private val visitorMediaUseCase: VisitorMediaUseCase
+    private val visitorMediaUseCase: VisitorMediaUseCase,
+    private val screenSharingUseCase: ScreenSharingUseCase
 ) : ChatHeadLayoutContract.Controller {
     private var chatHeadLayout: ChatHeadLayoutContract.View? = null
     private var state = State.ENDED
@@ -65,6 +68,15 @@ internal class ApplicationChatHeadLayoutController(
         }
         visitorMediaUseCase.onHoldState.unSafeSubscribe(::onHoldChanged)
         currentOperatorUseCase().unSafeSubscribe(::operatorDataLoaded)
+        screenSharingUseCase().filter { isCallVisualizerScreenSharingUseCase() }.unSafeSubscribe {
+            when (it) {
+                ScreenSharingState.Ended -> {
+                    chatHeadLayout?.hide()
+                    updateChatHeadView()
+                }
+                else -> updateChatHeadView()
+            }
+        }
     }
 
     override fun onChatHeadClicked() {


### PR DESCRIPTION
MOB 3236

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3236

**What was solved?**
Fix the screen-sharing bubble does not disappear when ending screen-sharing during the Call Visualizer

Steps to reproduce:

1. Start CV
2. Request screen-sharing
3. Accept the screen-sharing request 
4. End screen sharing from the notification

**Expected result:** Bubble should disappear
**Actual result:** Bubble stays on screen until the new screen is shown. 

**Release notes:**
Fix the screen-sharing bubble does not disappear when ending screen-sharing during the Call Visualizer

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
