### PR TITLE
Fix hardcoded company name

### DIFF
--- a/widgetssdk/src/androidTest/java/com/glia/widgets/CallActivityTest.kt
+++ b/widgetssdk/src/androidTest/java/com/glia/widgets/CallActivityTest.kt
@@ -78,7 +78,7 @@ class CallActivityTest {
         Dependencies.setResourceProvider(resourceProvider)
 
         // set up StringProvider
-        val localeProvider = LocaleProvider(resourceProvider, sdkConfigurationManager.companyName)
+        val localeProvider = LocaleProvider(resourceProvider)
         Dependencies.setLocaleProvider(localeProvider)
 
         callStatus = mockk(relaxed = true)

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -64,7 +64,7 @@ public class Dependencies {
     public static void onAppCreate(Application application) {
         schedulers = new GliaWidgetsSchedulers();
         resourceProvider = new ResourceProvider(application.getBaseContext());
-        localeProvider = new LocaleProvider(resourceProvider, sdkConfigurationManager.getCompanyName());
+        localeProvider = new LocaleProvider(resourceProvider);
         notificationManager = new NotificationManager(application);
         DownloadsFolderDataSource downloadsFolderDataSource = new DownloadsFolderDataSource(application);
         repositoryFactory = new RepositoryFactory(gliaCore, downloadsFolderDataSource);
@@ -196,6 +196,7 @@ public class Dependencies {
         controllerFactory.init();
         repositoryFactory.getEngagementRepository().initialize();
         sdkConfigurationManager.fromConfiguration(gliaWidgetsConfig);
+        localeProvider.setCompanyName(gliaWidgetsConfig.companyName);
     }
 
     public static ControllerFactory getControllerFactory() {

--- a/widgetssdk/src/main/java/com/glia/widgets/locale/LocaleProvider.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/locale/LocaleProvider.kt
@@ -35,10 +35,10 @@ data class LocaleString(
 
 @OpenForTesting
 internal open class LocaleProvider @JvmOverloads constructor(
-    private val resourceProvider: IResourceProvider,
-    private val hardcodedCompanyName: String?
+    private val resourceProvider: IResourceProvider
 ) : StringProvider {
 
+    private var hardcodedCompanyName: String? = null
     private val regex = "(\\{[a-zA-Z\\d]*\\})".toRegex()
     private val localeObservable: Observable<String>
     private val localeEmitter: Observer<String>
@@ -112,6 +112,10 @@ internal open class LocaleProvider @JvmOverloads constructor(
 
     fun getLocaleObservable(): Observable<String> {
         return localeObservable
+    }
+
+    fun setCompanyName(companyName: String?) {
+        hardcodedCompanyName = companyName
     }
 
     // Priority for remote company name but not found or no locales it will fall back to hardcoded one or "" if no hardcoded one

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
@@ -43,6 +43,7 @@ class GliaWidgetsTest {
         Dependencies.setControllerFactory(controllerFactory)
         repositoryFactory = mock()
         Dependencies.setRepositoryFactory(repositoryFactory)
+        Dependencies.setLocaleProvider(mock())
     }
 
     @Test

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotProviders.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotProviders.kt
@@ -11,7 +11,7 @@ internal interface SnapshotProviders: SnapshotContent, SnapshotTestLifecycle {
 
     fun localeProviderMock(): LocaleProvider {
         val resourceProvider = resourceProviderMock()
-        val localeProvider = object: LocaleProvider(resourceProvider, null) {
+        val localeProvider = object: LocaleProvider(resourceProvider) {
             override fun getStringInternal(stringKey: Int, values: List<StringKeyPair>): String {
                 return snapshotLocales[stringKey] ?: context.resources.getResourceName(stringKey).split("/")[1]
             }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**
There was a problem that the company name specified in SDK configs on `init` was ignored even when no remote was loaded.

**Release notes:**

 - [x] Feature: Part of custom locales improvement changes
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
