### PR TITLE
Fix: Video views do not appear during a video call

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -131,17 +131,14 @@ internal class CallController(
     // This is done to prevent errors such as "does not support one-way audio calls" only because the
     // other participant media state is passed few milliseconds late.
     private fun subscribeToMediaState() {
-        val dummyState = object : MediaState {
-            override fun getVideo(): Video? {
-                return null
-            }
-            override fun getAudio(): Audio? {
-                return null
-            }
+        val initialState = object : MediaState {
+            override fun getVideo(): Video? = null
+            override fun getAudio(): Audio? = null
         }
+
         Flowable.combineLatest(
-            visitorMediaUseCase().startWithItem(dummyState).map { Optional.of(it) },
-            operatorMediaUseCase().startWithItem(dummyState).map { Optional.of(it) }
+            visitorMediaUseCase().startWithItem(initialState).map { Optional.of(it) },
+            operatorMediaUseCase().startWithItem(initialState).map { Optional.of(it) }
         ) { visitorState, operatorState ->
             Pair(visitorState, operatorState)
         }.debounce(200, TimeUnit.MILLISECONDS)

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -3,9 +3,11 @@ package com.glia.widgets.call
 import android.text.format.DateUtils
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Operator
+import com.glia.androidsdk.comms.Audio
 import com.glia.androidsdk.comms.MediaDirection
 import com.glia.androidsdk.comms.MediaState
 import com.glia.androidsdk.comms.MediaUpgradeOffer
+import com.glia.androidsdk.comms.Video
 import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.widgets.Constants
 import com.glia.widgets.call.CallStatus.EngagementOngoingAudioCallStarted
@@ -129,9 +131,17 @@ internal class CallController(
     // This is done to prevent errors such as "does not support one-way audio calls" only because the
     // other participant media state is passed few milliseconds late.
     private fun subscribeToMediaState() {
+        val dummyState = object : MediaState {
+            override fun getVideo(): Video? {
+                return null
+            }
+            override fun getAudio(): Audio? {
+                return null
+            }
+        }
         Flowable.combineLatest(
-            visitorMediaUseCase().map { Optional.of(it) }.startWithItem(Optional.empty()),
-            operatorMediaUseCase().map { Optional.of(it) }.startWithItem(Optional.empty())
+            visitorMediaUseCase().startWithItem(dummyState).map { Optional.of(it) },
+            operatorMediaUseCase().startWithItem(dummyState).map { Optional.of(it) }
         ) { visitorState, operatorState ->
             Pair(visitorState, operatorState)
         }.debounce(200, TimeUnit.MILLISECONDS)

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/VisitorMediaUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/VisitorMediaUseCase.kt
@@ -5,7 +5,6 @@ import com.glia.widgets.engagement.EngagementRepository
 import com.glia.widgets.helper.Data
 import com.glia.widgets.helper.hasMedia
 import io.reactivex.rxjava3.core.Flowable
-import java.util.concurrent.TimeUnit
 
 internal interface VisitorMediaUseCase {
     val hasMedia: Boolean
@@ -24,5 +23,4 @@ internal class VisitorMediaUseCaseImpl(private val engagementRepository: Engagem
     override val hasMedia: Boolean get() = engagementRepository.visitorCurrentMediaState?.hasMedia ?: false
 
     override fun invoke(): Flowable<MediaState> = visitorMediaState
-        .throttleLatest(1000, TimeUnit.MILLISECONDS)
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3327

**What was solved?**
It seems that the startWithItem does not work well when called after some map functions. The combined visitor and operator media events can never occur in that case. Added dummy initial state that solves the issue.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
