### PR TITLE
Get rid of Kotlin reflection

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ ktlintVersion = "11.5.0"
 # https://github.com/cashapp/paparazzi/releases
 paparazziVersion = "1.3.1"
 
-javaKotlinReflectVersion = "1.8.22" # Kotlin, Kotlin Reflect and Dokka versions should have the same minor version to support the same kotlin version
 javaAppCompatVersion = "1.6.1" # This dependency higher versions require compileSDK 34
 javaConstraintLayoutVersion = "2.1.4"
 javaCoreKtxVersion = "1.10.1" # This dependency higher versions require compileSDK 34
@@ -60,7 +59,6 @@ java-material = { group = "com.google.android.material", name = "material", vers
 java-navigation-fargment = { module = "androidx.navigation:navigation-fragment", version.ref = "javaNavVersion" }
 java-navigation-ui = { module = "androidx.navigation:navigation-ui", version.ref = "javaNavVersion" }
 java-preference = { module = "androidx.preference:preference", version.ref = "javaPreferenceVersion" }
-java-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "javaKotlinReflectVersion" }
 java-rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "javaRxAndroid3Version" }
 java-rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "javaRxJava3Version" }
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "javaLifecycleProcessVersion" }

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -111,7 +111,6 @@ dependencies {
   // Test dependencies to Android native libraries
   // To prevent unit tests firing errors like 'Method length in org.json.JSONObject not mocked'
   testImplementation libs.test.json
-  implementation libs.java.kotlin.reflect
 
   lintChecks project(':lint_checker')
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/UiTheme.kt
@@ -11,6 +11,8 @@ import com.glia.widgets.view.configuration.ButtonConfiguration
 import com.glia.widgets.view.configuration.ChatHeadConfiguration
 import com.glia.widgets.view.configuration.TextConfiguration
 import com.glia.widgets.view.configuration.survey.SurveyStyle
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 import com.glia.widgets.view.unifiedui.theme.ColorPallet
 import com.glia.widgets.view.unifiedui.theme.Icons
@@ -366,7 +368,7 @@ data class UiTheme(
     @ColorRes
     val gvaQuickReplyTextColor: Int? = null
 
-) : Parcelable {
+) : Parcelable, Mergeable<UiTheme> {
 
     private constructor(builder: UiThemeBuilder) : this(
         appBarTitle = builder.appBarTitle,
@@ -433,6 +435,72 @@ data class UiTheme(
         gvaQuickReplyBackgroundColor = builder.gvaQuickReplyBackgroundColor,
         gvaQuickReplyStrokeColor = builder.gvaQuickReplyStrokeColor,
         gvaQuickReplyTextColor = builder.gvaQuickReplyTextColor
+    )
+
+    override fun merge(other: UiTheme): UiTheme = UiTheme(
+        appBarTitle = appBarTitle merge other.appBarTitle,
+        brandPrimaryColor = brandPrimaryColor merge other.brandPrimaryColor,
+        baseLightColor = baseLightColor merge other.baseLightColor,
+        baseDarkColor = baseDarkColor merge other.baseDarkColor,
+        baseNormalColor = baseNormalColor merge other.baseNormalColor,
+        baseShadeColor = baseShadeColor merge other.baseShadeColor,
+        systemAgentBubbleColor = systemAgentBubbleColor merge other.systemAgentBubbleColor,
+        systemNegativeColor = systemNegativeColor merge other.systemNegativeColor,
+        visitorMessageBackgroundColor = visitorMessageBackgroundColor merge other.visitorMessageBackgroundColor,
+        visitorMessageTextColor = visitorMessageTextColor merge other.visitorMessageTextColor,
+        operatorMessageBackgroundColor = operatorMessageBackgroundColor merge other.operatorMessageBackgroundColor,
+        operatorMessageTextColor = operatorMessageTextColor merge other.operatorMessageTextColor,
+        newMessageDividerColor = newMessageDividerColor merge other.newMessageDividerColor,
+        newMessageDividerTextColor = newMessageDividerTextColor merge other.newMessageDividerTextColor,
+        botActionButtonBackgroundColor = botActionButtonBackgroundColor merge other.botActionButtonBackgroundColor,
+        botActionButtonTextColor = botActionButtonTextColor merge other.botActionButtonTextColor,
+        botActionButtonSelectedBackgroundColor = botActionButtonSelectedBackgroundColor merge other.botActionButtonSelectedBackgroundColor,
+        botActionButtonSelectedTextColor = botActionButtonSelectedTextColor merge other.botActionButtonSelectedTextColor,
+        sendMessageButtonTintColor = sendMessageButtonTintColor merge other.sendMessageButtonTintColor,
+        gliaChatBackgroundColor = gliaChatBackgroundColor merge other.gliaChatBackgroundColor,
+        gliaChatHeaderTitleTintColor = gliaChatHeaderTitleTintColor merge other.gliaChatHeaderTitleTintColor,
+        gliaChatHeaderHomeButtonTintColor = gliaChatHeaderHomeButtonTintColor merge other.gliaChatHeaderHomeButtonTintColor,
+        gliaChatHeaderExitQueueButtonTintColor = gliaChatHeaderExitQueueButtonTintColor merge other.gliaChatHeaderExitQueueButtonTintColor,
+        visitorCodeTextColor = visitorCodeTextColor merge other.visitorCodeTextColor,
+        visitorCodeBackgroundColor = visitorCodeBackgroundColor merge other.visitorCodeBackgroundColor,
+        visitorCodeBorderColor = visitorCodeBorderColor merge other.visitorCodeBorderColor,
+        fontRes = fontRes merge other.fontRes,
+        iconAppBarBack = iconAppBarBack merge other.iconAppBarBack,
+        iconLeaveQueue = iconLeaveQueue merge other.iconLeaveQueue,
+        iconSendMessage = iconSendMessage merge other.iconSendMessage,
+        iconChatAudioUpgrade = iconChatAudioUpgrade merge other.iconChatAudioUpgrade,
+        iconUpgradeAudioDialog = iconUpgradeAudioDialog merge other.iconUpgradeAudioDialog,
+        iconCallAudioOn = iconCallAudioOn merge other.iconCallAudioOn,
+        iconChatVideoUpgrade = iconChatVideoUpgrade merge other.iconChatVideoUpgrade,
+        iconUpgradeVideoDialog = iconUpgradeVideoDialog merge other.iconUpgradeVideoDialog,
+        iconScreenSharingDialog = iconScreenSharingDialog merge other.iconScreenSharingDialog,
+        iconCallVideoOn = iconCallVideoOn merge other.iconCallVideoOn,
+        iconCallAudioOff = iconCallAudioOff merge other.iconCallAudioOff,
+        iconCallVideoOff = iconCallVideoOff merge other.iconCallVideoOff,
+        iconCallChat = iconCallChat merge other.iconCallChat,
+        iconCallSpeakerOn = iconCallSpeakerOn merge other.iconCallSpeakerOn,
+        iconCallSpeakerOff = iconCallSpeakerOff merge other.iconCallSpeakerOff,
+        iconCallMinimize = iconCallMinimize merge other.iconCallMinimize,
+        iconPlaceholder = iconPlaceholder merge other.iconPlaceholder,
+        iconOnHold = iconOnHold merge other.iconOnHold,
+        iconEndScreenShare = iconEndScreenShare merge other.iconEndScreenShare,
+        endScreenShareTintColor = endScreenShareTintColor merge other.endScreenShareTintColor,
+        gliaChatStartingHeadingTextColor = gliaChatStartingHeadingTextColor merge other.gliaChatStartingHeadingTextColor,
+        gliaChatStartingCaptionTextColor = gliaChatStartingCaptionTextColor merge other.gliaChatStartingCaptionTextColor,
+        gliaChatStartedHeadingTextColor = gliaChatStartedHeadingTextColor merge other.gliaChatStartedHeadingTextColor,
+        gliaChatStartedCaptionTextColor = gliaChatStartedCaptionTextColor merge other.gliaChatStartedCaptionTextColor,
+        whiteLabel = whiteLabel merge other.whiteLabel,
+        gliaAlertDialogButtonUseVerticalAlignment = gliaAlertDialogButtonUseVerticalAlignment merge other.gliaAlertDialogButtonUseVerticalAlignment,
+        gliaChoiceCardContentTextConfiguration = gliaChoiceCardContentTextConfiguration merge other.gliaChoiceCardContentTextConfiguration,
+        gliaEndButtonConfiguration = gliaEndButtonConfiguration merge other.gliaEndButtonConfiguration,
+        gliaPositiveButtonConfiguration = gliaPositiveButtonConfiguration merge other.gliaPositiveButtonConfiguration,
+        gliaNegativeButtonConfiguration = gliaNegativeButtonConfiguration merge other.gliaNegativeButtonConfiguration,
+        gliaNeutralButtonConfiguration = gliaNeutralButtonConfiguration merge other.gliaNeutralButtonConfiguration,
+        chatHeadConfiguration = chatHeadConfiguration merge other.chatHeadConfiguration,
+        surveyStyle = surveyStyle merge other.surveyStyle,
+        gvaQuickReplyBackgroundColor = gvaQuickReplyBackgroundColor merge other.gvaQuickReplyBackgroundColor,
+        gvaQuickReplyStrokeColor = gvaQuickReplyStrokeColor merge other.gvaQuickReplyStrokeColor,
+        gvaQuickReplyTextColor = gvaQuickReplyTextColor merge other.gvaQuickReplyTextColor
     )
 
     private fun toColorPallet(context: Context): ColorPallet = context.run {

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -8,7 +8,6 @@ import android.text.Spanned
 import android.text.format.DateUtils
 import androidx.annotation.ColorInt
 import androidx.core.graphics.drawable.DrawableCompat
-import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.Operator
@@ -22,7 +21,7 @@ import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.androidsdk.queuing.Queue
 import com.glia.widgets.UiTheme
 import com.glia.widgets.di.Dependencies
-import com.glia.widgets.view.unifiedui.deepMerge
+import com.glia.widgets.view.unifiedui.merge
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
@@ -39,7 +38,7 @@ internal fun ColorStateList?.colorForState(state: IntArray): Int? = this?.getCol
 // Common
 internal fun String.separateStringWithSymbol(symbol: String): String = asSequence().joinToString(symbol)
 
-internal fun Queue.supportMessaging() = state.medias.contains(Engagement.MediaType.MESSAGING)
+internal fun Queue.supportMessaging() = state.medias.contains(MediaType.MESSAGING)
 
 internal fun MediaType.isAudioOrVideo() = this == MediaType.AUDIO || this == MediaType.VIDEO
 
@@ -55,7 +54,7 @@ internal val Operator.imageUrl: String? get() = picture?.url?.getOrNull()
 
 internal fun UiTheme?.isAlertDialogButtonUseVerticalAlignment(): Boolean = this?.gliaAlertDialogButtonUseVerticalAlignment ?: false
 
-internal fun UiTheme?.getFullHybridTheme(newTheme: UiTheme?): UiTheme = deepMerge(newTheme) ?: UiTheme.UiThemeBuilder().build()
+internal fun UiTheme?.getFullHybridTheme(newTheme: UiTheme?): UiTheme = merge(newTheme) ?: UiTheme.UiThemeBuilder().build()
 
 internal val UiTheme?.withConfigurationTheme: UiTheme
     get() = getFullHybridTheme(Dependencies.getSdkConfigurationManager().uiTheme)

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
@@ -42,7 +42,7 @@ import com.glia.widgets.view.Dialogs
 import com.glia.widgets.view.dialog.base.DialogDelegate
 import com.glia.widgets.view.dialog.base.DialogDelegateImpl
 import com.glia.widgets.view.header.AppBarView
-import com.glia.widgets.view.unifiedui.deepMerge
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
@@ -234,7 +234,7 @@ internal class MessageCenterView(
             ColorTheme(getColorCompat(primaryColorId)),
             ColorTheme(getColorCompat(baseLightColorId)),
             null
-        ) deepMerge unifiedTheme?.secureConversationsConfirmationScreenTheme?.headerTheme
+        ) merge unifiedTheme?.secureConversationsConfirmationScreenTheme?.headerTheme
 
         appBar?.resetTheme()
         setupAppBarUnifiedTheme(appBarTheme)

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/StatefulWidgetAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/StatefulWidgetAdapter.kt
@@ -1,6 +1,7 @@
 package com.glia.widgets.messagecenter
 
-import com.glia.widgets.view.unifiedui.unsafeMerge
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import kotlin.properties.Delegates
 
 /**
@@ -8,7 +9,7 @@ import kotlin.properties.Delegates
  * [S] - State
  * [T] - Theme
  */
-internal interface StatefulWidgetAdapter<S : Enum<S>, T> {
+internal interface StatefulWidgetAdapter<S : Enum<S>, T : Mergeable<T>> {
 
     val callback: StatefulWidgetAdapterCallback<S, T>
 
@@ -20,12 +21,12 @@ internal interface StatefulWidgetAdapter<S : Enum<S>, T> {
 /**
  * Callback to get Theme and State updates from [StatefulWidgetAdapter]
  */
-internal fun interface StatefulWidgetAdapterCallback<S : Enum<S>, T> {
+internal fun interface StatefulWidgetAdapterCallback<S : Enum<S>, T : Mergeable<T>> {
     fun onNewTheme(theme: T)
     fun onNewState(newState: S) {}
 }
 
-internal class SimpleStatefulWidgetAdapter<S : Enum<S>, T>(
+internal class SimpleStatefulWidgetAdapter<S : Enum<S>, T : Mergeable<T>>(
     defaultState: S,
     override val callback: StatefulWidgetAdapterCallback<S, T>
 ) : StatefulWidgetAdapter<S, T> {
@@ -82,5 +83,5 @@ internal class SimpleStatefulWidgetAdapter<S : Enum<S>, T>(
         states.associate { composeThemeForState(it, newStatefulTheme) }
 
     private fun composeThemeForState(state: S, newStatefulTheme: Map<out S, T?>): Pair<S, T?> =
-        state to statefulTheme[state].unsafeMerge(newStatefulTheme[state])
+        state to statefulTheme[state].merge(newStatefulTheme[state])
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/InputQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/InputQuestionViewHolder.kt
@@ -17,7 +17,7 @@ import com.glia.widgets.view.configuration.survey.InputQuestionConfiguration
 import com.glia.widgets.view.configuration.survey.SurveyStyle
 import com.glia.widgets.view.unifiedui.applyLayerTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
-import com.glia.widgets.view.unifiedui.deepMerge
+import com.glia.widgets.view.unifiedui.nullSafeMerge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
@@ -82,28 +82,17 @@ internal class InputQuestionViewHolder(
         val backgroundColor =
             ColorTheme(Color.parseColor(optionButtonConfiguration.normalLayer.backgroundColor))
 
-        val baseTheme = OptionButtonTheme(
+        return OptionButtonTheme(
             normalText = TextTheme(),
-            normalLayer = LayerTheme(
-                fill = backgroundColor,
-                stroke = normalStrokeColor,
-                borderWidth = strokeWidth
-            ),
+            normalLayer = LayerTheme(fill = backgroundColor, stroke = normalStrokeColor, borderWidth = strokeWidth),
             selectedText = TextTheme(),
             selectedLayer = LayerTheme(),
             highlightedText = TextTheme(),
-            highlightedLayer = LayerTheme(
-                fill = backgroundColor,
-                stroke = highlightedStrokeColor,
-                borderWidth = strokeWidth
-            ),
+            highlightedLayer = LayerTheme(fill = backgroundColor, stroke = highlightedStrokeColor, borderWidth = strokeWidth),
             fontSize = null,
             fontStyle = null
-        )
+        ) nullSafeMerge inputTheme?.option
 
-        return inputTheme?.option?.let {
-            baseTheme deepMerge it
-        } ?: baseTheme
     }
 
     private fun setupTitle(inputQuestionConfig: InputQuestionConfiguration) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
@@ -16,13 +16,13 @@ import com.glia.widgets.view.dialog.screensharing.ScreenSharingDialogViewInflate
 import com.glia.widgets.view.dialog.screensharing.VerticalScreenSharingDialogViewInflater
 import com.glia.widgets.view.dialog.update.UpgradeDialogViewInflater
 import com.glia.widgets.view.dialog.update.VerticalUpgradeDialogViewInflater
-import com.glia.widgets.view.unifiedui.deepMerge
+import com.glia.widgets.view.unifiedui.nullSafeMerge
 import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 
 internal class DialogViewFactory(context: Context, uiTheme: UiTheme, unifiedTheme: UnifiedTheme?) {
     private val configuration: AlertDialogConfiguration = uiTheme.alertTheme(context).run {
-        copy(theme = this.theme.deepMerge(unifiedTheme?.alertTheme)!!)
+        copy(theme = theme nullSafeMerge unifiedTheme?.alertTheme)
     }
 
     private val layoutInflater: LayoutInflater = LayoutInflater.from(context)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/RemoteConfiguration.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/RemoteConfiguration.kt
@@ -10,7 +10,7 @@ import com.glia.widgets.view.unifiedui.config.secureconversations.SecureConversa
 import com.glia.widgets.view.unifiedui.config.snackbar.SnackBarRemoteConfig
 import com.glia.widgets.view.unifiedui.config.survey.SurveyRemoteConfig
 import com.glia.widgets.view.unifiedui.config.webbrowser.WebBrowserRemoteConfig
-import com.glia.widgets.view.unifiedui.deepMerge
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.glia.widgets.view.unifiedui.theme.defaulttheme.DefaultTheme
 import com.google.gson.annotations.SerializedName
@@ -66,6 +66,6 @@ internal data class RemoteConfiguration(
             webBrowserTheme = webBrowserRemoteConfig?.toWebBrowserTheme()
         )
 
-        return defaultTheme deepMerge unifiedTheme
+        return defaultTheme merge unifiedTheme
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/SnackBarTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/SnackBarTheme.kt
@@ -1,8 +1,15 @@
 package com.glia.widgets.view.unifiedui.theme
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 
 internal data class SnackBarTheme(
     val backgroundColorTheme: ColorTheme?,
     val textColorTheme: ColorTheme?
-)
+) : Mergeable<SnackBarTheme> {
+    override fun merge(other: SnackBarTheme): SnackBarTheme = SnackBarTheme(
+        backgroundColorTheme = backgroundColorTheme merge other.backgroundColorTheme,
+        textColorTheme = textColorTheme merge other.textColorTheme
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/UnifiedTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/UnifiedTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.alert.AlertTheme
 import com.glia.widgets.view.unifiedui.theme.bubble.BubbleTheme
 import com.glia.widgets.view.unifiedui.theme.call.CallTheme
@@ -21,4 +23,18 @@ internal data class UnifiedTheme(
     val secureConversationsConfirmationScreenTheme: SecureConversationsConfirmationScreenTheme? = null,
     val snackBarTheme: SnackBarTheme? = null,
     val webBrowserTheme: WebBrowserTheme? = null
-)
+) : Mergeable<UnifiedTheme> {
+    override fun merge(other: UnifiedTheme): UnifiedTheme = UnifiedTheme(
+        alertTheme = alertTheme merge other.alertTheme,
+        bubbleTheme = bubbleTheme merge other.bubbleTheme,
+        callTheme = callTheme merge other.callTheme,
+        chatTheme = chatTheme merge other.chatTheme,
+        surveyTheme = surveyTheme merge other.surveyTheme,
+        callVisualizerTheme = callVisualizerTheme merge other.callVisualizerTheme,
+        secureConversationsWelcomeScreenTheme = secureConversationsWelcomeScreenTheme merge other.secureConversationsWelcomeScreenTheme,
+        secureConversationsConfirmationScreenTheme = secureConversationsConfirmationScreenTheme merge other.secureConversationsConfirmationScreenTheme,
+        snackBarTheme = snackBarTheme merge other.snackBarTheme,
+        webBrowserTheme = webBrowserTheme merge other.webBrowserTheme
+    )
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/alert/AlertTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/alert/AlertTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.alert
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
@@ -14,4 +16,16 @@ internal data class AlertTheme(
     val positiveButton: ButtonTheme? = null,
     val negativeButton: ButtonTheme? = null,
     val isVerticalAxis: Boolean? = null
-)
+) : Mergeable<AlertTheme> {
+    override fun merge(other: AlertTheme): AlertTheme = AlertTheme(
+        title = title merge other.title,
+        titleImageColor = titleImageColor merge other.titleImageColor,
+        message = message merge other.message,
+        backgroundColor = backgroundColor merge other.backgroundColor,
+        closeButtonColor = closeButtonColor merge other.closeButtonColor,
+        linkButton = linkButton merge other.linkButton,
+        positiveButton = positiveButton merge other.positiveButton,
+        negativeButton = negativeButton merge other.negativeButton,
+        isVerticalAxis = isVerticalAxis merge other.isVerticalAxis
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/BadgeTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/BadgeTheme.kt
@@ -1,8 +1,18 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
 internal data class BadgeTheme(
     val textColor: ColorTheme? = null,
     val background: LayerTheme? = null,
     val textSize: Float? = null, // Size in SP
     val textStyle: Int? = null // Typeface.NORMAL
-)
+) : Mergeable<BadgeTheme> {
+    override fun merge(other: BadgeTheme): BadgeTheme = BadgeTheme(
+        textColor = textColor merge other.textColor,
+        background = background merge other.background,
+        textSize = textSize merge other.textSize,
+        textStyle = textStyle merge other.textStyle
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ButtonTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/ButtonTheme.kt
@@ -1,6 +1,8 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
 import androidx.annotation.ColorInt
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 
 internal data class ButtonTheme(
     val text: TextTheme? = null,
@@ -9,4 +11,12 @@ internal data class ButtonTheme(
     val elevation: Float? = null,
     @ColorInt
     val shadowColor: Int? = null
-)
+) : Mergeable<ButtonTheme> {
+    override fun merge(other: ButtonTheme): ButtonTheme = ButtonTheme(
+        text = text merge other.text,
+        background = background merge other.background,
+        iconColor = iconColor merge other.iconColor,
+        elevation = other.elevation ?: elevation,
+        shadowColor = other.shadowColor ?: shadowColor
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/HeaderTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/HeaderTheme.kt
@@ -1,9 +1,20 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
 internal data class HeaderTheme(
     val text: TextTheme? = null,
     val background: LayerTheme? = null,
     val backButton: ButtonTheme? = null,
     val closeButton: ButtonTheme? = null,
     val endButton: ButtonTheme? = null
-)
+) : Mergeable<HeaderTheme> {
+    override fun merge(other: HeaderTheme): HeaderTheme = HeaderTheme(
+        text = text merge other.text,
+        background = background merge other.background,
+        backButton = backButton merge other.backButton,
+        closeButton = closeButton merge other.closeButton,
+        endButton = endButton merge other.endButton
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/LayerTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/LayerTheme.kt
@@ -2,6 +2,8 @@ package com.glia.widgets.view.unifiedui.theme.base
 
 import androidx.annotation.ColorInt
 import androidx.annotation.Px
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import kotlin.math.roundToInt
 
 internal data class LayerTheme(
@@ -13,7 +15,7 @@ internal data class LayerTheme(
     val borderWidth: Float? = null, // width in pixels
     @Px
     val cornerRadius: Float? = null // radius in pixels
-) {
+) : Mergeable<LayerTheme> {
 
     @get:Px
     val borderWidthInt: Int?
@@ -22,4 +24,11 @@ internal data class LayerTheme(
     @get:Px
     val cornerRadiusInt: Int?
         get() = cornerRadius?.roundToInt()
+
+    override fun merge(other: LayerTheme): LayerTheme = LayerTheme(
+        fill = fill merge other.fill,
+        stroke = stroke merge other.stroke,
+        borderWidth = borderWidth merge other.borderWidth,
+        cornerRadius = cornerRadius merge other.cornerRadius
+    )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/TextInputTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/TextInputTheme.kt
@@ -1,6 +1,14 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
 internal data class TextInputTheme(
     val textTheme: TextTheme?,
     val backgroundTheme: LayerTheme?
-)
+) : Mergeable<TextInputTheme> {
+    override fun merge(other: TextInputTheme): TextInputTheme = TextInputTheme(
+        textTheme = textTheme merge other.textTheme,
+        backgroundTheme = backgroundTheme merge other.backgroundTheme
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/TextTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/base/TextTheme.kt
@@ -1,9 +1,20 @@
 package com.glia.widgets.view.unifiedui.theme.base
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
 internal data class TextTheme(
     val textColor: ColorTheme? = null,
     val backgroundColor: ColorTheme? = null,
     val textSize: Float? = null, // Size in SP
     val textStyle: Int? = null, // Typeface.NORMAL
     val textAlignment: Int? = null // TextView.TEXT_ALIGNMENT_TEXT_START
-)
+) : Mergeable<TextTheme> {
+    override fun merge(other: TextTheme): TextTheme = TextTheme(
+        textColor = textColor merge other.textColor,
+        backgroundColor = backgroundColor merge other.backgroundColor,
+        textSize = textSize merge other.textSize,
+        textStyle = textStyle merge other.textStyle,
+        textAlignment = textAlignment merge other.textAlignment
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/bubble/BubbleTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/bubble/BubbleTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.bubble
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.BadgeTheme
 import com.glia.widgets.view.unifiedui.theme.chat.OnHoldOverlayTheme
 import com.glia.widgets.view.unifiedui.theme.chat.UserImageTheme
@@ -8,4 +10,10 @@ internal data class BubbleTheme(
     val userImage: UserImageTheme? = null,
     val badge: BadgeTheme? = null,
     val onHoldOverlay: OnHoldOverlayTheme? = null
-)
+) : Mergeable<BubbleTheme> {
+    override fun merge(other: BubbleTheme): BubbleTheme = BubbleTheme(
+        userImage = userImage merge other.userImage,
+        badge = badge merge other.badge,
+        onHoldOverlay = onHoldOverlay merge other.onHoldOverlay
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/BarButtonStatesTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/BarButtonStatesTheme.kt
@@ -1,7 +1,16 @@
 package com.glia.widgets.view.unifiedui.theme.call
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
 internal data class BarButtonStatesTheme(
     val disabled: BarButtonStyleTheme? = null,
     val enabled: BarButtonStyleTheme? = null,
     val activated: BarButtonStyleTheme? = null
-)
+) : Mergeable<BarButtonStatesTheme> {
+    override fun merge(other: BarButtonStatesTheme): BarButtonStatesTheme = BarButtonStatesTheme(
+        disabled = disabled merge other.disabled,
+        enabled = enabled merge other.enabled,
+        activated = activated merge other.activated
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/BarButtonStyleTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/BarButtonStyleTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.call
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
@@ -7,4 +9,10 @@ internal data class BarButtonStyleTheme(
     val background: ColorTheme? = null,
     val imageColor: ColorTheme? = null,
     val title: TextTheme? = null
-)
+) : Mergeable<BarButtonStyleTheme> {
+    override fun merge(other: BarButtonStyleTheme): BarButtonStyleTheme = BarButtonStyleTheme(
+        background = background merge other.background,
+        imageColor = imageColor merge other.imageColor,
+        title = title merge other.title
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/ButtonBarTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/ButtonBarTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.call
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.BadgeTheme
 
 internal data class ButtonBarTheme(
@@ -9,4 +11,13 @@ internal data class ButtonBarTheme(
     val muteButton: BarButtonStatesTheme? = null,
     val speakerButton: BarButtonStatesTheme? = null,
     val videoButton: BarButtonStatesTheme? = null
-)
+) : Mergeable<ButtonBarTheme> {
+    override fun merge(other: ButtonBarTheme): ButtonBarTheme = ButtonBarTheme(
+        badge = badge merge other.badge,
+        chatButton = chatButton merge other.chatButton,
+        minimizeButton = minimizeButton merge other.minimizeButton,
+        muteButton = muteButton merge other.muteButton,
+        speakerButton = speakerButton merge other.speakerButton,
+        videoButton = videoButton merge other.videoButton
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/CallTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/CallTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.call
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.SnackBarTheme
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
@@ -17,4 +19,17 @@ internal data class CallTheme(
     val connect: EngagementStatesTheme? = null,
     val snackBar: SnackBarTheme? = null,
     val visitorVideo: VisitorVideoTheme? = null
-)
+) : Mergeable<CallTheme> {
+    override fun merge(other: CallTheme): CallTheme = CallTheme(
+        background = background merge other.background,
+        bottomText = bottomText merge other.bottomText,
+        buttonBar = buttonBar merge other.buttonBar,
+        duration = duration merge other.duration,
+        header = header merge other.header,
+        operator = operator merge other.operator,
+        topText = topText merge other.topText,
+        connect = connect merge other.connect,
+        snackBar = snackBar merge other.snackBar,
+        visitorVideo = visitorVideo merge other.visitorVideo
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/VisitorVideoTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/call/VisitorVideoTheme.kt
@@ -1,5 +1,11 @@
 package com.glia.widgets.view.unifiedui.theme.call
 
-internal data class VisitorVideoTheme(
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
+@JvmInline
+internal value class VisitorVideoTheme(
     val flipCameraButton: BarButtonStyleTheme? = null
-)
+) : Mergeable<VisitorVideoTheme> {
+    override fun merge(other: VisitorVideoTheme): VisitorVideoTheme = VisitorVideoTheme(flipCameraButton merge other.flipCameraButton)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/callvisulaizer/CallVisualizerTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/callvisulaizer/CallVisualizerTheme.kt
@@ -1,6 +1,14 @@
 package com.glia.widgets.view.unifiedui.theme.callvisulaizer
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
 internal data class CallVisualizerTheme(
     val endScreenSharingTheme: EndScreenSharingTheme? = null,
     val visitorCodeTheme: VisitorCodeTheme? = null
-)
+) : Mergeable<CallVisualizerTheme> {
+    override fun merge(other: CallVisualizerTheme): CallVisualizerTheme = CallVisualizerTheme(
+        endScreenSharingTheme = endScreenSharingTheme merge other.endScreenSharingTheme,
+        visitorCodeTheme = visitorCodeTheme merge other.visitorCodeTheme
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/callvisulaizer/EndScreenSharingTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/callvisulaizer/EndScreenSharingTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.callvisulaizer
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
@@ -10,4 +12,11 @@ internal data class EndScreenSharingTheme(
     val endButton: ButtonTheme? = null,
     val label: TextTheme? = null,
     val background: LayerTheme? = null
-)
+) : Mergeable<EndScreenSharingTheme> {
+    override fun merge(other: EndScreenSharingTheme): EndScreenSharingTheme = EndScreenSharingTheme(
+        header = header merge other.header,
+        endButton = endButton merge other.endButton,
+        label = label merge other.label,
+        background = background merge other.background
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/callvisulaizer/VisitorCodeTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/callvisulaizer/VisitorCodeTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.callvisulaizer
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
@@ -13,4 +15,14 @@ internal data class VisitorCodeTheme(
     val background: LayerTheme? = null,
     val title: TextTheme? = null,
     val loadingProgressBar: ColorTheme? = null
-)
+) : Mergeable<VisitorCodeTheme> {
+    override fun merge(other: VisitorCodeTheme): VisitorCodeTheme = VisitorCodeTheme(
+        numberSlotText = numberSlotText merge other.numberSlotText,
+        numberSlotBackground = numberSlotBackground merge other.numberSlotBackground,
+        closeButtonColor = closeButtonColor merge other.closeButtonColor,
+        refreshButton = refreshButton merge other.refreshButton,
+        background = background merge other.background,
+        title = title merge other.title,
+        loadingProgressBar = loadingProgressBar merge other.loadingProgressBar
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/AttachmentItemTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/AttachmentItemTheme.kt
@@ -1,9 +1,16 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class AttachmentItemTheme(
     val text: TextTheme? = null,
     val iconColor: ColorTheme? = null
-)
+) : Mergeable<AttachmentItemTheme> {
+    override fun merge(other: AttachmentItemTheme): AttachmentItemTheme = AttachmentItemTheme(
+        text = text merge other.text,
+        iconColor = iconColor merge other.iconColor
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/AttachmentsPopupTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/AttachmentsPopupTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 
 internal data class AttachmentsPopupTheme(
@@ -8,4 +10,12 @@ internal data class AttachmentsPopupTheme(
     val photoLibrary: AttachmentItemTheme? = null,
     val takePhoto: AttachmentItemTheme? = null,
     val browse: AttachmentItemTheme? = null
-)
+) : Mergeable<AttachmentsPopupTheme> {
+    override fun merge(other: AttachmentsPopupTheme): AttachmentsPopupTheme = AttachmentsPopupTheme(
+        dividerColor = dividerColor merge other.dividerColor,
+        background = background merge other.background,
+        photoLibrary = photoLibrary merge other.photoLibrary,
+        takePhoto = takePhoto merge other.takePhoto,
+        browse = browse merge other.browse
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ChatTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ChatTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
@@ -24,4 +26,23 @@ internal data class ChatTheme(
     val newMessagesDividerColorTheme: ColorTheme? = null,
     val newMessagesDividerTextTheme: TextTheme? = null,
     val gva: GvaTheme? = null
-)
+) : Mergeable<ChatTheme> {
+    override fun merge(other: ChatTheme): ChatTheme = ChatTheme(
+        background = background merge other.background,
+        header = header merge other.header,
+        operatorMessage = operatorMessage merge other.operatorMessage,
+        visitorMessage = visitorMessage merge other.visitorMessage,
+        connect = connect merge other.connect,
+        input = input merge other.input,
+        responseCard = responseCard merge other.responseCard,
+        audioUpgrade = audioUpgrade merge other.audioUpgrade,
+        videoUpgrade = videoUpgrade merge other.videoUpgrade,
+        bubble = bubble merge other.bubble,
+        attachmentsPopup = attachmentsPopup merge other.attachmentsPopup,
+        unreadIndicator = unreadIndicator merge other.unreadIndicator,
+        typingIndicator = typingIndicator merge other.typingIndicator,
+        newMessagesDividerColorTheme = newMessagesDividerColorTheme merge other.newMessagesDividerColorTheme,
+        newMessagesDividerTextTheme = newMessagesDividerTextTheme merge other.newMessagesDividerTextTheme,
+        gva = gva merge other.gva
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/EngagementStateTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/EngagementStateTheme.kt
@@ -1,8 +1,15 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class EngagementStateTheme(
     val title: TextTheme?,
     val description: TextTheme?
-)
+) : Mergeable<EngagementStateTheme> {
+    override fun merge(other: EngagementStateTheme): EngagementStateTheme = EngagementStateTheme(
+        title = title merge other.title,
+        description = description merge other.description
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/EngagementStatesTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/EngagementStatesTheme.kt
@@ -1,5 +1,8 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+
 internal data class EngagementStatesTheme(
     val operator: OperatorTheme? = null,
     val queue: EngagementStateTheme? = null,
@@ -7,4 +10,13 @@ internal data class EngagementStatesTheme(
     val connected: EngagementStateTheme? = null,
     val transferring: EngagementStateTheme? = null,
     val onHold: EngagementStateTheme? = null
-)
+) : Mergeable<EngagementStatesTheme> {
+    override fun merge(other: EngagementStatesTheme): EngagementStatesTheme = EngagementStatesTheme(
+        operator = operator merge other.operator,
+        queue = queue merge other.queue,
+        connecting = connecting merge other.connecting,
+        connected = connected merge other.connected,
+        transferring = transferring merge other.transferring,
+        onHold = onHold merge other.onHold
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/FilePreviewTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/FilePreviewTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
@@ -9,4 +11,11 @@ internal data class FilePreviewTheme(
     val errorIcon: ColorTheme? = null,
     val background: LayerTheme? = null,
     val errorBackground: LayerTheme? = null
-)
+) : Mergeable<FilePreviewTheme> {
+    override fun merge(other: FilePreviewTheme): FilePreviewTheme = FilePreviewTheme(
+        text = text merge other.text,
+        errorIcon = errorIcon merge other.errorIcon,
+        background = background merge other.background,
+        errorBackground = errorBackground merge other.errorBackground
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/FileUploadBarTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/FileUploadBarTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 
 internal data class FileUploadBarTheme(
@@ -11,4 +13,15 @@ internal data class FileUploadBarTheme(
     val errorProgress: ColorTheme? = null,
     val progressBackground: ColorTheme? = null,
     val removeButton: ColorTheme? = null
-)
+) : Mergeable<FileUploadBarTheme> {
+    override fun merge(other: FileUploadBarTheme): FileUploadBarTheme = FileUploadBarTheme(
+        filePreview = filePreview merge other.filePreview,
+        uploading = uploading merge other.uploading,
+        uploaded = uploaded merge other.uploaded,
+        error = error merge other.error,
+        progress = progress merge other.progress,
+        errorProgress = errorProgress merge other.errorProgress,
+        progressBackground = progressBackground merge other.progressBackground,
+        removeButton = removeButton merge other.removeButton
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/InputTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/InputTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
@@ -13,4 +15,14 @@ internal data class InputTheme(
     val mediaButton: ButtonTheme? = null,
     val background: LayerTheme? = null,
     val fileUploadBar: FileUploadBarTheme? = null
-)
+) : Mergeable<InputTheme> {
+    override fun merge(other: InputTheme): InputTheme = InputTheme(
+        text = text merge other.text,
+        placeholder = placeholder merge other.placeholder,
+        divider = divider merge other.divider,
+        sendButton = sendButton merge other.sendButton,
+        mediaButton = mediaButton merge other.mediaButton,
+        background = background merge other.background,
+        fileUploadBar = fileUploadBar merge other.fileUploadBar
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/MediaUpgradeTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/MediaUpgradeTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
@@ -9,4 +11,11 @@ internal data class MediaUpgradeTheme(
     val description: TextTheme? = null,
     val iconColor: ColorTheme? = null,
     val background: LayerTheme? = null
-)
+) : Mergeable<MediaUpgradeTheme> {
+    override fun merge(other: MediaUpgradeTheme): MediaUpgradeTheme = MediaUpgradeTheme(
+        text = text merge other.text,
+        description = description merge other.description,
+        iconColor = iconColor merge other.iconColor,
+        background = background merge other.background
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/MessageBalloonTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/MessageBalloonTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
@@ -9,4 +11,12 @@ internal data class MessageBalloonTheme(
     val status: TextTheme? = null,
     val error: TextTheme? = null,
     val userImage: UserImageTheme? = null
-)
+) : Mergeable<MessageBalloonTheme> {
+    override fun merge(other: MessageBalloonTheme): MessageBalloonTheme = MessageBalloonTheme(
+        background = background merge other.background,
+        text = text merge other.text,
+        status = status merge other.status,
+        error = error merge other.error,
+        userImage = userImage merge other.userImage
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/OnHoldOverlayTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/OnHoldOverlayTheme.kt
@@ -1,8 +1,15 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 
 internal data class OnHoldOverlayTheme(
     val backgroundColor: ColorTheme? = null,
     val tintColor: ColorTheme? = null
-)
+) : Mergeable<OnHoldOverlayTheme> {
+    override fun merge(other: OnHoldOverlayTheme): OnHoldOverlayTheme = OnHoldOverlayTheme(
+        backgroundColor = backgroundColor merge other.backgroundColor,
+        tintColor = tintColor merge other.tintColor
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/OperatorTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/OperatorTheme.kt
@@ -1,9 +1,17 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 
 internal data class OperatorTheme(
     val image: UserImageTheme? = null,
     val animationColor: ColorTheme? = null,
     val onHoldOverlay: OnHoldOverlayTheme? = null
-)
+) : Mergeable<OperatorTheme> {
+    override fun merge(other: OperatorTheme): OperatorTheme = OperatorTheme(
+        image = image merge other.image,
+        animationColor = animationColor merge other.animationColor,
+        onHoldOverlay = onHoldOverlay merge other.onHoldOverlay
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ResponseCardOptionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ResponseCardOptionTheme.kt
@@ -1,11 +1,14 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 
 @JvmInline
 internal value class ResponseCardOptionTheme(
     val normal: ButtonTheme? = null
-//    No longer needed, because the Response card has only one state when it is open
-//    val selected: ButtonTheme?,
-//    val disabled: ButtonTheme?,
-)
+) : Mergeable<ResponseCardOptionTheme> {
+    override fun merge(other: ResponseCardOptionTheme): ResponseCardOptionTheme = ResponseCardOptionTheme(
+        normal = normal merge other.normal
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ResponseCardTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ResponseCardTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
@@ -8,4 +10,11 @@ internal data class ResponseCardTheme(
     val option: ResponseCardOptionTheme? = null,
     val text: TextTheme? = null,
     val userImage: UserImageTheme? = null
-)
+) : Mergeable<ResponseCardTheme> {
+    override fun merge(other: ResponseCardTheme): ResponseCardTheme = ResponseCardTheme(
+        background = background merge other.background,
+        option = option merge other.option,
+        text = text merge other.text,
+        userImage = userImage merge other.userImage
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/UnreadIndicatorTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/UnreadIndicatorTheme.kt
@@ -1,9 +1,16 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.bubble.BubbleTheme
 
 internal data class UnreadIndicatorTheme(
     val background: ColorTheme? = null,
     val bubble: BubbleTheme? = null
-)
+) : Mergeable<UnreadIndicatorTheme> {
+    override fun merge(other: UnreadIndicatorTheme): UnreadIndicatorTheme = UnreadIndicatorTheme(
+        background = background merge other.background,
+        bubble = bubble merge other.bubble
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/UploadFileTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/UploadFileTheme.kt
@@ -1,8 +1,15 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class UploadFileTheme(
     val text: TextTheme?,
     val info: TextTheme?
-)
+) : Mergeable<UploadFileTheme> {
+    override fun merge(other: UploadFileTheme): UploadFileTheme = UploadFileTheme(
+        text = text merge other.text,
+        info = info merge other.info
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/UserImageTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/UserImageTheme.kt
@@ -1,9 +1,17 @@
 package com.glia.widgets.view.unifiedui.theme.chat
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 
 internal data class UserImageTheme(
     val placeholderColor: ColorTheme? = null,
     val placeholderBackgroundColor: ColorTheme? = null,
     val imageBackgroundColor: ColorTheme? = null
-)
+) : Mergeable<UserImageTheme> {
+    override fun merge(other: UserImageTheme): UserImageTheme = UserImageTheme(
+        placeholderColor = placeholderColor merge other.placeholderColor,
+        placeholderBackgroundColor = placeholderBackgroundColor merge other.placeholderBackgroundColor,
+        imageBackgroundColor = imageBackgroundColor merge other.imageBackgroundColor
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/gva/GvaGalleryCardTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/gva/GvaGalleryCardTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.gva
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
@@ -10,4 +12,12 @@ internal data class GvaGalleryCardTheme(
     val image: LayerTheme? = null,
     val button: ButtonTheme? = null,
     val background: LayerTheme? = null
-)
+) : Mergeable<GvaGalleryCardTheme> {
+    override fun merge(other: GvaGalleryCardTheme): GvaGalleryCardTheme = GvaGalleryCardTheme(
+        title = title merge other.title,
+        subtitle = subtitle merge other.subtitle,
+        image = image merge other.image,
+        button = button merge other.button,
+        background = background merge other.background
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/gva/GvaPersistentButtonTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/gva/GvaPersistentButtonTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.gva
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
@@ -8,4 +10,10 @@ internal data class GvaPersistentButtonTheme(
     val title: TextTheme? = null,
     val background: LayerTheme? = null,
     val button: ButtonTheme? = null
-)
+) : Mergeable<GvaPersistentButtonTheme> {
+    override fun merge(other: GvaPersistentButtonTheme): GvaPersistentButtonTheme = GvaPersistentButtonTheme(
+        title = title merge other.title,
+        background = background merge other.background,
+        button = button merge other.button
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/gva/GvaTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/gva/GvaTheme.kt
@@ -1,9 +1,17 @@
 package com.glia.widgets.view.unifiedui.theme.gva
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 
 internal data class GvaTheme(
     val quickReplyTheme: ButtonTheme? = null,
     val persistentButtonTheme: GvaPersistentButtonTheme? = null,
     val galleryCardTheme: GvaGalleryCardTheme? = null
-)
+) : Mergeable<GvaTheme> {
+    override fun merge(other: GvaTheme): GvaTheme = GvaTheme(
+        quickReplyTheme = quickReplyTheme merge other.quickReplyTheme,
+        persistentButtonTheme = persistentButtonTheme merge other.persistentButtonTheme,
+        galleryCardTheme = galleryCardTheme merge other.galleryCardTheme
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/secureconversations/SecureConversationsConfirmationScreenTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/secureconversations/SecureConversationsConfirmationScreenTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.secureconversations
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
@@ -12,4 +14,14 @@ internal data class SecureConversationsConfirmationScreenTheme(
     val titleTheme: TextTheme? = null,
     val subtitleTheme: TextTheme? = null,
     val checkMessagesButtonTheme: ButtonTheme? = null
-)
+) : Mergeable<SecureConversationsConfirmationScreenTheme> {
+    override fun merge(other: SecureConversationsConfirmationScreenTheme): SecureConversationsConfirmationScreenTheme =
+        SecureConversationsConfirmationScreenTheme(
+            headerTheme = headerTheme merge other.headerTheme,
+            backgroundTheme = backgroundTheme merge other.backgroundTheme,
+            iconColorTheme = iconColorTheme merge other.iconColorTheme,
+            titleTheme = titleTheme merge other.titleTheme,
+            subtitleTheme = subtitleTheme merge other.subtitleTheme,
+            checkMessagesButtonTheme = checkMessagesButtonTheme merge other.checkMessagesButtonTheme
+        )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/secureconversations/SecureConversationsWelcomeScreenTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/secureconversations/SecureConversationsWelcomeScreenTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.secureconversations
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
@@ -31,4 +33,30 @@ internal data class SecureConversationsWelcomeScreenTheme(
     val attachmentListTheme: FileUploadBarTheme? = null,
     val pickMediaTheme: AttachmentsPopupTheme? = null,
     val backgroundTheme: ColorTheme? = null
-)
+) : Mergeable<SecureConversationsWelcomeScreenTheme> {
+    override fun merge(other: SecureConversationsWelcomeScreenTheme): SecureConversationsWelcomeScreenTheme =
+        SecureConversationsWelcomeScreenTheme(
+            headerTheme = headerTheme merge other.headerTheme,
+            welcomeTitleTheme = welcomeTitleTheme merge other.welcomeTitleTheme,
+            titleImageTheme = titleImageTheme merge other.titleImageTheme,
+            welcomeSubtitleTheme = welcomeSubtitleTheme merge other.welcomeSubtitleTheme,
+            checkMessagesButtonTheme = checkMessagesButtonTheme merge other.checkMessagesButtonTheme,
+            messageTitleTheme = messageTitleTheme merge other.messageTitleTheme,
+            messageInputNormalTheme = messageInputNormalTheme merge other.messageInputNormalTheme,
+            messageInputActiveTheme = messageInputActiveTheme merge other.messageInputActiveTheme,
+            messageInputDisabledTheme = messageInputDisabledTheme merge other.messageInputDisabledTheme,
+            messageInputErrorTheme = messageInputErrorTheme merge other.messageInputErrorTheme,
+            messageInputHintTheme = messageInputHintTheme merge other.messageInputHintTheme,
+            enabledSendButtonTheme = enabledSendButtonTheme merge other.enabledSendButtonTheme,
+            disabledSendButtonTheme = disabledSendButtonTheme merge other.disabledSendButtonTheme,
+            loadingSendButtonTheme = loadingSendButtonTheme merge other.loadingSendButtonTheme,
+            activityIndicatorColorTheme = activityIndicatorColorTheme merge other.activityIndicatorColorTheme,
+            messageWarningTheme = messageWarningTheme merge other.messageWarningTheme,
+            messageWarningIconColorTheme = messageWarningIconColorTheme merge other.messageWarningIconColorTheme,
+            filePickerButtonTheme = filePickerButtonTheme merge other.filePickerButtonTheme,
+            filePickerButtonDisabledTheme = filePickerButtonDisabledTheme merge other.filePickerButtonDisabledTheme,
+            attachmentListTheme = attachmentListTheme merge other.attachmentListTheme,
+            pickMediaTheme = pickMediaTheme merge other.pickMediaTheme,
+            backgroundTheme = backgroundTheme merge other.backgroundTheme
+        )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/OptionButtonTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/OptionButtonTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.survey
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
@@ -12,4 +14,15 @@ internal data class OptionButtonTheme(
     val highlightedLayer: LayerTheme? = null,
     val fontSize: Float? = null,
     val fontStyle: Int? = null
-)
+) : Mergeable<OptionButtonTheme> {
+    override fun merge(other: OptionButtonTheme): OptionButtonTheme = OptionButtonTheme(
+        normalText = normalText merge other.normalText,
+        normalLayer = normalLayer merge other.normalLayer,
+        selectedText = selectedText merge other.selectedText,
+        selectedLayer = selectedLayer merge other.selectedLayer,
+        highlightedText = highlightedText merge other.highlightedText,
+        highlightedLayer = highlightedLayer merge other.highlightedLayer,
+        fontSize = fontSize merge other.fontSize,
+        fontStyle = fontStyle merge other.fontStyle
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyBooleanQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyBooleanQuestionTheme.kt
@@ -1,8 +1,15 @@
 package com.glia.widgets.view.unifiedui.theme.survey
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class SurveyBooleanQuestionTheme(
     val title: TextTheme? = null,
     val optionButton: OptionButtonTheme? = null
-)
+) : Mergeable<SurveyBooleanQuestionTheme> {
+    override fun merge(other: SurveyBooleanQuestionTheme): SurveyBooleanQuestionTheme = SurveyBooleanQuestionTheme(
+        title = title merge other.title,
+        optionButton = optionButton merge other.optionButton
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyInputQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyInputQuestionTheme.kt
@@ -1,9 +1,17 @@
 package com.glia.widgets.view.unifiedui.theme.survey
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class SurveyInputQuestionTheme(
     val title: TextTheme? = null,
     val option: OptionButtonTheme? = null,
     val text: TextTheme? = null
-)
+) : Mergeable<SurveyInputQuestionTheme> {
+    override fun merge(other: SurveyInputQuestionTheme): SurveyInputQuestionTheme = SurveyInputQuestionTheme(
+        title = title merge other.title,
+        option = option merge other.option,
+        text = text merge other.text
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyScaleQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyScaleQuestionTheme.kt
@@ -1,8 +1,15 @@
 package com.glia.widgets.view.unifiedui.theme.survey
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class SurveyScaleQuestionTheme(
     val title: TextTheme? = null,
     val optionButton: OptionButtonTheme? = null
-)
+) : Mergeable<SurveyScaleQuestionTheme> {
+    override fun merge(other: SurveyScaleQuestionTheme): SurveyScaleQuestionTheme = SurveyScaleQuestionTheme(
+        title = title merge other.title,
+        optionButton = optionButton merge other.optionButton
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveySingleQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveySingleQuestionTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.survey
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
@@ -7,4 +9,10 @@ internal data class SurveySingleQuestionTheme(
     val title: TextTheme? = null,
     val tintColor: ColorTheme? = null,
     val option: TextTheme? = null
-)
+) : Mergeable<SurveySingleQuestionTheme> {
+    override fun merge(other: SurveySingleQuestionTheme): SurveySingleQuestionTheme = SurveySingleQuestionTheme(
+        title = title merge other.title,
+        tintColor = tintColor merge other.tintColor,
+        option = option merge other.option
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyTheme.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.survey
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
@@ -13,4 +15,15 @@ internal data class SurveyTheme(
     val scaleQuestion: SurveyScaleQuestionTheme? = null,
     val singleQuestion: SurveySingleQuestionTheme? = null,
     val inputQuestion: SurveyInputQuestionTheme? = null
-)
+) : Mergeable<SurveyTheme> {
+    override fun merge(other: SurveyTheme): SurveyTheme = SurveyTheme(
+        layer = layer merge other.layer,
+        title = title merge other.title,
+        submitButton = submitButton merge other.submitButton,
+        cancelButton = cancelButton merge other.cancelButton,
+        booleanQuestion = booleanQuestion merge other.booleanQuestion,
+        scaleQuestion = scaleQuestion merge other.scaleQuestion,
+        singleQuestion = singleQuestion merge other.singleQuestion,
+        inputQuestion = inputQuestion merge other.inputQuestion
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/webbrowser/WebBrowserTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/webbrowser/WebBrowserTheme.kt
@@ -1,7 +1,11 @@
 package com.glia.widgets.view.unifiedui.webbrowser
 
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
 
 internal data class WebBrowserTheme(
     val header: HeaderTheme? = null
-)
+) : Mergeable<WebBrowserTheme> {
+    override fun merge(other: WebBrowserTheme): WebBrowserTheme = WebBrowserTheme(header = header merge other.header)
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/messagecenter/SimpleStatefulWidgetAdapterTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/messagecenter/SimpleStatefulWidgetAdapterTest.kt
@@ -1,6 +1,8 @@
 package com.glia.widgets.messagecenter
 
 import android.graphics.Color
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -26,7 +28,9 @@ class SimpleStatefulWidgetAdapterTest {
         State.FOCUSED to null
     )
 
-    data class Theme(val color: Int? = null, val size: Int? = null)
+    data class Theme(val color: Int? = null, val size: Int? = null) : Mergeable<Theme> {
+        override fun merge(other: Theme): Theme = Theme(color merge other.color, size merge other.size)
+    }
     enum class State {
         ENABLED,
         DISABLED,


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3418

**What was solved?**
Replaced the Kotlin reflection-based `Merge` functionality with manually written ones to make the SDK less sensitive to proguard on the integrator side.

Related issues could be found in - https://glia.atlassian.net/browse/MOB-3337

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
