### PR TITLE
Add tests for engagement completion layer

### DIFF
--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcherTest.kt
@@ -1,0 +1,324 @@
+package com.glia.widgets.engagement.completion
+
+import android.CONTEXT_EXTENSIONS_CLASS_PATH
+import android.LOGGER_PATH
+import android.app.Activity
+import android.content.Context
+import android.os.Parcelable
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import com.glia.widgets.UiTheme
+import com.glia.widgets.chat.ChatActivity
+import com.glia.widgets.helper.GliaActivityManager
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.OneTimeEvent
+import com.glia.widgets.helper.withRuntimeTheme
+import com.glia.widgets.view.Dialogs
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
+import io.reactivex.rxjava3.processors.PublishProcessor
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class EngagementCompletionActivityWatcherTest {
+    private val stateProcessor: PublishProcessor<OneTimeEvent<EngagementCompletionState>> = PublishProcessor.create()
+    private lateinit var dialog: AlertDialog
+
+    private lateinit var gliaActivityManager: GliaActivityManager
+    private lateinit var controller: EngagementCompletionContract.Controller
+
+    private lateinit var watcher: EngagementCompletionActivityWatcher
+
+    @Before
+    fun setUp() {
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler { Schedulers.trampoline() }
+
+        mockkObject(Dialogs)
+        mockkStatic(CONTEXT_EXTENSIONS_CLASS_PATH)
+
+        dialog = mockk(relaxed = true)
+        every { Dialogs.showOperatorEndedEngagementDialog(any(), any(), any()) } returns dialog
+        every { Dialogs.showNoMoreOperatorsAvailableDialog(any(), any(), any()) } returns dialog
+        every { Dialogs.showUnexpectedErrorDialog(any(), any(), any()) } returns dialog
+
+        gliaActivityManager = mockk(relaxed = true)
+
+        controller = mockk(relaxUnitFun = true) {
+            every { state } returns stateProcessor
+        }
+
+        watcher = EngagementCompletionActivityWatcher(controller, gliaActivityManager)
+
+        verify { controller.state }
+    }
+
+    @After
+    fun tearDown() {
+        RxAndroidPlugins.reset()
+
+        confirmVerified(controller)
+
+        unmockkObject(Dialogs)
+        unmockkStatic(CONTEXT_EXTENSIONS_CLASS_PATH)
+    }
+
+    @Test
+    fun `handleState will do nothing when event is consumed`() {
+        mockkStatic(LOGGER_PATH)
+        Logger.setIsDebug(false)
+        every { Logger.d(any(), any()) } just Runs
+
+        val event = createMockEvent(EngagementCompletionState.QueuingOrEngagementEnded)
+        every { event.consumed } returns true
+
+        val activity = mockkActivity<Activity>()
+
+        watcher.onActivityResumed(activity)
+        stateProcessor.onNext(event)
+
+        verify { event.consumed }
+        verify { Logger.d(any(), any()) }
+        verify(exactly = 2) { event.value }
+
+        verify(exactly = 0) { event.consume(any()) }
+        verify(exactly = 0) { Dialogs.showOperatorEndedEngagementDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showNoMoreOperatorsAvailableDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showUnexpectedErrorDialog(any(), any(), any()) }
+
+        verify(exactly = 0) { activity.startActivity(any()) }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+
+        confirmVerified(event, activity)
+
+        unmockkStatic(LOGGER_PATH)
+    }
+
+    @Test
+    fun `handleState will finish activities when state is QueuingOrEngagementEnded even if activity is null or finishing`() {
+        val event = createMockEvent(EngagementCompletionState.QueuingOrEngagementEnded)
+        val activity = mockkActivity<Activity>()
+
+        every { activity.isFinishing } returns true
+
+        watcher.onActivityResumed(activity)
+        stateProcessor.onNext(event)
+
+        verify { event.value }
+        verify { event.consumed }
+        verify { event.consume(any()) }
+
+        verify { gliaActivityManager.finishActivities() }
+
+        verify(exactly = 0) { Dialogs.showOperatorEndedEngagementDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showNoMoreOperatorsAvailableDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showUnexpectedErrorDialog(any(), any(), any()) }
+
+        verify(exactly = 0) { activity.startActivity(any()) }
+
+        confirmVerified(event)
+    }
+
+    @Test
+    fun `handleState will do nothing when event is not QueuingOrEngagementEnded and Activity is null or finishing`() {
+        mockkStatic(LOGGER_PATH)
+        Logger.setIsDebug(false)
+        every { Logger.d(any(), any()) } just Runs
+
+        val event = createMockEvent(EngagementCompletionState.QueueUnstaffed)
+
+        val activity = mockkActivity<Activity>()
+        every { activity.isFinishing } returns true
+
+        watcher.onActivityResumed(activity)
+        stateProcessor.onNext(event)
+
+        verify { event.consumed }
+        verify { activity.isFinishing }
+        verify { Logger.d(any(), any()) }
+        verify(exactly = 1) { event.value }
+
+        verify(exactly = 0) { event.consume(any()) }
+        verify(exactly = 0) { Dialogs.showOperatorEndedEngagementDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showNoMoreOperatorsAvailableDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showUnexpectedErrorDialog(any(), any(), any()) }
+
+        verify(exactly = 0) { activity.startActivity(any()) }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+
+        confirmVerified(event, activity)
+
+        unmockkStatic(LOGGER_PATH)
+    }
+
+    @Test
+    fun `handleState will show unstaffed dialog when event is QueueUnstaffed`() {
+        val event = createMockEvent(EngagementCompletionState.QueueUnstaffed)
+
+        val activity = mockkActivity<ChatActivity>()
+
+        watcher.onActivityResumed(activity)
+        stateProcessor.onNext(event)
+
+        verify { event.consumed }
+        verify { activity.isFinishing }
+        verify(exactly = 1) { event.value }
+
+        verify(exactly = 0) { event.consume(any()) }
+        verify(exactly = 0) { Dialogs.showOperatorEndedEngagementDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showUnexpectedErrorDialog(any(), any(), any()) }
+
+        verify(exactly = 0) { activity.startActivity(any()) }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+
+        val dialogCallbackSlot = slot<View.OnClickListener>()
+
+        verify { Dialogs.showNoMoreOperatorsAvailableDialog(activity, any(), capture(dialogCallbackSlot)) }
+
+        verify(exactly = 0) { dialog.dismiss() }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+        verify(exactly = 0) { event.markConsumed() }
+
+        dialogCallbackSlot.captured.onClick(mockk())
+
+        verify { dialog.dismiss() }
+        verify { gliaActivityManager.finishActivities() }
+        verify { event.markConsumed() }
+
+        confirmVerified(event, activity)
+    }
+
+    @Test
+    fun `handleState will show unexpected error dialog when event is UnexpectedErrorHappened`() {
+        val event = createMockEvent(EngagementCompletionState.UnexpectedErrorHappened)
+
+        val activity = mockkActivity<ChatActivity>()
+
+        watcher.onActivityResumed(activity)
+        stateProcessor.onNext(event)
+
+        verify { event.consumed }
+        verify { activity.isFinishing }
+        verify(exactly = 1) { event.value }
+
+        verify(exactly = 0) { event.consume(any()) }
+        verify(exactly = 0) { Dialogs.showOperatorEndedEngagementDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showNoMoreOperatorsAvailableDialog(any(), any(), any()) }
+
+        verify(exactly = 0) { activity.startActivity(any()) }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+
+        val dialogCallbackSlot = slot<View.OnClickListener>()
+
+        verify { Dialogs.showUnexpectedErrorDialog(activity, any(), capture(dialogCallbackSlot)) }
+
+        verify(exactly = 0) { dialog.dismiss() }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+        verify(exactly = 0) { event.markConsumed() }
+
+        dialogCallbackSlot.captured.onClick(mockk())
+
+        verify { dialog.dismiss() }
+        verify { gliaActivityManager.finishActivities() }
+        verify { event.markConsumed() }
+
+        confirmVerified(event, activity)
+    }
+
+    @Test
+    fun `handleState will show operator ended engagement dialog when event is OperatorEndedEngagement`() {
+        val event = createMockEvent(EngagementCompletionState.OperatorEndedEngagement)
+
+        val activity = mockkActivity<ChatActivity>()
+
+        watcher.onActivityResumed(activity)
+        stateProcessor.onNext(event)
+
+        verify { event.consumed }
+        verify { activity.isFinishing }
+        verify(exactly = 1) { event.value }
+
+        verify(exactly = 0) { event.consume(any()) }
+        verify(exactly = 0) { Dialogs.showUnexpectedErrorDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showNoMoreOperatorsAvailableDialog(any(), any(), any()) }
+
+        verify(exactly = 0) { activity.startActivity(any()) }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+
+        val dialogCallbackSlot = slot<View.OnClickListener>()
+
+        verify { Dialogs.showOperatorEndedEngagementDialog(activity, any(), capture(dialogCallbackSlot)) }
+
+        verify(exactly = 0) { dialog.dismiss() }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+        verify(exactly = 0) { event.markConsumed() }
+
+        dialogCallbackSlot.captured.onClick(mockk())
+
+        verify { dialog.dismiss() }
+        verify { gliaActivityManager.finishActivities() }
+        verify { event.markConsumed() }
+
+        confirmVerified(event, activity)
+    }
+
+    @Test
+    fun `handleState will start Survey when event is SurveyLoaded`() {
+        val event = createMockEvent(EngagementCompletionState.SurveyLoaded(mockk(moreInterfaces = arrayOf(Parcelable::class))))
+
+        val activity = mockkActivity<ChatActivity>()
+
+        watcher.onActivityResumed(activity)
+        stateProcessor.onNext(event)
+
+        verify { event.consumed }
+        verify { activity.isFinishing }
+        verify(exactly = 1) { event.value }
+
+        verify(exactly = 0) { Dialogs.showUnexpectedErrorDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showNoMoreOperatorsAvailableDialog(any(), any(), any()) }
+        verify(exactly = 0) { Dialogs.showOperatorEndedEngagementDialog(any(), any(), any()) }
+
+        verify { event.consume(any()) }
+
+        verify { activity.overridePendingTransition(any(), any()) }
+        verify { activity.startActivity(any()) }
+        verify { activity.packageName }
+
+        verify(exactly = 0) { dialog.dismiss() }
+        verify(exactly = 0) { gliaActivityManager.finishActivities() }
+
+        confirmVerified(event, activity)
+    }
+
+}
+
+private inline fun <reified T : Activity> mockkActivity(uiTheme: UiTheme = UiTheme()): T {
+    val activity: T = mockk(relaxed = true)
+
+    every { any<Activity>().withRuntimeTheme(captureLambda()) } answers {
+        secondArg<(Context, UiTheme) -> Unit>().invoke(activity, uiTheme)
+    }
+
+    return activity
+}
+
+private fun createMockEvent(state: EngagementCompletionState): OneTimeEvent<EngagementCompletionState> {
+    val event: OneTimeEvent<EngagementCompletionState> = mockk(relaxed = true)
+    every { event.value } returns state
+    every { event.consume(captureLambda()) } answers {
+        firstArg<EngagementCompletionState.() -> Unit>().invoke(state)
+    }
+    return event
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionControllerTest.kt
@@ -1,0 +1,143 @@
+package com.glia.widgets.engagement.completion
+
+import com.glia.androidsdk.engagement.Survey
+import com.glia.widgets.engagement.EngagementUpdateState
+import com.glia.widgets.engagement.State
+import com.glia.widgets.engagement.SurveyState
+import com.glia.widgets.engagement.domain.EngagementStateUseCase
+import com.glia.widgets.engagement.domain.ReleaseResourcesUseCase
+import com.glia.widgets.engagement.domain.SurveyUseCase
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
+import io.reactivex.rxjava3.processors.PublishProcessor
+import io.reactivex.rxjava3.schedulers.Schedulers
+import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class EngagementCompletionControllerTest {
+    private val surveyStateProcessor = PublishProcessor.create<SurveyState>()
+    private val engagementStateProcessor = PublishProcessor.create<State>()
+
+    private lateinit var releaseResourcesUseCase: ReleaseResourcesUseCase
+    private lateinit var engagementStateUseCase: EngagementStateUseCase
+    private lateinit var surveyUseCase: SurveyUseCase
+
+    private lateinit var controller: EngagementCompletionContract.Controller
+
+    @Before
+    fun setUp() {
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler { Schedulers.trampoline() }
+
+        releaseResourcesUseCase = mockk(relaxUnitFun = true)
+        engagementStateUseCase = mockk(relaxUnitFun = true)
+        surveyUseCase = mockk(relaxUnitFun = true)
+
+        every { engagementStateUseCase() } returns engagementStateProcessor
+        every { surveyUseCase() } returns surveyStateProcessor
+
+        controller = EngagementCompletionController(releaseResourcesUseCase, engagementStateUseCase, surveyUseCase)
+
+        verify { surveyUseCase() }
+        verify { engagementStateUseCase() }
+    }
+
+    @After
+    fun tearDown() {
+        confirmVerified(releaseResourcesUseCase, engagementStateUseCase, surveyUseCase)
+
+        RxAndroidPlugins.reset()
+    }
+
+    @Test
+    fun `State FinishedCallVisualizer should release resources and emit QueuingOrEngagementEnded`() {
+        engagementStateProcessor.onNext(State.FinishedCallVisualizer)
+
+        verify { releaseResourcesUseCase() }
+        assertEquals(EngagementCompletionState.QueuingOrEngagementEnded, controller.state.blockingFirst().value)
+    }
+
+    @Test
+    fun `State FinishedOmniCore should release resources and emit QueuingOrEngagementEnded`() {
+        engagementStateProcessor.onNext(State.FinishedOmniCore)
+
+        verify { releaseResourcesUseCase() }
+        assertEquals(EngagementCompletionState.QueuingOrEngagementEnded, controller.state.blockingFirst().value)
+    }
+
+    @Test
+    fun `State QueueUnstaffed should release resources and emit QueuingOrEngagementEnded and QueueUnstaffed`() {
+        val testState = controller.state.map { it.value }.test()
+
+        engagementStateProcessor.onNext(State.QueueUnstaffed)
+
+        verify { releaseResourcesUseCase() }
+
+        testState.assertValues(
+            EngagementCompletionState.QueuingOrEngagementEnded,
+            EngagementCompletionState.QueueUnstaffed
+        )
+    }
+
+    @Test
+    fun `State UnexpectedErrorHappened should release resources and emit QueuingOrEngagementEnded and UnexpectedErrorHappened`() {
+        val testState = controller.state.map { it.value }.test()
+
+        engagementStateProcessor.onNext(State.UnexpectedErrorHappened)
+
+        verify { releaseResourcesUseCase() }
+
+        testState.assertValues(
+            EngagementCompletionState.QueuingOrEngagementEnded,
+            EngagementCompletionState.UnexpectedErrorHappened
+        )
+    }
+
+    @Test
+    fun `State other than FinishedCallVisualizer, FinishedOmniCore, QueueUnstaffed, UnexpectedErrorHappened should not release resources`() {
+        val testState = controller.state.test()
+
+        engagementStateProcessor.onNext(State.NoEngagement)
+        engagementStateProcessor.onNext(State.PreQueuing("queueId"))
+        engagementStateProcessor.onNext(State.Queuing("queueId", "queueTicketId"))
+        engagementStateProcessor.onNext(State.QueueingCanceled)
+        engagementStateProcessor.onNext(State.StartedOmniCore)
+        engagementStateProcessor.onNext(State.StartedCallVisualizer)
+        engagementStateProcessor.onNext(State.Update(mockk(), EngagementUpdateState.Transferring))
+
+        verify(exactly = 0) { releaseResourcesUseCase() }
+        testState.assertNoValues()
+    }
+
+    @Test
+    fun `SurveyState EmptyFromOperatorRequest should produce OperatorEndedEngagement`() {
+        val testState = controller.state.map { it.value }.test()
+
+        surveyStateProcessor.onNext(SurveyState.EmptyFromOperatorRequest)
+
+        testState.assertValues(EngagementCompletionState.OperatorEndedEngagement)
+    }
+
+    @Test
+    fun `SurveyState Value should produce SurveyLoaded`() {
+        val survey = mockk<Survey>()
+        val testState = controller.state.map { it.value }.test()
+
+        surveyStateProcessor.onNext(SurveyState.Value(survey))
+
+        testState.assertValues(EngagementCompletionState.SurveyLoaded(survey))
+    }
+
+    @Test
+    fun `SurveyState Empty should not produce any state`() {
+        val testState = controller.state.test()
+
+        surveyStateProcessor.onNext(SurveyState.Empty)
+
+        testState.assertNoValues()
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2990

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
