### PR TITLE
Fix Screen sharing starts with delay

### DIFF
--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -83,6 +83,7 @@
 
         <service
             android:name=".core.screensharing.MediaProjectionService"
+            android:exported="false"
             android:foregroundServiceType="mediaProjection" />
 
         <service android:name=".core.notification.NotificationRemovalService" />

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/NotificationFactory.kt
@@ -34,6 +34,8 @@ internal object NotificationFactory {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .setOngoing(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .setSilent(true) // No sound or vibration and no heads-up notification
             .addAction(
                 R.drawable.ic_baseline_close,
                 stringProvider.getRemoteString(R.string.android_notification_end_screen_sharing_title),
@@ -105,6 +107,7 @@ internal object NotificationFactory {
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_CALL)
             .setOngoing(true)
+            .setSilent(true) // No sound or vibration and no heads-up notification
             .build()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
@@ -30,7 +30,9 @@ internal class NotificationManager(private val applicationContext: Application) 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private fun createCallChannel() {
         if (notificationManager.getNotificationChannel(NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID) == null) {
-            val importance = NotificationManager.IMPORTANCE_LOW
+            /* Screen sharing notification importance should have the possible highest value,
+            because it shows the ongoing audio/video streaming and it is preferable to be as high as possible in notifications list */
+            val importance = NotificationManager.IMPORTANCE_HIGH
             val notificationChannel = NotificationChannel(
                 NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID,
                 applicationContext.getString(R.string.android_notification_audio_call_channel_name),
@@ -43,7 +45,9 @@ internal class NotificationManager(private val applicationContext: Application) 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private fun createScreenSharingChannel() {
         if (notificationManager.getNotificationChannel(NotificationFactory.NOTIFICATION_SCREEN_SHARING_CHANNEL_ID) == null) {
-            val importance = NotificationManager.IMPORTANCE_LOW
+            /* Screen sharing notification importance should have the possible highest value,
+            because it affects the Media projection service initialization and streaming timing */
+            val importance = NotificationManager.IMPORTANCE_HIGH
             val notificationChannel = NotificationChannel(
                 NotificationFactory.NOTIFICATION_SCREEN_SHARING_CHANNEL_ID,
                 applicationContext.getString(R.string.android_notification_screen_sharing_channel_name),

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/MediaProjectionService.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/MediaProjectionService.kt
@@ -14,7 +14,7 @@ import com.glia.widgets.engagement.domain.InformThatReadyToShareScreenUseCase
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 
 private const val SERVICE_ID = 123
-const val ACTION_START = "EngagementMonitoringService:Start"
+internal const val MEDIA_PROJECTION_SERVICE_ACTION_START = "com.glia.widgets.core.screensharing.MediaProjectionService:Start"
 
 /**
  * Glia internal class.
@@ -52,9 +52,13 @@ class MediaProjectionService : Service() {
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
-        informThatReadyToShareScreenUseCase()
+        if (intent.action == null) {
+            return START_NOT_STICKY
+        }
 
-        if (ACTION_START == intent.action) {
+        if (MEDIA_PROJECTION_SERVICE_ACTION_START == intent.action) {
+            informThatReadyToShareScreenUseCase()
+
             engagementStateUseCase()
                 .filter { it is State.FinishedCallVisualizer || it is State.FinishedOmniCore }
                 .subscribe { stopSelf() }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/MediaProjectionServiceUseCases.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/MediaProjectionServiceUseCases.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.glia.widgets.core.screensharing.MEDIA_PROJECTION_SERVICE_ACTION_START
 import com.glia.widgets.core.screensharing.MediaProjectionService
 
 internal interface StartMediaProjectionServiceUseCase {
@@ -14,7 +15,7 @@ internal interface StartMediaProjectionServiceUseCase {
 internal class StartMediaProjectionServiceUseCaseImpl(private val context: Context) : StartMediaProjectionServiceUseCase {
     @RequiresApi(Build.VERSION_CODES.O)
     override fun invoke() {
-        context.startForegroundService(Intent(context, MediaProjectionService::class.java))
+        context.startForegroundService(Intent(context, MediaProjectionService::class.java).setAction(MEDIA_PROJECTION_SERVICE_ACTION_START))
     }
 }
 
@@ -26,6 +27,6 @@ internal interface StopMediaProjectionServiceUseCase {
 internal class StopMediaProjectionServiceUseCaseImpl(private val context: Context) : StopMediaProjectionServiceUseCase {
     @RequiresApi(Build.VERSION_CODES.O)
     override fun invoke() {
-        context.stopService(Intent(context, MediaProjectionService::class.java))
+        context.stopService(Intent(context, MediaProjectionService::class.java).setAction(MEDIA_PROJECTION_SERVICE_ACTION_START))
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/operator/OperatorRequestController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/operator/OperatorRequestController.kt
@@ -90,9 +90,7 @@ internal class OperatorRequestController(
     }
 
     private fun onScreenSharingRequested() {
-        withNotificationPermissionUseCase {
-            dialogController.showStartScreenSharingDialog()
-        }
+        dialogController.showStartScreenSharingDialog()
     }
 
     private fun handleMediaUpgradeOfferAcceptResult(mediaUpgradeOffer: MediaUpgradeOffer) {
@@ -159,8 +157,11 @@ internal class OperatorRequestController(
      */
     override fun onScreenSharingDialogAccepted(activity: Activity) {
         dismissAlertDialog()
-        _state.onNext(State.AcquireMediaProjectionToken)
-        screenSharingUseCase.acceptRequestWithAskedPermission(activity, gliaSdkConfigurationManager.screenSharingMode)
+
+        withNotificationPermissionUseCase {
+            _state.onNext(State.AcquireMediaProjectionToken)
+            screenSharingUseCase.acceptRequestWithAskedPermission(activity, gliaSdkConfigurationManager.screenSharingMode)
+        }
     }
 
     override fun onScreenSharingDialogDeclined(activity: Activity) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3240

**What was solved?**
After notification improvements, screen sharing started to be initiated with a huge ~15-second delay.

https://github.com/salemove/android-sdk-widgets/assets/19994238/fd3c1643-6217-48d9-82f5-b8a66cd8d816

As my investigation showed, that was related to the notification channel importance, which was set to a LOW level to prevent the notification from disturbing the user.

**Solution:**
- I returned the notification channel importance to the HIGH level for both call and screen-sharing notification channels.
- Put the `silent` flag to true for those notifications
> If {@code true}, silences this instance of the notification, regardless of the sounds or vibrations set on the notification or notification channel

So the notifications will appear at the top of the notification list, but still will be silent and will not pop up. And since the importance is HIGH system will initialize the media projection taking that into account.


https://github.com/salemove/android-sdk-widgets/assets/19994238/6c0ecb3e-8d5f-4042-80dc-1b5b3a15eab7

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests updated? Added? Unit, acceptance, snapshots?
 - [ ] Logging for future troubleshooting of client issues added?

**Screenshots:**
