### PR TITLE
Feature/mob 3281 show bubble internally with overlay false

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
+++ b/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
@@ -128,7 +128,7 @@ object ExampleAppConfigManager {
             context.getString(R.string.pref_company_name),
             context.getString(R.string.settings_value_default_company_name)
         )
-        val useOverlay = preferences.getBoolean(context.getString(R.string.pref_use_overlay), false)
+        val useOverlay = preferences.getBoolean(context.getString(R.string.pref_use_overlay), true)
         val bounded = context.getString(R.string.screen_sharing_mode_app_bounded)
         val unbounded = context.getString(R.string.screen_sharing_mode_unbounded)
         val screenSharingMode = if (

--- a/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
+++ b/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
@@ -128,7 +128,7 @@ object ExampleAppConfigManager {
             context.getString(R.string.pref_company_name),
             context.getString(R.string.settings_value_default_company_name)
         )
-        val useOverlay = preferences.getBoolean(context.getString(R.string.pref_use_overlay), true)
+        val useOverlay = preferences.getBoolean(context.getString(R.string.pref_use_overlay), false)
         val bounded = context.getString(R.string.screen_sharing_mode_app_bounded)
         val unbounded = context.getString(R.string.screen_sharing_mode_unbounded)
         val screenSharingMode = if (

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -73,9 +73,9 @@ public class GliaWidgets {
      * Use with {@link android.os.Bundle} to pass in a boolean which represents if you would like to
      * use the chat head bubble as an overlay outside your application for
      * navigating to {@link com.glia.widgets.chat.ChatActivity}
-     * If set to true then the sdk will ask for overlay permissions and try to always show the navigation bubble,
+     * If set to true then the SDK will ask for overlay permissions and try to always show the navigation bubble,
      * outside the application will be shown only if the user has accepted the permissions.
-     * If false, then overlay permissions are not requested, but the navigation bubble is still shown during your application being active.
+     * If false, then overlay permissions are not requested and the navigation bubble is shown when the application is active.
      * The {@link com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController} will notify any
      * listening {@link com.glia.widgets.view.head.ChatHeadLayout} of any visibility changes.
      * When this value is not passed then by default this value is true.

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -71,13 +71,13 @@ public class GliaWidgets {
     public static final String CONTEXT_ASSET_ID = "context_asset_id";
     /**
      * Use with {@link android.os.Bundle} to pass in a boolean which represents if you would like to
-     * use the chat head bubble as an overlay as a navigation argument when
+     * use the chat head bubble as an overlay outside your application for
      * navigating to {@link com.glia.widgets.chat.ChatActivity}
-     * If set to true then the chat head will appear in the overlay and the sdk will ask for
-     * overlay permissions. If false, then the {@link com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController} will notify any
+     * If set to true then the sdk will ask for overlay permissions and try to always show the navigation bubble,
+     * outside the application will be shown only if the user has accepted the permissions.
+     * If false, then overlay permissions are not requested, but the navigation bubble is still shown during your application being active.
+     * The {@link com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController} will notify any
      * listening {@link com.glia.widgets.view.head.ChatHeadLayout} of any visibility changes.
-     * It is up to the integrator to integrate {@link com.glia.widgets.view.head.ChatHeadLayout} in their
-     * application.
      * When this value is not passed then by default this value is true.
      */
     public static final String USE_OVERLAY = "use_overlay";

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
@@ -23,8 +23,12 @@ internal abstract class IsDisplayChatHeadUseCase(
 ) {
     abstract fun isDisplayBasedOnPermission(): Boolean
 
-    open operator fun invoke(viewName: String?): Boolean {
-        return isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
+    open operator fun invoke(viewName: String?, internal: Boolean = false): Boolean {
+        return if (internal) {
+            isDisplayBasedOnPermission() && isShowForEngagement(viewName)
+        } else {
+            isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
+        }
     }
 
     private fun isShowForEngagement(viewName: String?) =

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
@@ -25,7 +25,7 @@ internal abstract class IsDisplayChatHeadUseCase(
 
     open operator fun invoke(viewName: String?, internal: Boolean = false): Boolean {
         return if (internal) {
-            isDisplayBasedOnPermission() && isShowForEngagement(viewName)
+            isShowForEngagement(viewName)
         } else {
             isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
@@ -23,12 +23,16 @@ internal abstract class IsDisplayChatHeadUseCase(
 ) {
     abstract fun isDisplayBasedOnPermission(): Boolean
 
-    open operator fun invoke(viewName: String?, internal: Boolean = false): Boolean {
-        return if (internal) {
-            isShowForEngagement(viewName)
-        } else {
-            isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
+    open operator fun invoke(viewName: String?, type: ChatHeadType): Boolean {
+        return when (type) {
+            ChatHeadType.INTERNAL -> isShowForEngagement(viewName)
+            ChatHeadType.GLOBAL -> isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
         }
+    }
+
+    open operator fun invoke(viewName: String?): Boolean {
+        val a = isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
+        return a
     }
 
     private fun isShowForEngagement(viewName: String?) =
@@ -60,7 +64,7 @@ internal abstract class IsDisplayChatHeadUseCase(
             viewName != DialogHolderView::class.java.simpleName
     }
 
-    private fun isNotInListOfGliaViews(viewName: String?): Boolean {
+    fun isNotInListOfGliaViews(viewName: String?): Boolean {
         return viewName != ChatView::class.java.simpleName && isNotInListOfGliaViewsExceptChat(viewName)
     }
 
@@ -70,4 +74,9 @@ internal abstract class IsDisplayChatHeadUseCase(
     private val isMediaEngagementOngoing: Boolean get() = engagementTypeUseCase.isMediaEngagement
     private val isChatQueueingOngoing: Boolean get() = isQueueingOrEngagementUseCase.isQueueingForChat
     private val isChatEngagementOngoing: Boolean get() = engagementTypeUseCase.isChatEngagement
+
+    enum class ChatHeadType {
+        INTERNAL,
+        GLOBAL
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
@@ -26,8 +26,8 @@ internal class ToggleChatHeadServiceUseCase(
     configurationManager,
     engagementTypeUseCase
 ) {
-    override operator fun invoke(viewName: String?, internal: Boolean): Boolean {
-        val isDisplayDeviceBubble = super.invoke(viewName, internal)
+    override operator fun invoke(viewName: String?): Boolean {
+        val isDisplayDeviceBubble = super.invoke(viewName, ChatHeadType.GLOBAL) && viewName == null
         if (isDisplayDeviceBubble) {
             Logger.i(TAG, "Bubble: show device bubble")
             chatHeadManager.startChatHeadService()

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
@@ -26,8 +26,8 @@ internal class ToggleChatHeadServiceUseCase(
     configurationManager,
     engagementTypeUseCase
 ) {
-    override operator fun invoke(viewName: String?): Boolean {
-        val isDisplayDeviceBubble = super.invoke(viewName)
+    override operator fun invoke(viewName: String?, internal: Boolean): Boolean {
+        val isDisplayDeviceBubble = super.invoke(viewName, internal)
         if (isDisplayDeviceBubble) {
             Logger.i(TAG, "Bubble: show device bubble")
             chatHeadManager.startChatHeadService()

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.view.head.controller
 import com.glia.androidsdk.Operator
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
 import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase
+import com.glia.widgets.core.chathead.domain.IsDisplayChatHeadUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
 import com.glia.widgets.engagement.ScreenSharingState
@@ -110,7 +111,7 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     override fun shouldShow(gliaOrRootViewName: String?): Boolean {
-        return isDisplayApplicationChatHeadUseCase(gliaOrRootViewName, true)
+        return isDisplayApplicationChatHeadUseCase(gliaOrRootViewName, IsDisplayChatHeadUseCase.ChatHeadType.INTERNAL)
     }
 
     override fun onResume(viewName: String) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -110,7 +110,7 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     override fun shouldShow(gliaOrRootViewName: String?): Boolean {
-        return isDisplayApplicationChatHeadUseCase(gliaOrRootViewName)
+        return isDisplayApplicationChatHeadUseCase(gliaOrRootViewName, true)
     }
 
     override fun onResume(viewName: String) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
@@ -67,11 +67,12 @@ internal class ServiceChatHeadController(
 
         // see the comment on the resumedViewName field declaration above
         if (!isResumedView(view)) return
-        toggleChatHeadServiceUseCase(view?.javaClass?.simpleName)
+
     }
 
     override fun onPause(gliaOrRootView: View?) {
         clearResumedViewName(gliaOrRootView)
+        toggleChatHeadServiceUseCase(gliaOrRootView?.javaClass?.simpleName)
     }
 
     override fun onSetChatHeadView(view: ChatHeadContract.View) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3281

**What was solved?**
Even with setUseOverlay(false) we are still showing the chathead in the integrator application. Also added relevant javadoc changes, but those will hopefully be confirmed/modified by Kadri today.

**Release notes:**

 - [X] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
