### PR TITLE
Fix useOverlays property having different values during configuration

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -36,7 +36,7 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
 
     @JvmField
     val screenSharingMode: ScreenSharing.Mode?
-    val isUseOverlay: Boolean
+    val isUseOverlay: Boolean?
 
     @JvmField
     val uiTheme: UiTheme?
@@ -53,9 +53,8 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
         requestCode = builder.requestCode
         uiJsonRemoteConfig = builder.uiJsonRemoteConfig
         companyName = builder.companyName
-        screenSharingMode =
-            if (builder.screenSharingMode != null) builder.screenSharingMode else DEFAULT_SCREEN_SHARING_MODE
-        isUseOverlay = if (builder.useOverlay != null) builder.useOverlay!! else DEFAULT_USE_OVERLAY
+        screenSharingMode = builder.screenSharingMode ?: DEFAULT_SCREEN_SHARING_MODE
+        isUseOverlay = builder.useOverlay
         uiTheme = builder.uiTheme
         manualLocaleOverride = builder.manualLocaleOverride
     }
@@ -249,7 +248,6 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
     }
 
     internal companion object {
-        const val DEFAULT_USE_OVERLAY = true
         val DEFAULT_SCREEN_SHARING_MODE = ScreenSharing.Mode.APP_BOUNDED
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -34,10 +34,10 @@ import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCase
 import com.glia.widgets.engagement.domain.EndEngagementUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
 import com.glia.widgets.engagement.domain.EnqueueForEngagementUseCase
+import com.glia.widgets.engagement.domain.FlipCameraButtonStateUseCase
 import com.glia.widgets.engagement.domain.FlipVisitorCameraUseCase
 import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
 import com.glia.widgets.engagement.domain.IsQueueingOrEngagementUseCase
-import com.glia.widgets.engagement.domain.FlipCameraButtonStateUseCase
 import com.glia.widgets.engagement.domain.OperatorMediaUseCase
 import com.glia.widgets.engagement.domain.ScreenSharingUseCase
 import com.glia.widgets.engagement.domain.ToggleVisitorAudioMediaStateUseCase
@@ -54,10 +54,7 @@ import com.glia.widgets.view.MessagesNotSeenHandler.MessagesNotSeenHandlerListen
 import com.glia.widgets.view.MinimizeHandler
 import com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoContract
 import io.reactivex.rxjava3.core.Flowable
-import io.reactivex.rxjava3.core.Observable
-import com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoView
 import io.reactivex.rxjava3.disposables.CompositeDisposable
-import org.reactivestreams.Publisher
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 
@@ -215,8 +212,10 @@ internal class CallController(
     ) {
         sdkConfigurationManager.isUseOverlay = useOverlays
         sdkConfigurationManager.screenSharingMode = screenSharingMode
-        if (isShowOverlayPermissionRequestDialogUseCase.invoke()) {
+        if (isShowOverlayPermissionRequestDialogUseCase()) {
             dialogController.showOverlayPermissionsDialog()
+        } else {
+            decideOnQueueingUseCase.markOverlayStepCompleted()
         }
         messagesNotSeenHandler.onNavigatedToCall()
         if (callState.integratorCallStarted || dialogController.isShowingUnexpectedErrorDialog) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -223,11 +223,11 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         companyName: String?,
         queueId: String?,
         visitorContextAssetId: String?,
-        useOverlays: Boolean = false,
+        useOverlays: Boolean? = null,
         screenSharingMode: ScreenSharing.Mode? = null,
         chatType: ChatType = ChatType.LIVE_CHAT
     ) {
-        Dependencies.getSdkConfigurationManager().isUseOverlay = useOverlays
+        useOverlays?.also { Dependencies.getSdkConfigurationManager().isUseOverlay = it }
         Dependencies.getSdkConfigurationManager().screenSharingMode = screenSharingMode
         dialogCallback?.also { dialogController?.addCallback(it) }
         controller?.initChat(companyName, queueId, visitorContextAssetId, chatType)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -478,8 +478,10 @@ internal class ChatController(
         isChatViewPaused = false
         messagesNotSeenHandler.callChatButtonClicked()
 
-        if (isShowOverlayPermissionRequestDialogUseCase.invoke()) {
+        if (isShowOverlayPermissionRequestDialogUseCase()) {
             dialogController.showOverlayPermissionsDialog()
+        } else {
+            decideOnQueueingUseCase.markOverlayStepCompleted()
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/DecideOnQueueingUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/DecideOnQueueingUseCase.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.chat.domain
 
-import com.glia.widgets.core.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
 import com.glia.widgets.core.dialog.domain.SetOverlayPermissionRequestDialogShownUseCase
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.subjects.CompletableSubject
@@ -9,37 +8,30 @@ internal interface DecideOnQueueingUseCase {
     operator fun invoke(): Completable
     fun onOverlayDialogShown()
     fun onQueueingRequested()
-
+    fun markOverlayStepCompleted()
 }
 
 internal class DecideOnQueueingUseCaseImpl(
-    private val isShowOverlayPermissionRequestDialogUseCase: IsShowOverlayPermissionRequestDialogUseCase,
     private val setOverlayPermissionRequestDialogShownUseCase: SetOverlayPermissionRequestDialogShownUseCase
 ) : DecideOnQueueingUseCase {
 
-    private val overlayShown: CompletableSubject = CompletableSubject.create()
-    private val queueingRequested: CompletableSubject = CompletableSubject.create()
+    private val overlayStep: CompletableSubject = CompletableSubject.create()
+    private val queueingStep: CompletableSubject = CompletableSubject.create()
 
-    override fun invoke(): Completable = Completable.concat(listOf(overlayShown, queueingRequested))
-
-    init {
-        checkOverlayShown()
-    }
-
-    private fun checkOverlayShown() {
-        if (!isShowOverlayPermissionRequestDialogUseCase()) {
-            overlayShown.onComplete()
-        }
-    }
+    override fun invoke(): Completable = Completable.concat(listOf(overlayStep, queueingStep))
 
     override fun onOverlayDialogShown() {
-        overlayShown.onComplete()
+        markOverlayStepCompleted()
 
         setOverlayPermissionRequestDialogShownUseCase()
     }
 
     override fun onQueueingRequested() {
-        queueingRequested.onComplete()
+        queueingStep.onComplete()
+    }
+
+    override fun markOverlayStepCompleted() {
+        overlayStep.onComplete()
     }
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfiguration.kt
@@ -16,7 +16,7 @@ internal class GliaSdkConfiguration private constructor(builder: Builder) {
     private val contextUrl: String?
     val runTimeTheme: UiTheme?
         get() = field ?: Dependencies.getSdkConfigurationManager().uiTheme
-    val useOverlay: Boolean
+    val useOverlay: Boolean?
     val screenSharingMode: ScreenSharing.Mode?
         get() = field ?: Dependencies.getSdkConfigurationManager().screenSharingMode
     val chatType: ChatType?
@@ -46,7 +46,7 @@ internal class GliaSdkConfiguration private constructor(builder: Builder) {
         var contextAssetId: String? = null
         var contextUrl: String? = null
         var runTimeTheme: UiTheme? = null
-        var useOverlay = false
+        var useOverlay: Boolean? = null
         var screenSharingMode: ScreenSharing.Mode? = null
         var chatType: ChatType? = null
         var manualLocaleOverride: String? = null

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
@@ -1,13 +1,14 @@
 package com.glia.widgets.core.configuration;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.glia.androidsdk.Glia;
 import com.glia.androidsdk.screensharing.ScreenSharing;
+import com.glia.widgets.GliaWidgetsConfig;
 import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.di.Dependencies;
-import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.ResourceProvider;
 
 import org.jetbrains.annotations.Nullable;
@@ -17,21 +18,30 @@ import org.jetbrains.annotations.Nullable;
  */
 public class GliaSdkConfigurationManager {
 
-    private boolean useOverlay = false;
     private ScreenSharing.Mode screenSharingMode = null;
     private String companyName = null;
     private String legacyCompanyName = null;
-
-    private String manualLocaleOverride = null;
+    private boolean useOverlay = true;
 
     private UiTheme uiTheme = null;
+
+    public void fromConfiguration(@NonNull GliaWidgetsConfig configuration) {
+        this.screenSharingMode = configuration.screenSharingMode;
+        this.companyName = configuration.companyName;
+        this.uiTheme = configuration.uiTheme;
+
+        Boolean useOverlay = configuration.isUseOverlay();
+        if (useOverlay != null) {
+            this.useOverlay = useOverlay;
+        }
+    }
 
     public boolean isUseOverlay() {
         return this.useOverlay;
     }
 
-    public void setUseOverlay(boolean enabled) {
-        this.useOverlay = enabled;
+    public void setUseOverlay(boolean useOverlay) {
+        this.useOverlay = useOverlay;
     }
 
     public void setLegacyCompanyName(String companyName) {
@@ -107,7 +117,6 @@ public class GliaSdkConfigurationManager {
                 .companyName(companyName)
                 .screenSharingMode(screenSharingMode)
                 .useOverlay(useOverlay)
-                .manualLocaleOverride(manualLocaleOverride)
                 .runTimeTheme(uiTheme)
                 .build();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -183,13 +183,10 @@ public class Dependencies {
         return UNIFIED_THEME_MANAGER;
     }
 
-    public static void init(GliaWidgetsConfig gliaWidgetsConfig) {
+    public static void init(@NonNull GliaWidgetsConfig gliaWidgetsConfig) {
         controllerFactory.init();
         repositoryFactory.getEngagementRepository().initialize();
-        sdkConfigurationManager.setScreenSharingMode(gliaWidgetsConfig.screenSharingMode);
-        sdkConfigurationManager.setUseOverlay(gliaWidgetsConfig.isUseOverlay());
-        sdkConfigurationManager.setCompanyName(gliaWidgetsConfig.companyName);
-        sdkConfigurationManager.setUiTheme(gliaWidgetsConfig.uiTheme);
+        sdkConfigurationManager.fromConfiguration(gliaWidgetsConfig);
     }
 
     public static ControllerFactory getControllerFactory() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -140,18 +140,18 @@ import com.glia.widgets.engagement.domain.EngagementTypeUseCase;
 import com.glia.widgets.engagement.domain.EngagementTypeUseCaseImpl;
 import com.glia.widgets.engagement.domain.EnqueueForEngagementUseCase;
 import com.glia.widgets.engagement.domain.EnqueueForEngagementUseCaseImpl;
-import com.glia.widgets.engagement.domain.InformThatReadyToShareScreenUseCase;
-import com.glia.widgets.engagement.domain.InformThatReadyToShareScreenUseCaseImpl;
+import com.glia.widgets.engagement.domain.FlipCameraButtonStateUseCase;
+import com.glia.widgets.engagement.domain.FlipCameraButtonStateUseCaseImpl;
 import com.glia.widgets.engagement.domain.FlipVisitorCameraUseCase;
 import com.glia.widgets.engagement.domain.FlipVisitorCameraUseCaseImpl;
+import com.glia.widgets.engagement.domain.InformThatReadyToShareScreenUseCase;
+import com.glia.widgets.engagement.domain.InformThatReadyToShareScreenUseCaseImpl;
 import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase;
 import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCaseImpl;
 import com.glia.widgets.engagement.domain.IsOperatorPresentUseCase;
 import com.glia.widgets.engagement.domain.IsOperatorPresentUseCaseImpl;
 import com.glia.widgets.engagement.domain.IsQueueingOrEngagementUseCase;
 import com.glia.widgets.engagement.domain.IsQueueingOrEngagementUseCaseImpl;
-import com.glia.widgets.engagement.domain.FlipCameraButtonStateUseCase;
-import com.glia.widgets.engagement.domain.FlipCameraButtonStateUseCaseImpl;
 import com.glia.widgets.engagement.domain.OperatorMediaUpgradeOfferUseCase;
 import com.glia.widgets.engagement.domain.OperatorMediaUpgradeOfferUseCaseImpl;
 import com.glia.widgets.engagement.domain.OperatorMediaUseCase;
@@ -970,10 +970,7 @@ public class UseCaseFactory {
 
     @NonNull
     public DecideOnQueueingUseCase getDecideOnQueueingUseCase() {
-        return new DecideOnQueueingUseCaseImpl(
-            createIsShowOverlayPermissionRequestDialogUseCase(),
-            createSetOverlayPermissionRequestDialogShownUseCase()
-        );
+        return new DecideOnQueueingUseCaseImpl(createSetOverlayPermissionRequestDialogShownUseCase());
     }
 
     @NonNull

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/DecideOnQueueingUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/DecideOnQueueingUseCaseTest.kt
@@ -1,9 +1,7 @@
 package com.glia.widgets.chat.domain
 
-import com.glia.widgets.core.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
 import com.glia.widgets.core.dialog.domain.SetOverlayPermissionRequestDialogShownUseCase
 import io.mockk.confirmVerified
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.After
@@ -11,29 +9,27 @@ import org.junit.Before
 import org.junit.Test
 
 class DecideOnQueueingUseCaseTest {
-    private lateinit var isShowOverlayPermissionRequestDialogUseCase: IsShowOverlayPermissionRequestDialogUseCase
     private lateinit var setOverlayPermissionRequestDialogShownUseCase: SetOverlayPermissionRequestDialogShownUseCase
     private lateinit var useCase: DecideOnQueueingUseCase
 
     @Before
     fun setUp() {
-        isShowOverlayPermissionRequestDialogUseCase = mockk()
         setOverlayPermissionRequestDialogShownUseCase = mockk(relaxUnitFun = true)
     }
 
     @After
     fun tearDown() {
-        confirmVerified(isShowOverlayPermissionRequestDialogUseCase)
         confirmVerified(setOverlayPermissionRequestDialogShownUseCase)
     }
 
     @Test
     fun `invoke completes when both completable are completed`() {
-        every { isShowOverlayPermissionRequestDialogUseCase.invoke() } returns false
-        useCase = DecideOnQueueingUseCaseImpl(isShowOverlayPermissionRequestDialogUseCase, setOverlayPermissionRequestDialogShownUseCase)
-        verify { isShowOverlayPermissionRequestDialogUseCase.invoke() }
+        useCase = DecideOnQueueingUseCaseImpl(setOverlayPermissionRequestDialogShownUseCase)
 
         val testCompletable = useCase().test()
+        testCompletable.assertNotComplete()
+
+        useCase.markOverlayStepCompleted()
         testCompletable.assertNotComplete()
 
         useCase.onQueueingRequested()
@@ -41,10 +37,8 @@ class DecideOnQueueingUseCaseTest {
     }
 
     @Test
-    fun `initialization not complete overlay completable when overlay dialog is not yet shown`() {
-        every { isShowOverlayPermissionRequestDialogUseCase.invoke() } returns true
-        useCase = DecideOnQueueingUseCaseImpl(isShowOverlayPermissionRequestDialogUseCase, setOverlayPermissionRequestDialogShownUseCase)
-        verify { isShowOverlayPermissionRequestDialogUseCase.invoke() }
+    fun `onOverlayDialogShown marks overlay dialog shown when called`() {
+        useCase = DecideOnQueueingUseCaseImpl(setOverlayPermissionRequestDialogShownUseCase)
 
         val testCompletable = useCase().test()
         testCompletable.assertNotComplete()
@@ -53,7 +47,7 @@ class DecideOnQueueingUseCaseTest {
         testCompletable.assertNotComplete()
 
         useCase.onOverlayDialogShown()
-        verify { setOverlayPermissionRequestDialogShownUseCase.invoke() }
+        verify { setOverlayPermissionRequestDialogShownUseCase() }
         testCompletable.assertComplete()
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3416
https://glia.atlassian.net/browse/MOB-3405

**What was solved?**

**The Problem:**
In certain environments, particularly cross-platform ones, the UI can become stuck in the engagement-request state while actually no request is being made.

**The Reason:**
We had different default values for `useOverlays` property, so it was returning different values during initialization steps, as a result to start a queuing we were waiting for the overlay dialog, but in call or chat screen we were receiving `false` and skipping the overlay dialog.

**The Solution**
I left only one default value for the `useOverlays` property inside `GliaSdkConfigurationManager` and move the overlay check from the `DecideOnQueuingUseCase` init block to avoid concurrency issues and mark it completed manually from the chat or call screens.

**Release notes:**
We resolved the problem with concurrency that caused the SDK to become stuck in a `connecting` state without making an engagement request.

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
