### PR TITLE
Remove company name requirement for CV engagements

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/CallVisualizerManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/CallVisualizerManager.kt
@@ -14,22 +14,12 @@ internal class CallVisualizerManager(
     private val buildVisitorCodeUseCase: VisitorCodeViewBuilderUseCase,
     private val callVisualizerController: CallVisualizerContract.Controller
 ) : CallVisualizer {
-    private fun checkForProperInit() {
-        if (Dependencies.getSdkConfigurationManager().companyName.isNullOrEmpty()) {
-            throw GliaException(
-                "companyName not set during GliaWidgets.init(GliaWidgetsConfig gliaWidgetsConfig)",
-                GliaException.Cause.INVALID_INPUT
-            )
-        }
-    }
 
     override fun createVisitorCodeView(context: Context): View {
-        checkForProperInit()
         return buildVisitorCodeUseCase(context, false)
     }
 
     override fun showVisitorCodeDialog() {
-        checkForProperInit()
         callVisualizerController.showVisitorCodeDialog()
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-1060

**What was solved?**
Before PR#1060 the company name was not allowed to be null for Call Visualizer engagements. Now, the default company name is "" and setting it up from SDK side is optional since it is expected to be setup in Glia Hub custom locales settings.

**Release notes:**

 - [x] Feature: Bugfix for https://github.com/salemove/android-sdk-widgets/pull/1060. Important point is that `Company Name` is not anymore mandatory to be set up on SDK side but in this case has to be set up in Glia Hub custom locales
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
