### PR TITLE
Fix expected behavior being sent as an error

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/imageattachment/ImageAttachmentViewHolder.kt
@@ -48,13 +48,13 @@ internal open class ImageAttachmentViewHolder(
         imageView.setImageResource(android.R.color.transparent) // clear the previous view state
         val imageName = attachmentFile.fileName
         disposable = getImageFileFromCacheUseCase.invoke(imageName)
-            .doOnError { error: Throwable -> e(TAG, "failed loading from cache: " + imageName + " reason: " + error.message) }
+            .doOnError { error: Throwable -> d(TAG, "failed loading from cache: " + imageName + " reason: " + error.message) }
             .doOnSuccess { _: Bitmap? -> d(TAG, "loaded from cache: $imageName") }
             .onErrorResumeNext { getImageFileFromDownloadsUseCase.invoke(imageName) }
-            .doOnError { error: Throwable -> e(TAG, imageName + " failed loading from downloads: " + error.message) }
+            .doOnError { error: Throwable -> d(TAG, imageName + " failed loading from downloads: " + error.message) }
             .doOnSuccess { _: Bitmap? -> d(TAG, "loaded from downloads: $imageName") }
             .onErrorResumeNext { getImageFileFromNetworkUseCase.invoke(attachmentFile)}
-            .doOnError { error: Throwable -> e(TAG, imageName + " failed loading from network: " + error.message) }
+            .doOnError { error: Throwable -> d(TAG, imageName + " failed loading from network: " + error.message) }
             .doOnSuccess { _: Bitmap? -> d(TAG, "loaded from network: $imageName") }
             .subscribeOn(schedulers.computationScheduler)
             .observeOn(schedulers.mainScheduler)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3294

**What was solved?**
ImageAttachmentViewHolder#bind() method tries to
1) load image from cache
  1.1) log error if failed
2) if not found load image from local storage
  2.1) log error if failed
3) if still not found load image from network link 
  3.1) log error if failed
4) log error if all of above attempts failed

I have change 1.1, 2.1 and 3.1 to debug logs instead of errors since error should be throws only if all 3 steps should fail.


**Release notes:**

 - [x] Feature: Tiny improvements to error loging
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
