### PR TITLE
Show Snackbar if an engagement request is timed out

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -26,6 +26,7 @@ internal interface CallVisualizerContract {
         object DisplayVisitorCodeDialog : State
         data class DisplayConfirmationDialog(val links: ConfirmationDialogLinks) : State
         object DismissDialog : State
+        object ShowTimeoutSnackBar : State
         object CloseHolderActivity : State
         data class OpenWebBrowserScreen(val title: LocaleString, val url: String) : State
     }
@@ -108,6 +109,7 @@ internal class CallVisualizerController(
     private fun onIncomingEngagementRequestTimeout() {
         dialogController.dismissCVEngagementConfirmationDialog()
         closeHolderActivity()
+        _state.onNext(CallVisualizerContract.State.ShowTimeoutSnackBar)
     }
 
     override fun onLinkClicked(link: Link) {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.java
@@ -99,7 +99,9 @@ public class Dependencies {
 
         CallVisualizerActivityWatcher callVisualizerActivityWatcher = new CallVisualizerActivityWatcher(
             getControllerFactory().getCallVisualizerController(),
-            new GliaActivityManagerImpl()
+            new GliaActivityManagerImpl(),
+            getLocaleProvider(),
+            getGliaThemeManager()
         );
 
         application.registerActivityLifecycleCallbacks(callVisualizerActivityWatcher);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/ActivityWatcherForLiveObservation.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/ActivityWatcherForLiveObservation.kt
@@ -2,6 +2,7 @@ package com.glia.widgets.view.snackbar
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import com.glia.widgets.R
 import com.glia.widgets.base.BaseActivityStackWatcher
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
@@ -34,6 +35,11 @@ internal class ActivityWatcherForLiveObservation(
     }
 
     private fun makeSnackBar(activity: Activity): SnackBarDelegate =
-        SnackBarDelegateFactory(activity, localeProvider, themeManager.theme).createDelegate()
+        SnackBarDelegateFactory(
+            activity,
+            R.string.live_observation_indicator_message,
+            localeProvider,
+            themeManager.theme
+        ).createDelegate()
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/SnackBarDelegate.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/SnackBarDelegate.kt
@@ -24,7 +24,10 @@ import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.google.android.material.snackbar.Snackbar
 
 internal abstract class SnackBarDelegate(
-    view: View, localeProvider: LocaleProvider, snackBarTheme: SnackBarTheme?
+    view: View,
+    titleStringKey: Int,
+    localeProvider: LocaleProvider,
+    snackBarTheme: SnackBarTheme?
 ) {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
@@ -43,14 +46,14 @@ internal abstract class SnackBarDelegate(
     open val fallbackTextColor: Int = R.color.glia_base_light_color
 
     @VisibleForTesting
-    val snackBar: Snackbar by lazy { makeSnackBar(view, localeProvider, snackBarTheme) }
+    val snackBar: Snackbar by lazy { makeSnackBar(view, titleStringKey, localeProvider, snackBarTheme) }
 
     fun show() = snackBar.show()
 
-    private fun makeSnackBar(view: View, stringProvider: LocaleProvider, snackBarTheme: SnackBarTheme?): Snackbar {
+    private fun makeSnackBar(view: View, titleStringKey: Int, stringProvider: LocaleProvider, snackBarTheme: SnackBarTheme?): Snackbar {
         val bgColor = snackBarTheme?.backgroundColorTheme?.primaryColor ?: view.getColorCompat(fallbackBackgroundColor)
         val textColor = snackBarTheme?.textColorTheme?.primaryColor ?: view.getColorCompat(fallbackTextColor)
-        val message = stringProvider.getRemoteString(R.string.live_observation_indicator_message)
+        val message = stringProvider.getRemoteString(titleStringKey)
 
         return Snackbar.make(view, message, Snackbar.LENGTH_SHORT)
             .setBackgroundTint(bgColor)
@@ -68,8 +71,8 @@ internal abstract class SnackBarDelegate(
 }
 
 @VisibleForTesting
-internal class CommonSnackBarDelegate(activity: Activity, localeProvider: LocaleProvider, unifiedTheme: UnifiedTheme?) :
-    SnackBarDelegate(activity.rootView, localeProvider, unifiedTheme?.snackBarTheme) {
+internal class CommonSnackBarDelegate(activity: Activity, titleStringKey: Int, localeProvider: LocaleProvider, unifiedTheme: UnifiedTheme?) :
+    SnackBarDelegate(activity.rootView, titleStringKey, localeProvider, unifiedTheme?.snackBarTheme) {
     override val marginBottom: Int = calculateBottomMargin(activity.rootView)
 
     private fun calculateBottomMargin(view: View): Int {
@@ -83,14 +86,14 @@ internal class CommonSnackBarDelegate(activity: Activity, localeProvider: Locale
 }
 
 @VisibleForTesting
-internal class ChatActivitySnackBarDelegate(activity: ChatActivity, localeProvider: LocaleProvider, unifiedTheme: UnifiedTheme?) :
-    SnackBarDelegate(activity.findViewById(R.id.chat_view), localeProvider, unifiedTheme?.snackBarTheme) {
+internal class ChatActivitySnackBarDelegate(activity: ChatActivity, titleStringKey: Int, localeProvider: LocaleProvider, unifiedTheme: UnifiedTheme?) :
+    SnackBarDelegate(activity.findViewById(R.id.chat_view), titleStringKey, localeProvider, unifiedTheme?.snackBarTheme) {
     override val anchorViewId: Int = R.id.chat_message_layout
 }
 
 @VisibleForTesting
-internal class CallActivitySnackBarDelegate(activity: CallActivity, localeProvider: LocaleProvider, unifiedTheme: UnifiedTheme?) :
-    SnackBarDelegate(activity.findViewById(R.id.call_view), localeProvider, unifiedTheme?.callTheme?.snackBar) {
+internal class CallActivitySnackBarDelegate(activity: CallActivity, titleStringKey: Int, localeProvider: LocaleProvider, unifiedTheme: UnifiedTheme?) :
+    SnackBarDelegate(activity.findViewById(R.id.call_view), titleStringKey, localeProvider, unifiedTheme?.callTheme?.snackBar) {
     override val anchorViewId: Int = R.id.buttons_layout_bg
     override val fallbackBackgroundColor: Int = R.color.glia_base_light_color
     override val fallbackTextColor: Int = R.color.glia_base_dark_color
@@ -98,12 +101,13 @@ internal class CallActivitySnackBarDelegate(activity: CallActivity, localeProvid
 
 internal class SnackBarDelegateFactory(
     private val activity: Activity,
+    private val titleStringKey: Int,
     private val localeProvider: LocaleProvider,
     private val unifiedTheme: UnifiedTheme?
 ) {
     fun createDelegate(): SnackBarDelegate = when (activity) {
-        is ChatActivity -> ChatActivitySnackBarDelegate(activity, localeProvider, unifiedTheme)
-        is CallActivity -> CallActivitySnackBarDelegate(activity, localeProvider, unifiedTheme)
-        else -> CommonSnackBarDelegate(activity, localeProvider, unifiedTheme)
+        is ChatActivity -> ChatActivitySnackBarDelegate(activity, titleStringKey, localeProvider, unifiedTheme)
+        is CallActivity -> CallActivitySnackBarDelegate(activity, titleStringKey, localeProvider, unifiedTheme)
+        else -> CommonSnackBarDelegate(activity, titleStringKey, localeProvider, unifiedTheme)
     }
 }

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -24,7 +24,6 @@
     <string name="call_visualizer_visitor_code_refresh_accessibility_hint">Generates a new visitor code</string>
     <string name="call_visualizer_visitor_code_close_accessibility_hint">Closes the visitor code</string>
 
-
     <!-- File preview -->
     <string name="android_preview_title">@string/glia_preview_activity_toolbar_title</string>
     <string name="android_preview_save_success">@string/glia_preview_activity_image_save_success_msg</string>
@@ -209,6 +208,7 @@
     <string name="engagement_confirm_link2_text">Privacy Policies</string>
     <string name="engagement_confirm_link2_url"/>
     <string name="live_observation_indicator_message">Your app screen is visible to the operator.</string>
+    <string name="engagement_incoming_request_timed_out_message">The engagement request is timed out.</string>
 
     <!--    GVA -->
     <string name="gva_unsupported_action_error">This action is not currently supported on mobile.</string>

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcherTest.kt
@@ -17,8 +17,10 @@ import com.glia.widgets.helper.GliaActivityManager
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.OneTimeEvent
 import com.glia.widgets.helper.withRuntimeTheme
+import com.glia.widgets.locale.LocaleProvider
 import com.glia.widgets.locale.LocaleString
 import com.glia.widgets.view.Dialogs
+import com.glia.widgets.view.unifiedui.theme.UnifiedThemeManager
 import com.glia.widgets.webbrowser.WebBrowserActivity
 import io.mockk.Runs
 import io.mockk.confirmVerified
@@ -43,6 +45,8 @@ class CallVisualizerActivityWatcherTest {
 
     private lateinit var controller: CallVisualizerContract.Controller
     private lateinit var gliaActivityManager: GliaActivityManager
+    private lateinit var localeProvider: LocaleProvider
+    private lateinit var themeManager: UnifiedThemeManager
 
     private lateinit var watcher: CallVisualizerActivityWatcher
     private lateinit var mockLocale: LocaleString
@@ -59,9 +63,11 @@ class CallVisualizerActivityWatcherTest {
             every { state } returns controllerState
         }
         gliaActivityManager = mockk(relaxed = true)
+        localeProvider = mockk(relaxed = true)
+        themeManager = mockk(relaxed = true)
         mockLocale = mockk(relaxed = true)
 
-        watcher = CallVisualizerActivityWatcher(controller, gliaActivityManager)
+        watcher = CallVisualizerActivityWatcher(controller, gliaActivityManager, localeProvider, themeManager)
         verify { controller.state }
     }
 
@@ -96,7 +102,7 @@ class CallVisualizerActivityWatcherTest {
     @Test
     fun `event will be skipped when activity is null or finishing`() {
         emitActivity<ChatActivity>(finishing = true)
-        val event = createMockEvent(CallVisualizerContract.State.DismissDialog)
+        val event = createMockEvent(CallVisualizerContract.State.ShowTimeoutSnackBar)
         emitState(event)
 
         verify { event.consumed }
@@ -303,7 +309,6 @@ class CallVisualizerActivityWatcherTest {
         val event = createMockEvent(CallVisualizerContract.State.CloseHolderActivity)
         emitState(event)
 
-        verify { activity.isFinishing }
         verify { event.consumed }
         verify { event.value }
         verify { event.consume(any()) }

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
@@ -219,13 +219,17 @@ class CallVisualizerControllerTest {
 
     @Test
     fun `incoming engagement request timeout will request to dismiss CV dialog`() {
-        val testState = controller.state.test()
+        val testState = controller.state.map { it.value }.test()
         verify(exactly = 0) { dialogController.dismissCVEngagementConfirmationDialog() }
 
         incomingEngagementRequestTimeoutProcessor.onNext(Unit)
-        testState.assertNotComplete().assertValue { it.value is CallVisualizerContract.State.CloseHolderActivity }
 
         verify { dialogController.dismissCVEngagementConfirmationDialog() }
+
+        testState.assertNotComplete().assertValueCount(2).values().run {
+            assertTrue(get(0) is CallVisualizerContract.State.CloseHolderActivity)
+            assertTrue(get(1) is CallVisualizerContract.State.ShowTimeoutSnackBar)
+        }
     }
 
     private fun emitDialogState(state: DialogState) {

--- a/widgetssdk/src/test/java/com/glia/widgets/view/snackbar/SnackBarDelegateTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/snackbar/SnackBarDelegateTest.kt
@@ -31,6 +31,7 @@ class SnackBarDelegateTest {
     private val mockResources: Resources = mock {
         on { getDimensionPixelSize(any()) } doReturn bottomMargin
     }
+    private val titleStringKey: Int = 123
 
     private val mockViewWithResources: View = mock<CoordinatorLayout> {
         on { context } doReturn mockContext
@@ -59,41 +60,41 @@ class SnackBarDelegateTest {
 
     @Test
     fun `ChatActivitySnackBarDelegate passes the corresponding view when initialized`() {
-        ChatActivitySnackBarDelegate(chatActivity, mock(), mock())
+        ChatActivitySnackBarDelegate(chatActivity, titleStringKey, mock(), mock())
         verify(chatActivity).findViewById<View>(R.id.chat_view)
     }
 
     @Test
     fun `CallActivitySnackBarDelegate passes the corresponding view when initialized`() {
-        CallActivitySnackBarDelegate(callActivity, mock(), mock())
+        CallActivitySnackBarDelegate(callActivity, titleStringKey, mock(), mock())
         verify(callActivity).findViewById<View>(R.id.call_view)
     }
 
     @Test
     fun `CommonSnackBarDelegate passes the root view when initialized`() {
-        CommonSnackBarDelegate(commonActivity, mock(), mock())
+        CommonSnackBarDelegate(commonActivity, titleStringKey, mock(), mock())
         verify(commonActivity, times(2)).rootView
     }
 
     @Test
     fun `anchorViewId returns corresponding ids when chat or call activity is passed`() {
-        CommonSnackBarDelegate(commonActivity, mock(), mock()).apply { assertNull(anchorViewId) }
-        CallActivitySnackBarDelegate(callActivity, mock(), mock()).apply { assertEquals(R.id.buttons_layout_bg, anchorViewId) }
-        ChatActivitySnackBarDelegate(chatActivity, mock(), mock()).apply { assertEquals(R.id.chat_message_layout, anchorViewId) }
+        CommonSnackBarDelegate(commonActivity, titleStringKey, mock(), mock()).apply { assertNull(anchorViewId) }
+        CallActivitySnackBarDelegate(callActivity, titleStringKey, mock(), mock()).apply { assertEquals(R.id.buttons_layout_bg, anchorViewId) }
+        ChatActivitySnackBarDelegate(chatActivity, titleStringKey, mock(), mock()).apply { assertEquals(R.id.chat_message_layout, anchorViewId) }
     }
 
     @Test
     fun `marginBottom margin is calculated when the passed activity is not a call or chat activity`() {
-        CommonSnackBarDelegate(commonActivity, mock(), mock()).apply { assertEquals(bottomMargin, marginBottom) }
-        CallActivitySnackBarDelegate(callActivity, mock(), mock()).apply { assertNull(marginBottom) }
-        ChatActivitySnackBarDelegate(chatActivity, mock(), mock()).apply { assertNull(marginBottom) }
+        CommonSnackBarDelegate(commonActivity, titleStringKey, mock(), mock()).apply { assertEquals(bottomMargin, marginBottom) }
+        CallActivitySnackBarDelegate(callActivity, titleStringKey, mock(), mock()).apply { assertNull(marginBottom) }
+        ChatActivitySnackBarDelegate(chatActivity, titleStringKey, mock(), mock()).apply { assertNull(marginBottom) }
     }
 
     @Test
     fun `background and text colors are inverse in CallActivitySnackBarDelegate`() {
-        val common = CommonSnackBarDelegate(commonActivity, mock(), mock())
-        val call = CallActivitySnackBarDelegate(callActivity, mock(), mock())
-        val chat = ChatActivitySnackBarDelegate(chatActivity, mock(), mock())
+        val common = CommonSnackBarDelegate(commonActivity, titleStringKey, mock(), mock())
+        val call = CallActivitySnackBarDelegate(callActivity, titleStringKey, mock(), mock())
+        val chat = ChatActivitySnackBarDelegate(chatActivity, titleStringKey, mock(), mock())
 
         assertEquals(common.fallbackBackgroundColor, chat.fallbackBackgroundColor)
         assertEquals(common.fallbackTextColor, chat.fallbackTextColor)
@@ -103,9 +104,9 @@ class SnackBarDelegateTest {
 
     @Test
     fun `snackBarDelegateFactory creates appropriate instance`() {
-        SnackBarDelegateFactory(callActivity, mock(), mock()).apply { assertTrue(createDelegate() is CallActivitySnackBarDelegate) }
-        SnackBarDelegateFactory(chatActivity, mock(), mock()).apply { assertTrue(createDelegate() is ChatActivitySnackBarDelegate) }
-        SnackBarDelegateFactory(commonActivity, mock(), mock()).apply { assertTrue(createDelegate() is CommonSnackBarDelegate) }
+        SnackBarDelegateFactory(callActivity, titleStringKey, mock(), mock()).apply { assertTrue(createDelegate() is CallActivitySnackBarDelegate) }
+        SnackBarDelegateFactory(chatActivity, titleStringKey, mock(), mock()).apply { assertTrue(createDelegate() is ChatActivitySnackBarDelegate) }
+        SnackBarDelegateFactory(commonActivity, titleStringKey, mock(), mock()).apply { assertTrue(createDelegate() is CommonSnackBarDelegate) }
     }
 
 }

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotSnackBar.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotSnackBar.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.IdRes
+import com.glia.widgets.R
 import com.glia.widgets.locale.LocaleProvider
 import com.glia.widgets.view.snackbar.SnackBarDelegateFactory
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
@@ -44,7 +45,7 @@ internal interface SnapshotSnackBar : SnapshotContent, SnapshotTestLifecycle, Sn
         kClass: KClass<T>,
         unifiedTheme: UnifiedTheme? = null
     ): View = snackBarMock(kClass).run {
-        SnackBarDelegateFactory(mockActivity, localeProvider, unifiedTheme)
+        SnackBarDelegateFactory(mockActivity, R.string.live_observation_indicator_message, localeProvider, unifiedTheme)
             .createDelegate()
             .apply { addViewToRoot(anchorViewId ?: return@apply, rootLayout) }
             .snackBar


### PR DESCRIPTION
MOB-3495

**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**
The Snackbar is displayed to inform visitors if an engagement request is timed out.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

<img src="https://github.com/user-attachments/assets/e742bf87-3296-4482-806e-5851d66c38a0" width="280">