### PR TITLE
Revert "Change bubble behavior to display it inside client’s mobile application even if bubble overlay flag is disabled"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="settings_authorization_summary">Authorization type</string>
     <string name="settings_queue_id">Queue id</string>
     <string name="settings_white_label">White label</string>
-    <string name="settings_use_overlay">Use Overlay (needs restart)</string>
+    <string name="settings_use_overlay">Use Overlay</string>
     <string name="settings_remote_theme">Enable Remote Theme</string>
     <string name="settings_runtime_theme">Enable Runtime Theme</string>
     <string name="settings_visitor_context_asset_id">Visitor context asset id</string>

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -70,13 +70,15 @@ public class GliaWidgets {
      */
     public static final String CONTEXT_ASSET_ID = "context_asset_id";
     /**
-     * It's recommended to use {@link GliaWidgetsConfig.Builder#setUseOverlay(boolean)} ()} instead of this constant directly.
-     * Use with {@link android.os.Bundle}  to pass in a boolean which represents if you would like to use the chat head bubble
-     * as an overlay outside your application for navigating to {@link com.glia.widgets.chat.ChatActivity}.
-     * If set to true then the SDK will ask for overlay permissions and try to always show the navigation bubble outside
-     * the application. However, it will be shown only if the user has accepted the permissions.
-     * If false, then overlay permission is not requested and the navigation bubble is shown when the application is active.
-     * Default value is true.
+     * Use with {@link android.os.Bundle} to pass in a boolean which represents if you would like to
+     * use the chat head bubble as an overlay as a navigation argument when
+     * navigating to {@link com.glia.widgets.chat.ChatActivity}
+     * If set to true then the chat head will appear in the overlay and the sdk will ask for
+     * overlay permissions. If false, then the {@link com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController} will notify any
+     * listening {@link com.glia.widgets.view.head.ChatHeadLayout} of any visibility changes.
+     * It is up to the integrator to integrate {@link com.glia.widgets.view.head.ChatHeadLayout} in their
+     * application.
+     * When this value is not passed then by default this value is true.
      */
     public static final String USE_OVERLAY = "use_overlay";
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -206,13 +206,7 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
         }
 
         /**
-         * Use this function to pass in a boolean which represents if you would like to use the chat head bubble as an overlay outside
-         * your application for navigating to {@link com.glia.widgets.chat.ChatActivity}.
-         * If set to true then the SDK will ask for overlay permissions and try to always show the navigation bubble outside
-         * the application. However, it will be shown only if the user has accepted the permissions.
-         * If false, then overlay permission is not requested and the navigation bubble is shown when the application is active.
-         * Default value is true.
-         * @param useOverlay - is it allowed to overlay the application
+         * @param useOverlay - Is it allowed to overlay the application
          * @return Builder instance
          */
         fun setUseOverlay(useOverlay: Boolean): Builder {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayApplicationChatHeadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayApplicationChatHeadUseCase.kt
@@ -22,13 +22,7 @@ internal class IsDisplayApplicationChatHeadUseCase(
     configurationManager,
     engagementTypeUseCase
 ) {
-    override fun isBubbleEnabled(): Boolean {
-        // Bubble should always be displayed inside the app.
-        //
-        // So, isBubbleEnabled() for IsDisplayApplicationChatHeadUseCase returns true when:
-        // global device bubble is turned off by integrator (turned ON by default)
-        // OR
-        // global device bubble is not allowed by visitor
-        return (!configurationManager.isUseOverlay || !permissionManager.hasOverlayPermission())
+    override fun isDisplayBasedOnPermission(): Boolean {
+        return !permissionManager.hasOverlayPermission()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayChatHeadUseCase.kt
@@ -18,11 +18,13 @@ internal abstract class IsDisplayChatHeadUseCase(
     private val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase,
     private val screenSharingUseCase: ScreenSharingUseCase,
     val permissionManager: PermissionManager,
-    internal val configurationManager: GliaSdkConfigurationManager,
+    private val configurationManager: GliaSdkConfigurationManager,
     private val engagementTypeUseCase: EngagementTypeUseCase
 ) {
+    abstract fun isDisplayBasedOnPermission(): Boolean
+
     open operator fun invoke(viewName: String?): Boolean {
-        return isBubbleEnabled() && isShowForEngagement(viewName)
+        return isBubbleEnabled() && isDisplayBasedOnPermission() && isShowForEngagement(viewName)
     }
 
     private fun isShowForEngagement(viewName: String?) =
@@ -30,7 +32,9 @@ internal abstract class IsDisplayChatHeadUseCase(
             isShowForChatEngagement(viewName) ||
             isCallVisualizerScreenSharing(viewName)
 
-    abstract fun isBubbleEnabled(): Boolean
+    private fun isBubbleEnabled(): Boolean {
+        return configurationManager.isUseOverlay
+    }
 
     private fun isCallVisualizerScreenSharing(viewName: String?): Boolean {
         return isCurrentEngagementCallVisualizerUseCase() && screenSharingUseCase.isSharing && isNotInListOfGliaViews(viewName)

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/ToggleChatHeadServiceUseCase.kt
@@ -38,14 +38,8 @@ internal class ToggleChatHeadServiceUseCase(
         return isDisplayDeviceBubble
     }
 
-    override fun isBubbleEnabled(): Boolean {
-        // "Global" device bubble should be displayed only when allowed.
-        //
-        // So, isBubbleEnabled() for ToggleChatHeadServiceUseCase returns true when:
-        // global device bubble is NOT turned off by integrator (turned ON by default)
-        // AND
-        // global device bubble is allowed by visitor.
-        return configurationManager.isUseOverlay && permissionManager.hasOverlayPermission()
+    override fun isDisplayBasedOnPermission(): Boolean {
+        return permissionManager.hasOverlayPermission()
     }
 
     fun onDestroy() {


### PR DESCRIPTION
This reverts commit 365c7166b409724dc00cc0a4126eae7d46acf055.

**Jira issue:**
[[Android] Fix bubble behavior when overlay flag is disabled](https://glia.atlassian.net/browse/MOB-3281)

**What was solved?**
There are two reasons to revert:

1. These changes would affect bubble behavior for current integrators
2. These changes are not completely synced between platforms

We decided to step back and think through the changes more thoroughly.

See more in [this](https://salemove.slack.com/archives/CHN6UB7UH/p1713515423754129) thread.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

