### PR TITLE
Add an interface for refreshing visitor access token using direct ID token

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -222,8 +222,8 @@ class MainFragment : Fragment() {
 
             if (authentication == null) {
                 prepareAuthentication()
-                setupAuthButtonsVisibility()
             }
+            setupAuthButtonsVisibility()
         }
     }
 

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -92,6 +92,8 @@ class MainFragment : Fragment() {
             .setOnClickListener { showAuthenticationDialog(null) }
         view.findViewById<View>(R.id.deauthenticationButton)
             .setOnClickListener { deAuthenticate() }
+        view.findViewById<View>(R.id.refreshAuthButton)
+            .setOnClickListener { showRefreshAuthDialog() }
         view.findViewById<View>(R.id.clear_session_button)
             .setOnClickListener { clearSession() }
         view.findViewById<View>(R.id.visitor_code_button).setOnClickListener {
@@ -251,12 +253,14 @@ class MainFragment : Fragment() {
                 containerView!!.findViewById<View>(R.id.initGliaWidgetsButton).visibility = View.GONE
                 containerView!!.findViewById<View>(R.id.authenticationButton).visibility = View.GONE
                 containerView!!.findViewById<View>(R.id.deauthenticationButton).visibility = View.VISIBLE
+                containerView!!.findViewById<View>(R.id.refreshAuthButton).visibility = View.VISIBLE
             }
         } else {
             requireActivity().runOnUiThread {
                 containerView!!.findViewById<View>(R.id.initGliaWidgetsButton).visibility = View.GONE
                 containerView!!.findViewById<View>(R.id.authenticationButton).visibility = View.VISIBLE
                 containerView!!.findViewById<View>(R.id.deauthenticationButton).visibility = View.GONE
+                containerView!!.findViewById<View>(R.id.refreshAuthButton).visibility = View.GONE
             }
         }
     }
@@ -378,8 +382,8 @@ class MainFragment : Fragment() {
     private fun showAuthenticationDialog(callback: OnAuthCallback?) {
         if (context == null) return
         val builder = AlertDialog.Builder(requireContext())
-        val jwtInput = prepareJwtInputViewEditText(builder)
-        val externalTokenInput = prepareExternalTokenInputViewEditText(builder)
+        val jwtInput = prepareJwtInputViewEditText(builder, R.string.authentication_dialog_title)
+        val externalTokenInput = prepareExternalTokenInputViewEditText(builder, R.string.authentication_dialog_title)
         jwtInput.setText(authToken)
         builder.setPositiveButton(
             getString(R.string.authentication_dialog_authenticate_button)
@@ -428,28 +432,75 @@ class MainFragment : Fragment() {
         return container
     }
 
-    private fun prepareJwtInputViewEditText(builder: AlertDialog.Builder): EditText {
+    private fun prepareJwtInputViewEditText(builder: AlertDialog.Builder,
+                                            dialogTitle: Int): EditText {
         val input = EditText(context)
         input.setHint(R.string.authentication_dialog_jwt_input_hint)
         input.setSingleLine()
         input.maxLines = 10
         input.setHorizontallyScrolling(false)
         input.inputType = InputType.TYPE_CLASS_TEXT
-        builder.setTitle(R.string.authentication_dialog_title)
+        builder.setTitle(dialogTitle)
         builder.setView(input)
         return input
     }
 
-    private fun prepareExternalTokenInputViewEditText(builder: AlertDialog.Builder): EditText {
+    private fun prepareExternalTokenInputViewEditText(builder: AlertDialog.Builder,
+                                                      dialogTitle: Int): EditText {
         val input = EditText(context)
         input.setHint(R.string.authentication_dialog_external_token_input_hint)
         input.setSingleLine()
         input.maxLines = 10
         input.setHorizontallyScrolling(false)
         input.inputType = InputType.TYPE_CLASS_TEXT
-        builder.setTitle(R.string.authentication_dialog_title)
+        builder.setTitle(dialogTitle)
         builder.setView(input)
         return input
+    }
+
+    private fun showRefreshAuthDialog() {
+        if (context == null) return
+        val builder = AlertDialog.Builder(requireContext())
+        val jwtInput = prepareJwtInputViewEditText(builder, R.string.refresh_auth_dialog_title)
+        val externalTokenInput = prepareExternalTokenInputViewEditText(builder, R.string.refresh_auth_dialog_title)
+        jwtInput.setText(authToken)
+        builder.setPositiveButton(
+            getString(R.string.refresh_dialog_refresh_button)
+        ) { _, _ ->
+            refresh(jwtInput, externalTokenInput)
+        }
+        builder.setNeutralButton(getString(R.string.authentication_dialog_clear_button), null)
+        builder.setNegativeButton(
+            R.string.authentication_dialog_cancel_button
+        ) { dialog: DialogInterface, _ -> dialog.cancel() }
+        builder.setView(prepareDialogLayout(jwtInput, externalTokenInput))
+        val alertDialog = builder.create()
+        alertDialog.setOnShowListener {
+            val button = alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL)
+            button.setOnClickListener {
+                jwtInput.setText("")
+                externalTokenInput.setText("")
+                clearAuthToken()
+            }
+        }
+        alertDialog.show()
+    }
+
+    private fun refresh(jwtInput: EditText, externalTokenInput: EditText) {
+        val jwt = jwtInput.text.toString()
+        var externalToken: String? = externalTokenInput.text.toString()
+        if (externalToken!!.isEmpty()) externalToken = null
+        authentication?.refresh(
+            jwt, externalToken
+        ) { response, exception ->
+            setupAuthButtonsVisibility()
+            if (exception != null || !authentication!!.isAuthenticated) {
+                showToast("Error: $exception")
+            } else {
+                showToast("Refreshed")
+            }
+        }
+        saveAuthToken(jwt)
     }
 
     private fun initGliaWidgets() {

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -166,6 +166,17 @@
                 app:layout_constraintTop_toBottomOf="@+id/authenticationButton" />
 
             <Button
+                android:id="@+id/refreshAuthButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_refresh_auth"
+                android:visibility="gone"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/deauthenticationButton" />
+
+            <Button
                 android:id="@+id/visitor_info_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -173,7 +184,7 @@
                 android:text="@string/visitor_info"
                 app:layout_constraintEnd_toEndOf="@id/end_guideline"
                 app:layout_constraintStart_toStartOf="@id/start_guideline"
-                app:layout_constraintTop_toBottomOf="@id/deauthenticationButton" />
+                app:layout_constraintTop_toBottomOf="@id/refreshAuthButton" />
 
             <Button
                 android:id="@+id/clear_session_button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="main_init_glia">Init Glia Widgets SDK</string>
     <string name="main_authenticate">Authenticate</string>
     <string name="main_deauthenticate">De-authenticate</string>
+    <string name="main_refresh_auth">Refresh authentication</string>
     <string name="main_clear_visitor_session">Clear Session</string>
     <string name="main_show_visitor_code">Show Visitor Code</string>
 
@@ -97,6 +98,8 @@
     <string name="authentication_dialog_authenticate_button">Authenticate</string>
     <string name="authentication_dialog_clear_button">Clear</string>
     <string name="authentication_dialog_cancel_button">Cancel</string>
+    <string name="refresh_auth_dialog_title">Refresh authentication</string>
+    <string name="refresh_dialog_refresh_button">Refresh</string>
 
     <string name="visitor_info_name">Name</string>
     <string name="visitor_info_email">Email</string>

--- a/widgetssdk/src/main/java/com/glia/widgets/core/authentication/AuthenticationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/authentication/AuthenticationManager.kt
@@ -49,4 +49,9 @@ internal class AuthenticationManager(
     }
 
     override fun isAuthenticated(): Boolean = authentication.isAuthenticated
+
+    override fun refresh(jwtToken: String?, externalAccessToken: String?, authCallback: RequestCallback<Void>?) {
+        Logger.i(TAG, "Refresh authentication")
+        authentication.refresh(jwtToken, externalAccessToken, authCallback)
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -135,7 +135,8 @@ public class ControllerFactory {
                 useCaseFactory.getUriToFileAttachmentUseCase(),
                 useCaseFactory.getWithCameraPermissionUseCase(),
                 useCaseFactory.getWithReadWritePermissionsUseCase(),
-                useCaseFactory.getRequestNotificationPermissionIfPushNotificationsSetUpUseCase()
+                useCaseFactory.getRequestNotificationPermissionIfPushNotificationsSetUpUseCase(),
+                useCaseFactory.getReleaseResourcesUseCase(getDialogController())
             );
         }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/controller/ChatControllerTest.kt
@@ -44,6 +44,7 @@ import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCa
 import com.glia.widgets.engagement.domain.IsQueueingOrEngagementUseCase
 import com.glia.widgets.engagement.domain.OperatorMediaUseCase
 import com.glia.widgets.engagement.domain.OperatorTypingUseCase
+import com.glia.widgets.engagement.domain.ReleaseResourcesUseCase
 import com.glia.widgets.engagement.domain.ScreenSharingUseCase
 import com.glia.widgets.filepreview.domain.usecase.DownloadFileUseCase
 import com.glia.widgets.filepreview.domain.usecase.IsFileReadyForPreviewUseCase
@@ -108,6 +109,7 @@ class ChatControllerTest {
     private lateinit var withCameraPermissionUseCase: WithCameraPermissionUseCase
     private lateinit var withReadWritePermissionsUseCase: WithReadWritePermissionsUseCase
     private lateinit var requestNotificationPermissionIfPushNotificationsSetUpUseCase: RequestNotificationPermissionIfPushNotificationsSetUpUseCase
+    private lateinit var releaseResourcesUseCase: ReleaseResourcesUseCase
 
     private lateinit var chatController: ChatController
     private lateinit var isAuthenticatedUseCase: IsAuthenticatedUseCase
@@ -175,6 +177,7 @@ class ChatControllerTest {
         withCameraPermissionUseCase = mock()
         withReadWritePermissionsUseCase = mock()
         requestNotificationPermissionIfPushNotificationsSetUpUseCase = mock()
+        releaseResourcesUseCase = mock()
 
         chatController = ChatController(
             callTimer = callTimer,
@@ -220,7 +223,8 @@ class ChatControllerTest {
             uriToFileAttachmentUseCase = uriToFileAttachmentUseCase,
             withCameraPermissionUseCase = withCameraPermissionUseCase,
             withReadWritePermissionsUseCase = withReadWritePermissionsUseCase,
-            requestNotificationPermissionIfPushNotificationsSetUpUseCase = requestNotificationPermissionIfPushNotificationsSetUpUseCase
+            requestNotificationPermissionIfPushNotificationsSetUpUseCase = requestNotificationPermissionIfPushNotificationsSetUpUseCase,
+            releaseResourcesUseCase = releaseResourcesUseCase
         )
         chatController.setView(chatView)
     }


### PR DESCRIPTION
[MOB-3204](https://glia.atlassian.net/browse/MOB-3204)
Build fails because [Core SDK changes](https://github.com/salemove/android-sdk/pull/670) should be released first.

**What was solved?**
- Add an interface for refreshing visitor access token using direct ID token
- Example App: update Authenticate/De-authenticate button state each time onResume() is called

**Release notes:**
Add an interface for refreshing visitor access token using direct ID token

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [x] Did you add logging beneficial for troubleshooting of customer issues?
 - [x] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-3204]: https://glia.atlassian.net/browse/MOB-3204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ