### PR TITLE
Clear the state on Chat screen if visitor authentication has changed

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -135,7 +135,8 @@ public class ControllerFactory {
                 useCaseFactory.getUriToFileAttachmentUseCase(),
                 useCaseFactory.getWithCameraPermissionUseCase(),
                 useCaseFactory.getWithReadWritePermissionsUseCase(),
-                useCaseFactory.getRequestNotificationPermissionIfPushNotificationsSetUpUseCase()
+                useCaseFactory.getRequestNotificationPermissionIfPushNotificationsSetUpUseCase(),
+                useCaseFactory.getReleaseResourcesUseCase(getDialogController())
             );
         }
 


### PR DESCRIPTION
Jira issue:
[Improve observations for test case #1 from exploratory testing](https://glia.atlassian.net/browse/MOB-3317)

**What was solved?**
Since fetch visitor request [can receive an error now](https://github.com/salemove/android-sdk/pull/706), Widgets SDK can clear the state on Chat screen if visitor authentication has changed. Otherwise, Chat screen state is invalid.

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

