### PR TITLE
Upgrade Core SDK to 1.3.1 and increment Widgets version

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Thu Mar 21 12:52:56 UTC 2024
-dependency.coreSdk.version=1.3.0
+dependency.coreSdk.version=1.3.1
 widgets.versionCode=79
-widgets.versionName=2.4.1
+widgets.versionName=2.4.2


### PR DESCRIPTION
This is a hotfix release that contains only a Core SDK version increase to 1.3.1 and a Widgets SDK version increment to 2.4.2

This PR is not for merging into the master and this branch will be used for the hotfix release of Widgets SDK 2.4.2

Conflict with the master branch is expected as this release is not based on the latest master branch changes.