### PR TITLE
Show call notification only on Android APIs prior to 31

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
@@ -58,6 +58,11 @@ internal class NotificationManager(private val applicationContext: Application) 
     }
 
     override fun showAudioCallNotification() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Android APIs 31+ have built in privacy indicators for microphone and camera
+            // See https://source.android.com/docs/core/permissions/privacy-indicators
+            return
+        }
         if (areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID)) {
             notificationManager.notify(
                 NotificationFactory.CALL_NOTIFICATION_ID,
@@ -67,6 +72,11 @@ internal class NotificationManager(private val applicationContext: Application) 
     }
 
     override fun showVideoCallNotification(isTwoWayVideo: Boolean, hasAudio: Boolean) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Android APIs 31+ have built in privacy indicators for microphone and camera
+            // See https://source.android.com/docs/core/permissions/privacy-indicators
+            return
+        }
         if (areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID)) {
             notificationManager.notify(
                 NotificationFactory.CALL_NOTIFICATION_ID,

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import androidx.lifecycle.Lifecycle;
 
+import com.glia.androidsdk.Glia;
 import com.glia.widgets.GliaWidgetsConfig;
 import com.glia.widgets.StringProvider;
 import com.glia.widgets.StringProviderImpl;
@@ -251,7 +252,9 @@ public class Dependencies {
         lifecycleManager.addObserver((source, event) -> {
             if (event == Lifecycle.Event.ON_STOP) {
                 chatBubbleController.onApplicationStop();
-                notificationManager.startNotificationRemovalService();
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && Glia.isInitialized()) {
+                    notificationManager.startNotificationRemovalService();
+                }
             } else if (event == Lifecycle.Event.ON_DESTROY) {
                 chatBubbleController.onDestroy();
             }


### PR DESCRIPTION
**Jira issue:**
[Crashes in Glia Android SDK (Monument)](https://glia.atlassian.net/browse/MOB-3358)

**What was solved?**
In my opinion, call notifications are not needed on Android APIs 31+ (Android 12+) because of the built-in Android [privacy indicators](https://source.android.com/docs/core/permissions/privacy-indicators). 

As a result, there is no need to start `NotificationRemovalService` on 31+ APIs. 

So the following crash should not happen: `Not allowed to start service Intent ... NotificationRemovalService ... app is in background` anymore.

See more details in [Slack](https://salemove.slack.com/archives/CHN6UB7UH/p1718174711873439?thread_ts=1717669165.207099&cid=CHN6UB7UH).

**Release notes:**
Fix `Not allowed to start service Intent ... NotificationRemovalService ... app is in background` crash that sometimes happen on Android 12+.

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img width="1383" alt="Screenshot 2024-06-12 at 09 41 58" src="https://github.com/salemove/android-sdk-widgets/assets/57521863/64c3b2ad-0054-4bcf-9b82-140d556ec997">

