### PR TITLE
Fix thread for remove chat header

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ActivityWatcherForChatHead.kt
@@ -121,7 +121,11 @@ internal class ActivityWatcherForChatHead(
     override fun removeChatHeadLayoutIfPresent() {
         Logger.d(TAG, "Bubble: remove application-only bubble")
         saveBubblePosition()
-        (fetchGliaOrRootView() as? ViewGroup)?.removeView(chatHeadLayout)
+        (fetchGliaOrRootView() as? ViewGroup)?.let { gliaOrRootView ->
+            gliaOrRootView.post {
+                gliaOrRootView.removeView(chatHeadLayout)
+            }
+        }
         chatHeadLayout = null
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3387

**What was solved?**
Fixed the crash on de-authentication.
Made removing the chat head from the UI thread to avoid issues when the removeChatHeadLayoutIfPresent() called from the not UI thread.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
