### PR TITLE
Fix dialog case handling error in logs

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -226,7 +226,7 @@ internal class CallView(
                     DialogState.OverlayPermission -> post { showOverlayPermissionsDialog() }
                     DialogState.EndEngagement -> post { showEndEngagementDialog() }
                     DialogState.Confirmation -> post { callController?.onLiveObservationDialogRequested() }
-                    else -> Logger.e(TAG, "DialogController callback in CallView with $it")
+                    else -> { /* noop */ }
                 }
             }
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -515,7 +515,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
                     DialogState.VisitorCode -> {
                         Logger.e(TAG, "DialogController callback in ChatView with MODE_VISITOR_CODE")
                     } // Should never happen inside ChatView
-                    else -> Logger.d(TAG, "Dialog mode $it not handled.")
+                    else -> { /* noop */ }
                 }
             }
         }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3294

**What was solved?**
During the refactoring of dialogs logic, many dialogs are now handled by global watchers and do not require to be handled by views separately. However, the views were still throwing error/debug logs which are confusing.

**Release notes:**

 - [x] Feature: Tiny improvement to error logging
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
