### PR TITLE
Add refresh DirectID token possibility to Widgets Example App

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -93,7 +93,7 @@ class MainFragment : Fragment() {
         view.findViewById<View>(R.id.deauthenticationButton)
             .setOnClickListener { deAuthenticate() }
         view.findViewById<View>(R.id.refreshAuthButton)
-            .setOnClickListener { showRefreshAuthDialog(null) }
+            .setOnClickListener { showRefreshAuthDialog() }
         view.findViewById<View>(R.id.clear_session_button)
             .setOnClickListener { clearSession() }
         view.findViewById<View>(R.id.visitor_code_button).setOnClickListener {
@@ -382,8 +382,8 @@ class MainFragment : Fragment() {
     private fun showAuthenticationDialog(callback: OnAuthCallback?) {
         if (context == null) return
         val builder = AlertDialog.Builder(requireContext())
-        val jwtInput = prepareJwtInputViewEditText(builder)
-        val externalTokenInput = prepareExternalTokenInputViewEditText(builder)
+        val jwtInput = prepareJwtInputViewEditText(builder, R.string.authentication_dialog_title)
+        val externalTokenInput = prepareExternalTokenInputViewEditText(builder, R.string.authentication_dialog_title)
         jwtInput.setText(authToken)
         builder.setPositiveButton(
             getString(R.string.authentication_dialog_authenticate_button)
@@ -432,35 +432,37 @@ class MainFragment : Fragment() {
         return container
     }
 
-    private fun prepareJwtInputViewEditText(builder: AlertDialog.Builder): EditText {
+    private fun prepareJwtInputViewEditText(builder: AlertDialog.Builder,
+                                            dialogTitle: Int): EditText {
         val input = EditText(context)
         input.setHint(R.string.authentication_dialog_jwt_input_hint)
         input.setSingleLine()
         input.maxLines = 10
         input.setHorizontallyScrolling(false)
         input.inputType = InputType.TYPE_CLASS_TEXT
-        builder.setTitle(R.string.authentication_dialog_title)
+        builder.setTitle(dialogTitle)
         builder.setView(input)
         return input
     }
 
-    private fun prepareExternalTokenInputViewEditText(builder: AlertDialog.Builder): EditText {
+    private fun prepareExternalTokenInputViewEditText(builder: AlertDialog.Builder,
+                                                      dialogTitle: Int): EditText {
         val input = EditText(context)
         input.setHint(R.string.authentication_dialog_external_token_input_hint)
         input.setSingleLine()
         input.maxLines = 10
         input.setHorizontallyScrolling(false)
         input.inputType = InputType.TYPE_CLASS_TEXT
-        builder.setTitle(R.string.authentication_dialog_title)
+        builder.setTitle(dialogTitle)
         builder.setView(input)
         return input
     }
 
-    private fun showRefreshAuthDialog(callback: OnAuthCallback?) {
+    private fun showRefreshAuthDialog() {
         if (context == null) return
         val builder = AlertDialog.Builder(requireContext())
-        val jwtInput = prepareJwtInputViewEditText(builder)
-        val externalTokenInput = prepareExternalTokenInputViewEditText(builder)
+        val jwtInput = prepareJwtInputViewEditText(builder, R.string.refresh_auth_dialog_title)
+        val externalTokenInput = prepareExternalTokenInputViewEditText(builder, R.string.refresh_auth_dialog_title)
         jwtInput.setText(authToken)
         builder.setPositiveButton(
             getString(R.string.refresh_dialog_refresh_button)

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -166,6 +166,17 @@
                 app:layout_constraintTop_toBottomOf="@+id/authenticationButton" />
 
             <Button
+                android:id="@+id/refreshAuthButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_m"
+                android:text="@string/main_refresh_auth"
+                android:visibility="gone"
+                app:layout_constraintEnd_toStartOf="@+id/end_guideline"
+                app:layout_constraintStart_toStartOf="@+id/start_guideline"
+                app:layout_constraintTop_toBottomOf="@+id/deauthenticationButton" />
+
+            <Button
                 android:id="@+id/visitor_info_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -173,7 +184,7 @@
                 android:text="@string/visitor_info"
                 app:layout_constraintEnd_toEndOf="@id/end_guideline"
                 app:layout_constraintStart_toStartOf="@id/start_guideline"
-                app:layout_constraintTop_toBottomOf="@id/deauthenticationButton" />
+                app:layout_constraintTop_toBottomOf="@id/refreshAuthButton" />
 
             <Button
                 android:id="@+id/clear_session_button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="main_init_glia">Init Glia Widgets SDK</string>
     <string name="main_authenticate">Authenticate</string>
     <string name="main_deauthenticate">De-authenticate</string>
+    <string name="main_refresh_auth">Refresh authentication</string>
     <string name="main_clear_visitor_session">Clear Session</string>
     <string name="main_show_visitor_code">Show Visitor Code</string>
 
@@ -97,6 +98,8 @@
     <string name="authentication_dialog_authenticate_button">Authenticate</string>
     <string name="authentication_dialog_clear_button">Clear</string>
     <string name="authentication_dialog_cancel_button">Cancel</string>
+    <string name="refresh_auth_dialog_title">Refresh authentication</string>
+    <string name="refresh_dialog_refresh_button">Refresh</string>
 
     <string name="visitor_info_name">Name</string>
     <string name="visitor_info_email">Email</string>


### PR DESCRIPTION
[Devs want to update Widgets Testing App with refresh DirectID token possibility](https://glia.atlassian.net/browse/MOB-3274)

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img width="222" alt="Screenshot 2024-04-26 at 23 19 09" src="https://github.com/salemove/android-sdk-widgets/assets/57521863/5da1e405-c909-44f2-8ef0-4a9ac76a0979">
<img width="222" alt="Screenshot 2024-04-26 at 23 29 59" src="https://github.com/salemove/android-sdk-widgets/assets/57521863/5999c974-a532-4172-9c0a-278dcdf1bcae">
