### PR TITLE
Dismiss CV dialog on timeout

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcher.kt
@@ -34,7 +34,10 @@ internal class CallVisualizerActivityWatcher(
             activity == null || activity.isFinishing -> Logger.d(TAG, "skipping.. activity is null or finishing")
             activity is WebBrowserActivity && state is ControllerState.DisplayConfirmationDialog -> Logger.d(TAG, "skipping.. WebBrowser is open")
             activity is WebBrowserActivity && state is ControllerState.OpenWebBrowserScreen -> event.consume { controller.onWebBrowserOpened() }
-            state is ControllerState.DismissDialog -> event.consume { dismissAlertDialogSilently() }
+            state is ControllerState.DismissDialog -> event.consume {
+                dismissAlertDialogSilently()
+                closeHolderActivity(activity)
+            }
             //Ensure this state remains unconsumed until the opening of the WebBrowserActivity.
             state is ControllerState.OpenWebBrowserScreen -> openWebBrowser(activity, state.title, state.url)
             state is ControllerState.CloseHolderActivity -> event.consume { closeHolderActivity(activity) }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/DialogController.kt
@@ -21,6 +21,7 @@ internal interface DialogContract {
         fun showCVOverlayPermissionDialog()
         fun dismissOverlayPermissionsDialog()
         fun dismissMessageCenterUnavailableDialog()
+        fun dismissCVEngagementConfirmationDialog()
         fun showStartScreenSharingDialog()
         fun showMessageCenterUnavailableDialog()
         fun showUnauthenticatedDialog()
@@ -108,6 +109,11 @@ internal class DialogController : DialogContract.Controller {
     override fun dismissMessageCenterUnavailableDialog() {
         Logger.d(TAG, "Dismiss Message Center Unavailable Dialog")
         dialogManager.remove(DialogState.MessageCenterUnavailable)
+    }
+
+    override fun dismissCVEngagementConfirmationDialog() {
+        Logger.d(TAG, "Dismiss CV Live Observation Opt In Dialog")
+        dialogManager.remove(DialogState.CVConfirmation)
     }
 
     override fun showStartScreenSharingDialog() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -281,7 +281,8 @@ public class ControllerFactory {
                 useCaseFactory.getEngagementRequestUseCase(),
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.createConfirmationDialogLinksUseCase(),
-                useCaseFactory.createGetUrlFromLinkUseCase()
+                useCaseFactory.createGetUrlFromLinkUseCase(),
+                useCaseFactory.getOnIncomingEngagementRequestTimeoutUseCase()
             );
         }
         return callVisualizerController;

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -156,6 +156,8 @@ import com.glia.widgets.engagement.domain.OperatorMediaUseCase;
 import com.glia.widgets.engagement.domain.OperatorMediaUseCaseImpl;
 import com.glia.widgets.engagement.domain.OperatorTypingUseCase;
 import com.glia.widgets.engagement.domain.OperatorTypingUseCaseImpl;
+import com.glia.widgets.engagement.domain.OnIncomingEngagementRequestTimeoutUseCase;
+import com.glia.widgets.engagement.domain.OnIncomingEngagementRequestTimeoutUseCaseImpl;
 import com.glia.widgets.engagement.domain.PrepareToScreenSharingUseCase;
 import com.glia.widgets.engagement.domain.PrepareToScreenSharingUseCaseImpl;
 import com.glia.widgets.engagement.domain.ReleaseResourcesUseCase;
@@ -949,6 +951,11 @@ public class UseCaseFactory {
     @NonNull
     public EngagementRequestUseCase getEngagementRequestUseCase() {
         return new EngagementRequestUseCaseImpl(repositoryFactory.getEngagementRepository());
+    }
+
+    @NonNull
+    public OnIncomingEngagementRequestTimeoutUseCase getOnIncomingEngagementRequestTimeoutUseCase() {
+        return new OnIncomingEngagementRequestTimeoutUseCaseImpl(repositoryFactory.getEngagementRepository());
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.engagement
 import android.app.Activity
 import android.content.Intent
 import com.glia.androidsdk.Engagement.MediaType
+import com.glia.androidsdk.EngagementRequest.Outcome
 import com.glia.androidsdk.IncomingEngagementRequest
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.comms.CameraDevice
@@ -14,6 +15,7 @@ import io.reactivex.rxjava3.core.Flowable
 
 internal interface EngagementRepository {
     val engagementRequest: Flowable<IncomingEngagementRequest>
+    val engagementOutcome: Flowable<Outcome>
     val engagementState: Flowable<State>
     val survey: Flowable<SurveyState>
     val currentOperator: Flowable<Data<Operator>>

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/OnIncomingEngagementRequestTimeoutUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/OnIncomingEngagementRequestTimeoutUseCase.kt
@@ -1,0 +1,18 @@
+package com.glia.widgets.engagement.domain
+
+import com.glia.androidsdk.EngagementRequest.Outcome
+import com.glia.widgets.engagement.EngagementRepository
+import io.reactivex.rxjava3.core.Flowable
+
+internal interface OnIncomingEngagementRequestTimeoutUseCase {
+    operator fun invoke(): Flowable<Unit>
+}
+
+internal class OnIncomingEngagementRequestTimeoutUseCaseImpl(
+    private val engagementRepository: EngagementRepository
+) : OnIncomingEngagementRequestTimeoutUseCase {
+
+    override fun invoke(): Flowable<Unit> = engagementRepository.engagementOutcome
+        .filter { it == Outcome.TIMEOUT }
+        .map { Unit }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcherTest.kt
@@ -140,6 +140,7 @@ class CallVisualizerActivityWatcherTest {
         verify { dismissDialogEvent.value }
         verify { dismissDialogEvent.consume(any()) }
         verify { dialog.dismiss() }
+        verify { activity.finish() }
 
         confirmVerified(dialog, activity, event, dismissDialogEvent)
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3456

**What was solved?**
The incoming engagement request dialog is dismissed if the request is timeout.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [x] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
