### PR TITLE
Revert "Add a Maven link for staging Core SDK"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,6 @@ subprojects {
 
   repositories {
     mavenCentral()
-    // Added for running acceptance tests before Core SDK release
-    // Will remove via a separate PR after acceptance tests succeed
-    maven { url 'https://s01.oss.sonatype.org/content/repositories/comglia-1292' }
   }
 
   ktlint {


### PR DESCRIPTION
This reverts commit 3cc5e3d420165b3217a13c75e2b926f4b2d713c4.

**What was solved?**
Removes a link to a temporary maven repository added for running acceptance tests before release.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

