### PR TITLE
Introduce new configurations for bubble - enableBubbleOutsideApp and enableBubbleInsideApp

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
+++ b/app/src/main/java/com/glia/exampleapp/ExampleAppConfigManager.kt
@@ -128,7 +128,14 @@ object ExampleAppConfigManager {
             context.getString(R.string.pref_company_name),
             context.getString(R.string.settings_value_default_company_name)
         )
-        val useOverlay = preferences.getBoolean(context.getString(R.string.pref_use_overlay), true)
+        val enableBubbleOutsideApp = preferences.getBoolean(
+            context.getString(R.string.settings_enable_bubble_outside_app),
+            true
+        )
+        val enableBubbleInsideApp = preferences.getBoolean(
+            context.getString(R.string.settings_enable_bubble_inside_app),
+            true
+        )
         val bounded = context.getString(R.string.screen_sharing_mode_app_bounded)
         val unbounded = context.getString(R.string.screen_sharing_mode_unbounded)
         val screenSharingMode = if (
@@ -145,7 +152,8 @@ object ExampleAppConfigManager {
             .setRegion(siteRegion)
             .setBaseDomain(baseDomain)
             .setCompanyName(companyName)
-            .setUseOverlay(useOverlay)
+            .enableBubbleOutsideApp(enableBubbleOutsideApp)
+            .enableBubbleInsideApp(enableBubbleInsideApp)
             .setScreenSharingMode(screenSharingMode)
             .setContext(context)
             .setUiJsonRemoteConfig(uiJsonRemoteConfig ?: Utils.getRemoteThemeByPrefs(preferences, context.resources))

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -295,7 +295,7 @@ class MainFragment : Fragment() {
             .putExtra(GliaWidgets.QUEUE_IDS, ArrayList(getQueueIdsFromPrefs(sharedPreferences)))
             .putExtra(GliaWidgets.CONTEXT_ASSET_ID, getContextAssetIdFromPrefs(sharedPreferences))
             .putExtra(GliaWidgets.UI_THEME, getRuntimeThemeFromPrefs(sharedPreferences))
-            .putExtra(GliaWidgets.USE_OVERLAY, getUseOverlay(sharedPreferences))
+//            .putExtra(GliaWidgets.USE_OVERLAY, true) // Use it to make sure this deprecated approach is still working
             .putExtra(GliaWidgets.SCREEN_SHARING_MODE, getScreenSharingModeFromPrefs(sharedPreferences))
             .putExtra(GliaWidgets.MEDIA_TYPE, Utils.toMediaType(mediaType))
         startActivity(intent)
@@ -306,12 +306,8 @@ class MainFragment : Fragment() {
         intent.putExtra(GliaWidgets.QUEUE_IDS, ArrayList(getQueueIdsFromPrefs(sharedPreferences)))
             .putExtra(GliaWidgets.CONTEXT_ASSET_ID, getContextAssetIdFromPrefs(sharedPreferences))
             .putExtra(GliaWidgets.UI_THEME, getRuntimeThemeFromPrefs(sharedPreferences))
-            .putExtra(GliaWidgets.USE_OVERLAY, getUseOverlay(sharedPreferences))
+//            .putExtra(GliaWidgets.USE_OVERLAY, true) // Use it to make sure this deprecated approach is still working
             .putExtra(GliaWidgets.SCREEN_SHARING_MODE, getScreenSharingModeFromPrefs(sharedPreferences))
-    }
-
-    private fun getUseOverlay(sharedPreferences: SharedPreferences): Boolean {
-        return Utils.getUseOverlay(sharedPreferences, resources)
     }
 
     private fun getScreenSharingModeFromPrefs(sharedPreferences: SharedPreferences): ScreenSharing.Mode {

--- a/app/src/main/java/com/glia/exampleapp/Utils.java
+++ b/app/src/main/java/com/glia/exampleapp/Utils.java
@@ -287,10 +287,6 @@ class Utils {
         return null;
     }
 
-    public static boolean getUseOverlay(SharedPreferences sharedPreferences, Resources resources) {
-        return sharedPreferences.getBoolean(resources.getString(R.string.pref_use_overlay), true);
-    }
-
     public static ScreenSharing.Mode getScreenSharingModeFromPrefs(
             SharedPreferences sharedPreferences,
             Resources resources

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,8 @@
     <string name="settings_default_queues">Default Queues</string>
     <string name="settings_queue_id">Queue id</string>
     <string name="settings_white_label">White label</string>
-    <string name="settings_use_overlay">Use Overlay</string>
+    <string name="settings_enable_bubble_outside_app">Enable bubble outside app \n (needs restart)</string>
+    <string name="settings_enable_bubble_inside_app">Enable bubble inside app \n (needs restart)</string>
     <string name="settings_remote_theme">Enable Remote Theme</string>
     <string name="settings_runtime_theme">Enable Runtime Theme</string>
     <string name="settings_visitor_context_asset_id">Visitor context asset id</string>

--- a/app/src/main/res/xml/sdk_basic_prefs.xml
+++ b/app/src/main/res/xml/sdk_basic_prefs.xml
@@ -35,8 +35,13 @@
 
         <SwitchPreference
             app:defaultValue="true"
-            app:key="@string/pref_use_overlay"
-            app:title="@string/settings_use_overlay" />
+            app:key="@string/settings_enable_bubble_outside_app"
+            app:title="@string/settings_enable_bubble_outside_app" />
+
+        <SwitchPreference
+            app:defaultValue="true"
+            app:key="@string/settings_enable_bubble_inside_app"
+            app:title="@string/settings_enable_bubble_inside_app" />
 
         <SwitchPreference
             app:defaultValue="false"

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -9,7 +9,6 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.glia.androidsdk.GliaConfig;
 import com.glia.androidsdk.GliaException;
 import com.glia.androidsdk.RequestCallback;
 import com.glia.androidsdk.visitor.Authentication;
@@ -86,16 +85,17 @@ public class GliaWidgets {
      */
     public static final String CONTEXT_ASSET_ID = "context_asset_id";
     /**
-     * Use with {@link android.os.Bundle} to pass in a boolean which represents if you would like to
-     * use the chat head bubble as an overlay as a navigation argument when
-     * navigating to {@link com.glia.widgets.chat.ChatActivity}
-     * If set to true then the chat head will appear in the overlay and the sdk will ask for
-     * overlay permissions. If false, then the {@link com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController} will notify any
-     * listening {@link com.glia.widgets.view.head.ChatHeadLayout} of any visibility changes.
-     * It is up to the integrator to integrate {@link com.glia.widgets.view.head.ChatHeadLayout} in their
-     * application.
-     * When this value is not passed then by default this value is true.
+     * It's recommended to use {@link GliaWidgetsConfig.Builder#setUseOverlay(boolean)} ()} instead of this constant directly.
+     * Use with {@link android.os.Bundle}  to pass in a boolean which represents if you would like to use the chat head bubble
+     * as an overlay outside your application for navigating to {@link com.glia.widgets.chat.ChatActivity}.
+     * If set to true then the SDK will ask for overlay permissions and try to always show the navigation bubble outside
+     * the application. However, it will be shown only if the user has accepted the permissions.
+     * If false, then overlay permission is not requested and the navigation bubble is shown when the application is active.
+     * Default value is true.
+     * @deprecated Use {@link com.glia.widgets.GliaWidgetsConfig#isEnableBubbleOutsideApp() and
+     * @link GliaWidgetsConfig#isEnableBubbleInsideApp()}
      */
+    @Deprecated
     public static final String USE_OVERLAY = "use_overlay";
     /**
      * Use with {@link android.os.Bundle} to pass an input parameter to the call activity to

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -36,7 +36,12 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
 
     @JvmField
     val screenSharingMode: ScreenSharing.Mode?
-    val isUseOverlay: Boolean?
+
+    @JvmField
+    val enableBubbleOutsideApp: Boolean?
+
+    @JvmField
+    val enableBubbleInsideApp: Boolean?
 
     @JvmField
     val uiTheme: UiTheme?
@@ -54,7 +59,8 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
         uiJsonRemoteConfig = builder.uiJsonRemoteConfig
         companyName = builder.companyName
         screenSharingMode = builder.screenSharingMode ?: DEFAULT_SCREEN_SHARING_MODE
-        isUseOverlay = builder.useOverlay
+        enableBubbleOutsideApp = builder.enableBubbleOutsideApp
+        enableBubbleInsideApp = builder.enableBubbleInsideApp
         uiTheme = builder.uiTheme
         manualLocaleOverride = builder.manualLocaleOverride
     }
@@ -124,7 +130,9 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
             private set
         var screenSharingMode: ScreenSharing.Mode? = null
             private set
-        var useOverlay: Boolean? = null
+        var enableBubbleOutsideApp: Boolean? = null
+            private set
+        var enableBubbleInsideApp: Boolean? = null
             private set
         var uiTheme: UiTheme? = null
             private set
@@ -204,11 +212,35 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
         }
 
         /**
-         * @param useOverlay - Is it allowed to overlay the application
+         * @param useOverlay - is it allowed to overlay the application
+         * @return Builder instance
+         * @deprecated Use [GliaWidgetsConfig.enableBubbleOutsideApp] and [GliaWidgetsConfig.enableBubbleInsideApp]
+         */
+        @Deprecated("Please use GliaWidgetsConfig.enableBubbleOutsideApp and GliaWidgetsConfig.enableBubbleInsideApp")
+        fun setUseOverlay(useOverlay: Boolean): Builder {
+            Logger.logDeprecatedMethodUse(TAG, "GliaWidgetsConfig.setUseOverlay()")
+            this.enableBubbleOutsideApp = useOverlay
+            this.enableBubbleInsideApp = useOverlay
+            return this
+        }
+
+        /**
+         * @param enableBubbleOutsideApp - is bubble enabled outside the app
          * @return Builder instance
          */
-        fun setUseOverlay(useOverlay: Boolean): Builder {
-            this.useOverlay = useOverlay
+        fun enableBubbleOutsideApp(enableBubbleOutsideApp: Boolean): Builder {
+            Logger.i(TAG, "Bubble: enable outside app $enableBubbleOutsideApp")
+            this.enableBubbleOutsideApp = enableBubbleOutsideApp
+            return this
+        }
+
+        /**
+         * @param enableBubbleInsideApp - is bubble enabled inside the app
+         * @return Builder instance
+         */
+        fun enableBubbleInsideApp(enableBubbleInsideApp: Boolean): Builder {
+            Logger.i(TAG, "Bubble: enable inside app $enableBubbleInsideApp")
+            this.enableBubbleInsideApp = enableBubbleInsideApp
             return this
         }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivityIntentHelper.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivityIntentHelper.kt
@@ -5,33 +5,32 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.glia.androidsdk.Engagement
 import com.glia.widgets.GliaWidgets
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import java.util.ArrayList
 
 internal object CallActivityIntentHelper {
 
     @JvmStatic
-    fun createIntent(context: Context, configuration: Configuration): Intent {
-        val sdkConfiguration = configuration.sdkConfiguration ?: throw NullPointerException("WidgetsSdk Configuration can't be null")
+    fun createIntent(context: Context, callConfiguration: CallConfiguration): Intent {
+        val sdkConfiguration = callConfiguration.engagementConfiguration ?: throw NullPointerException("WidgetsSdk Configuration can't be null")
 
         return Intent(context, CallActivity::class.java)
             .putExtra(GliaWidgets.QUEUE_IDS, sdkConfiguration.queueIds?.let { ArrayList(it) })
             .putExtra(GliaWidgets.CONTEXT_ASSET_ID, sdkConfiguration.contextAssetId)
             .putExtra(GliaWidgets.UI_THEME, sdkConfiguration.runTimeTheme)
-            .putExtra(GliaWidgets.USE_OVERLAY, sdkConfiguration.useOverlay)
             .putExtra(GliaWidgets.SCREEN_SHARING_MODE, sdkConfiguration.screenSharingMode)
-            .putExtra(GliaWidgets.MEDIA_TYPE, configuration.mediaType)
-            .putExtra(GliaWidgets.IS_UPGRADE_TO_CALL, configuration.isUpgradeToCall)
+            .putExtra(GliaWidgets.MEDIA_TYPE, callConfiguration.mediaType)
+            .putExtra(GliaWidgets.IS_UPGRADE_TO_CALL, callConfiguration.isUpgradeToCall)
     }
 
     @JvmStatic
-    fun readConfiguration(activity: AppCompatActivity): Configuration {
+    fun readConfiguration(activity: AppCompatActivity): CallConfiguration {
         val intent = activity.intent
-        val sdkConfiguration = GliaSdkConfiguration.Builder().intent(intent).build()
+        val engagementConfiguration = EngagementConfiguration.Builder().intent(intent).build()
         val mediaType = intent.getSerializableExtra(GliaWidgets.MEDIA_TYPE) as Engagement.MediaType?
         val isUpgradeToCall = intent.getBooleanExtra(GliaWidgets.IS_UPGRADE_TO_CALL, false)
-        return Configuration.Builder()
-            .setWidgetsConfiguration(sdkConfiguration)
+        return CallConfiguration.Builder()
+            .setEngagementConfiguration(engagementConfiguration)
             .setMediaType(mediaType)
             .setIsUpgradeToCall(isUpgradeToCall)
             .build()

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallConfiguration.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallConfiguration.kt
@@ -1,33 +1,33 @@
 package com.glia.widgets.call
 
 import com.glia.androidsdk.Engagement
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.helper.Utils
 
-internal class Configuration private constructor(builder: Builder) {
+internal class CallConfiguration private constructor(builder: Builder) {
     @JvmField
-    val sdkConfiguration: GliaSdkConfiguration?
+    val engagementConfiguration: EngagementConfiguration?
     @JvmField
     val mediaType: Engagement.MediaType?
     @JvmField
     val isUpgradeToCall: Boolean
 
     init {
-        sdkConfiguration = builder.widgetsConfiguration
+        engagementConfiguration = builder.engagementConfiguration
         mediaType = builder.mediaType
         isUpgradeToCall = builder.isUpgradeToCall
     }
 
     class Builder {
-        var widgetsConfiguration: GliaSdkConfiguration? = null
+        var engagementConfiguration: EngagementConfiguration? = null
             private set
         var mediaType: Engagement.MediaType? = null
             private set
         var isUpgradeToCall = false
             private set
 
-        fun setWidgetsConfiguration(configuration: GliaSdkConfiguration?) = apply {
-            widgetsConfiguration = configuration
+        fun setEngagementConfiguration(engagementConfiguration: EngagementConfiguration?) = apply {
+            this.engagementConfiguration = engagementConfiguration
         }
 
         fun setMediaType(mediaType: Engagement.MediaType?) = apply {
@@ -43,8 +43,8 @@ internal class Configuration private constructor(builder: Builder) {
         }
 
 
-        fun build(): Configuration {
-            return Configuration(this)
+        fun build(): CallConfiguration {
+            return CallConfiguration(this)
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallContract.kt
@@ -26,7 +26,6 @@ internal interface CallContract {
             queueIds: List<String>?,
             visitorContextAssetId: String?,
             mediaType: Engagement.MediaType?,
-            useOverlays: Boolean,
             screenSharingMode: ScreenSharing.Mode,
             upgradeToCall: Boolean
         )

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -189,17 +189,26 @@ internal class CallController(
         queueIds: List<String>?,
         visitorContextAssetId: String?,
         mediaType: Engagement.MediaType?,
-        useOverlays: Boolean,
         screenSharingMode: ScreenSharing.Mode,
         upgradeToCall: Boolean
     ) {
         if (upgradeToCall || mediaType == null) {
-            initCall(companyName, queueIds, visitorContextAssetId, mediaType, useOverlays, screenSharingMode)
+            initCall(
+                companyName,
+                queueIds,
+                visitorContextAssetId,
+                mediaType,
+                screenSharingMode)
             return
         }
         handleCallPermissionsUseCase.invoke(mediaType) { isPermissionsGranted: Boolean ->
             if (isPermissionsGranted) {
-                initCall(companyName, queueIds, visitorContextAssetId, mediaType, useOverlays, screenSharingMode)
+                initCall(
+                    companyName,
+                    queueIds,
+                    visitorContextAssetId,
+                    mediaType,
+                    screenSharingMode)
             } else {
                 view?.showMissingPermissionsDialog()
             }
@@ -211,10 +220,8 @@ internal class CallController(
         queueIds: List<String>?,
         visitorContextAssetId: String?,
         mediaType: Engagement.MediaType?,
-        useOverlays: Boolean,
         screenSharingMode: ScreenSharing.Mode
     ) {
-        sdkConfigurationManager.isUseOverlay = useOverlays
         sdkConfigurationManager.screenSharingMode = screenSharingMode
         if (isShowOverlayPermissionRequestDialogUseCase()) {
             dialogController.showOverlayPermissionsDialog()

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -28,7 +28,7 @@ import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.glia.widgets.UiTheme.UiThemeBuilder
 import com.glia.widgets.call.CallState.ViewState
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.databinding.CallButtonsLayoutBinding
@@ -174,7 +174,6 @@ internal class CallView(
         companyName: String,
         queueIds: List<String>?,
         visitorContextAssetId: String?,
-        useOverlays: Boolean,
         screenSharingMode: ScreenSharing.Mode,
         isUpgradeToCall: Boolean,
         mediaType: Engagement.MediaType?
@@ -184,7 +183,6 @@ internal class CallView(
             queueIds,
             visitorContextAssetId,
             mediaType,
-            useOverlays,
             screenSharingMode,
             isUpgradeToCall
         )
@@ -685,9 +683,9 @@ internal class CallView(
         callController?.onUserInteraction()
     }
 
-    fun setConfiguration(configuration: GliaSdkConfiguration?) {
+    fun setEngagementConfiguration(engagementConfiguration: EngagementConfiguration?) {
         serviceChatHeadController?.setBuildTimeTheme(theme)
-        serviceChatHeadController?.setSdkConfiguration(configuration)
+        serviceChatHeadController?.setEngagementConfiguration(engagementConfiguration)
     }
 
     override fun showToast(message: String) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -43,7 +43,7 @@ import com.glia.widgets.chat.model.ChatInputMode
 import com.glia.widgets.chat.model.ChatItem
 import com.glia.widgets.chat.model.ChatState
 import com.glia.widgets.chat.model.CustomCardChatItem
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.core.fileupload.model.FileAttachment
@@ -217,7 +217,6 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
      * @param companyName Text shown in the chat while waiting in a queue.
      * @param queueIds    The queue ids to which you would like to queue to and speak to operators from.
      * @param visitorContextAssetId  Provide some context asset ID as to from where are you initiating the chat from.
-     * @param useOverlays Used to set if the user opted to use overlays or not.
      * @see [com.glia.widgets.GliaWidgets].USE_OVERLAY to see its full usage description.
      * Important! This parameter is ignored if the view is not used in the sdk's [ChatActivity]
      */
@@ -226,11 +225,9 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         companyName: String?,
         queueIds: List<String>?,
         visitorContextAssetId: String?,
-        useOverlays: Boolean? = null,
         screenSharingMode: ScreenSharing.Mode? = null,
         chatType: ChatType = ChatType.LIVE_CHAT
     ) {
-        useOverlays?.also { Dependencies.sdkConfigurationManager.isUseOverlay = it }
         Dependencies.sdkConfigurationManager.screenSharingMode = screenSharingMode
         dialogCallback?.also { dialogController?.addCallback(it) }
         controller?.initChat(companyName, queueIds, visitorContextAssetId, chatType)
@@ -850,9 +847,9 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         controller?.onImageItemClick(item, view)
     }
 
-    fun setConfiguration(configuration: GliaSdkConfiguration?) {
+    fun setConfiguration(configuration: EngagementConfiguration?) {
         serviceChatHeadController?.setBuildTimeTheme(theme)
-        serviceChatHeadController?.setSdkConfiguration(configuration)
+        serviceChatHeadController?.setEngagementConfiguration(configuration)
     }
 
     override fun showToast(message: String, duration: Int) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayApplicationChatHeadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayApplicationChatHeadUseCase.kt
@@ -22,7 +22,13 @@ internal class IsDisplayApplicationChatHeadUseCase(
     configurationManager,
     engagementTypeUseCase
 ) {
-    override fun isDisplayBasedOnPermission(): Boolean {
-        return !permissionManager.hasOverlayPermission()
+    override fun isBubbleEnabled(): Boolean {
+        return configurationManager.isEnableBubbleInsideApp
+    }
+
+    override fun isShowBasedOnForegroundBackground(viewName: String?): Boolean {
+        return viewName != null && // App is in foreground
+            // Use only ChatHeadService instead of ChatHeadService + app bubble if bubble is enabled outside and inside
+            (!configurationManager.isEnableBubbleOutsideApp || !configurationManager.isEnableBubbleInsideApp || !permissionManager.hasOverlayPermission())
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/EngagementConfiguration.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/EngagementConfiguration.kt
@@ -9,14 +9,13 @@ import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.Logger.logDeprecatedMethodUse
 import com.glia.widgets.helper.TAG
 
-internal class GliaSdkConfiguration private constructor(builder: Builder) {
+internal class EngagementConfiguration private constructor(builder: Builder) {
     val companyName: String?
     val queueIds: List<String>?
     val contextAssetId: String?
     private val contextUrl: String?
     val runTimeTheme: UiTheme?
         get() = field ?: Dependencies.sdkConfigurationManager.uiTheme
-    val useOverlay: Boolean?
     val screenSharingMode: ScreenSharing.Mode?
         get() = field ?: Dependencies.sdkConfigurationManager.screenSharingMode
     val chatType: ChatType?
@@ -28,7 +27,6 @@ internal class GliaSdkConfiguration private constructor(builder: Builder) {
         contextAssetId = builder.contextAssetId
         contextUrl = builder.contextUrl
         runTimeTheme = builder.runTimeTheme
-        useOverlay = builder.useOverlay
         screenSharingMode = builder.screenSharingMode
         chatType = builder.chatType
         manualStringOverrideL = builder.manualLocaleOverride
@@ -46,7 +44,6 @@ internal class GliaSdkConfiguration private constructor(builder: Builder) {
         var contextAssetId: String? = null
         var contextUrl: String? = null
         var runTimeTheme: UiTheme? = null
-        var useOverlay: Boolean? = null
         var screenSharingMode: ScreenSharing.Mode? = null
         var chatType: ChatType? = null
         var manualLocaleOverride: String? = null
@@ -87,11 +84,6 @@ internal class GliaSdkConfiguration private constructor(builder: Builder) {
             return this
         }
 
-        fun useOverlay(useOverlay: Boolean): Builder {
-            this.useOverlay = useOverlay
-            return this
-        }
-
         fun screenSharingMode(screenSharingMode: ScreenSharing.Mode?): Builder {
             this.screenSharingMode = screenSharingMode
             return this
@@ -112,10 +104,6 @@ internal class GliaSdkConfiguration private constructor(builder: Builder) {
             val tempTheme = intent.getParcelableExtra<UiTheme>(GliaWidgets.UI_THEME)
             runTimeTheme = tempTheme ?: Dependencies.sdkConfigurationManager.uiTheme
             contextAssetId = intent.getStringExtra(GliaWidgets.CONTEXT_ASSET_ID)
-            useOverlay = intent.getBooleanExtra(
-                GliaWidgets.USE_OVERLAY,
-                Dependencies.sdkConfigurationManager.isUseOverlay
-            )
             val tempMode =
                 if (intent.hasExtra(GliaWidgets.SCREEN_SHARING_MODE)) intent.getSerializableExtra(
                     GliaWidgets.SCREEN_SHARING_MODE
@@ -127,8 +115,8 @@ internal class GliaSdkConfiguration private constructor(builder: Builder) {
             return this
         }
 
-        fun build(): GliaSdkConfiguration {
-            return GliaSdkConfiguration(this)
+        fun build(): EngagementConfiguration {
+            return EngagementConfiguration(this)
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/configuration/GliaSdkConfigurationManager.java
@@ -3,12 +3,11 @@ package com.glia.widgets.core.configuration;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
-import com.glia.androidsdk.Glia;
 import com.glia.androidsdk.screensharing.ScreenSharing;
 import com.glia.widgets.GliaWidgetsConfig;
-import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
 import com.glia.widgets.di.Dependencies;
+import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.ResourceProvider;
 
 import org.jetbrains.annotations.Nullable;
@@ -18,10 +17,13 @@ import org.jetbrains.annotations.Nullable;
  */
 public class GliaSdkConfigurationManager {
 
+    private static final String TAG = GliaSdkConfigurationManager.class.getSimpleName();
+
     private ScreenSharing.Mode screenSharingMode = null;
     private String companyName = null;
     private String legacyCompanyName = null;
-    private boolean useOverlay = true;
+    private boolean enableBubbleOutsideApp = true; // default values
+    private boolean enableBubbleInsideApp = true; // default values
 
     private UiTheme uiTheme = null;
 
@@ -30,18 +32,33 @@ public class GliaSdkConfigurationManager {
         this.companyName = configuration.companyName;
         this.uiTheme = configuration.uiTheme;
 
-        Boolean useOverlay = configuration.isUseOverlay();
-        if (useOverlay != null) {
-            this.useOverlay = useOverlay;
+        Boolean enableBubbleOutsideApp = configuration.enableBubbleOutsideApp;
+        if (enableBubbleOutsideApp != null) {
+            this.enableBubbleOutsideApp = enableBubbleOutsideApp;
+        }
+
+        Boolean enableBubbleInsideApp = configuration.enableBubbleInsideApp;
+        if (enableBubbleInsideApp != null) {
+            this.enableBubbleInsideApp = enableBubbleInsideApp;
         }
     }
 
-    public boolean isUseOverlay() {
-        return this.useOverlay;
+    public boolean isEnableBubbleOutsideApp() {
+        return this.enableBubbleOutsideApp;
     }
 
-    public void setUseOverlay(boolean useOverlay) {
-        this.useOverlay = useOverlay;
+    public boolean isEnableBubbleInsideApp() {
+        return this.enableBubbleInsideApp;
+    }
+
+    /**
+     * @deprecated Should be removed together with GliaWidgetsConfig.USE_OVERLAY
+     */
+    @Deprecated
+    public void setLegacyUseOverlay(boolean useOverlay) {
+        Logger.logDeprecatedMethodUse(TAG, "setLegacyUseOverlay()");
+        this.enableBubbleOutsideApp = useOverlay;
+        this.enableBubbleInsideApp = useOverlay;
     }
 
     public void setLegacyCompanyName(String companyName) {
@@ -82,11 +99,10 @@ public class GliaSdkConfigurationManager {
     }
 
     @Nullable
-    public GliaSdkConfiguration createWidgetsConfiguration() {
-        return new GliaSdkConfiguration.Builder()
+    public EngagementConfiguration buildEngagementConfiguration() {
+        return new EngagementConfiguration.Builder()
                 .companyName(companyName)
                 .screenSharingMode(screenSharingMode)
-                .useOverlay(useOverlay)
                 .runTimeTheme(uiTheme)
                 .build();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/dialog/domain/IsShowOverlayPermissionRequestDialogUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/dialog/domain/IsShowOverlayPermissionRequestDialogUseCase.kt
@@ -15,7 +15,7 @@ internal class IsShowOverlayPermissionRequestDialogUseCaseImpl(
 ) : IsShowOverlayPermissionRequestDialogUseCase {
     private val hasNoOverlayPermissions: Boolean get() = !permissionManager.hasOverlayPermission()
     private val hasNotShownOverlayPermissionRequest: Boolean get() = !permissionDialogManager.hasOverlayPermissionDialogShown()
-    private val isUseOverlay: Boolean get() = gliaSdkConfigurationManager.isUseOverlay
+    private val isUseOverlay: Boolean get() = gliaSdkConfigurationManager.isEnableBubbleOutsideApp
 
     override fun invoke(): Boolean = hasNoOverlayPermissions && hasNotShownOverlayPermissionRequest && isUseOverlay
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/IntentConfigurationHelper.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/IntentConfigurationHelper.kt
@@ -6,7 +6,7 @@ import android.provider.Settings
 import androidx.core.net.toUri
 import com.glia.androidsdk.Engagement.MediaType
 import com.glia.widgets.call.CallActivity
-import com.glia.widgets.call.Configuration
+import com.glia.widgets.call.CallConfiguration
 import com.glia.widgets.di.Dependencies
 
 internal interface IntentConfigurationHelper {
@@ -16,10 +16,10 @@ internal interface IntentConfigurationHelper {
 }
 
 internal class IntentConfigurationHelperImpl : IntentConfigurationHelper {
-    private val defaultBuilder: Configuration.Builder
+    private val defaultBuilder: CallConfiguration.Builder
         get() = Dependencies.sdkConfigurationManager
-            .createWidgetsConfiguration()
-            .let(Configuration.Builder()::setWidgetsConfiguration)
+            .buildEngagementConfiguration()
+            .let(CallConfiguration.Builder()::setEngagementConfiguration)
 
     override fun createForCall(context: Context, mediaType: MediaType, upgradeToCall: Boolean): Intent = defaultBuilder
         .setMediaType(mediaType)

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterContract.kt
@@ -4,13 +4,13 @@ import android.net.Uri
 import com.glia.widgets.UiTheme
 import com.glia.widgets.base.BaseController
 import com.glia.widgets.base.BaseView
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.fileupload.model.FileAttachment
 
 internal interface MessageCenterContract {
     interface Controller : BaseController {
-        fun setConfiguration(uiTheme: UiTheme?, configuration: GliaSdkConfiguration?)
+        fun setConfiguration(uiTheme: UiTheme?, configuration: EngagementConfiguration?)
         fun setView(view: View)
         fun initialize()
         fun onCheckMessagesClicked()

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
@@ -14,7 +14,7 @@ import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
 import com.glia.widgets.chat.domain.TakePictureUseCase
 import com.glia.widgets.chat.domain.UriToFileAttachmentUseCase
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.engagement.domain.SetEngagementConfigUseCase
 import com.glia.widgets.core.fileupload.domain.AddFileToAttachmentAndUploadUseCase
@@ -61,11 +61,11 @@ internal class MessageCenterController(
     @Volatile
     private var state = MessageCenterState()
 
-    override fun setConfiguration(uiTheme: UiTheme?, configuration: GliaSdkConfiguration?) {
+    override fun setConfiguration(uiTheme: UiTheme?, configuration: EngagementConfiguration?) {
         setQueueIds(configuration?.queueIds)
 
         serviceChatHeadController.setBuildTimeTheme(uiTheme)
-        serviceChatHeadController.setSdkConfiguration(configuration)
+        serviceChatHeadController.setEngagementConfiguration(configuration)
     }
 
     private fun setQueueIds(queueIds: List<String>?) {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterView.kt
@@ -21,7 +21,7 @@ import com.glia.widgets.Constants
 import com.glia.widgets.locale.LocaleString
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.core.fileupload.model.FileAttachment
@@ -182,7 +182,7 @@ internal class MessageCenterView(
         }
     }
 
-    fun setConfiguration(configuration: GliaSdkConfiguration?) {
+    fun setConfiguration(configuration: EngagementConfiguration?) {
         controller?.setConfiguration(theme, configuration)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadContract.kt
@@ -1,10 +1,9 @@
 package com.glia.widgets.view.head
 
-import android.view.View
 import com.glia.widgets.UiTheme
 import com.glia.widgets.base.BaseController
 import com.glia.widgets.base.BaseView
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 
 internal interface ChatHeadContract {
     interface Controller : BaseController {
@@ -14,7 +13,7 @@ internal interface ChatHeadContract {
         fun onApplicationStop()
         fun onChatHeadPositionChanged(x: Int, y: Int)
         fun setBuildTimeTheme(uiTheme: UiTheme?)
-        fun setSdkConfiguration(configuration: GliaSdkConfiguration?)
+        fun setEngagementConfiguration(configuration: EngagementConfiguration?)
         fun onPause(gliaOrRootView: android.view.View?)
         fun updateChatHeadView()
         fun onSetChatHeadView(view: View)
@@ -31,6 +30,6 @@ internal interface ChatHeadContract {
         fun navigateToChat()
         fun navigateToCall()
         fun navigateToEndScreenSharing()
-        fun updateConfiguration(buildTimeTheme: UiTheme, sdkConfiguration: GliaSdkConfiguration?)
+        fun updateConfiguration(buildTimeTheme: UiTheme, engagementConfiguration: EngagementConfiguration?)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadLayout.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadLayout.kt
@@ -9,7 +9,7 @@ import androidx.core.view.ViewCompat
 import com.glia.widgets.Constants
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.databinding.ChatHeadLayoutBinding
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.Utils
@@ -195,9 +195,9 @@ internal class ChatHeadLayout @JvmOverloads constructor(
 
     private fun updateChatHeadConfiguration(
         buildTimeTheme: UiTheme,
-        sdkConfiguration: GliaSdkConfiguration? = null
+        engagementConfiguration: EngagementConfiguration? = null
     ) {
-        chatHeadView.updateConfiguration(buildTimeTheme, sdkConfiguration)
+        chatHeadView.updateConfiguration(buildTimeTheme, engagementConfiguration)
     }
 
     private fun onChatHeadDragged(x: Float, y: Float) {
@@ -221,7 +221,7 @@ internal class ChatHeadLayout @JvmOverloads constructor(
     }
 
     fun interface OnChatHeadClickedListener {
-        fun onClicked(chatHeadInput: GliaSdkConfiguration?)
+        fun onClicked(engagementConfiguration: EngagementConfiguration?)
     }
 
     interface NavigationCallback {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadView.kt
@@ -18,11 +18,11 @@ import com.glia.widgets.GliaWidgets
 import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.glia.widgets.call.CallActivity
-import com.glia.widgets.call.Configuration
+import com.glia.widgets.call.CallConfiguration
 import com.glia.widgets.callvisualizer.EndScreenSharingActivity
 import com.glia.widgets.chat.ChatActivity
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.databinding.ChatHeadViewBinding
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
@@ -32,7 +32,6 @@ import com.glia.widgets.helper.getColorCompat
 import com.glia.widgets.helper.getColorStateListCompat
 import com.glia.widgets.helper.layoutInflater
 import com.glia.widgets.helper.load
-import com.glia.widgets.helper.setContentDescription
 import com.glia.widgets.helper.setLocaleContentDescription
 import com.glia.widgets.view.configuration.ChatHeadConfiguration
 import com.glia.widgets.view.unifiedui.applyColorTheme
@@ -55,7 +54,7 @@ internal class ChatHeadView @JvmOverloads constructor(
     defStyleRes
 ), ChatHeadContract.View {
     private val binding by lazy { ChatHeadViewBinding.inflate(layoutInflater, this) }
-    private var sdkConfiguration: GliaSdkConfiguration? = null
+    private var engagementConfiguration: EngagementConfiguration? = null
     private var configuration: ChatHeadConfiguration by Delegates.notNull()
 
     private val isService by lazy { context is Service }
@@ -165,11 +164,11 @@ internal class ChatHeadView @JvmOverloads constructor(
 
     override fun updateConfiguration(
         buildTimeTheme: UiTheme,
-        sdkConfiguration: GliaSdkConfiguration?
+        engagementConfiguration: EngagementConfiguration?
     ) {
-        this.sdkConfiguration = sdkConfiguration
+        this.engagementConfiguration = engagementConfiguration
         serviceChatHeadController.setBuildTimeTheme(buildTimeTheme)
-        createHybridConfiguration(buildTimeTheme, sdkConfiguration)
+        createHybridConfiguration(buildTimeTheme, engagementConfiguration)
         post { updateView() }
     }
 
@@ -190,14 +189,14 @@ internal class ChatHeadView @JvmOverloads constructor(
     }
 
     override fun navigateToChat() {
-        sdkConfiguration?.let {
+        engagementConfiguration?.let {
             context.startActivity(getNavigationIntent(context, ChatActivity::class.java, it))
         }
     }
 
     override fun navigateToCall() {
         val activityConfig =
-            Configuration.Builder().setWidgetsConfiguration(sdkConfiguration).build()
+            CallConfiguration.Builder().setEngagementConfiguration(engagementConfiguration).build()
 
         val intent = CallActivity.getIntent(context, activityConfig)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -226,10 +225,10 @@ internal class ChatHeadView @JvmOverloads constructor(
 
     private fun createHybridConfiguration(
         buildTimeTheme: UiTheme,
-        sdkConfiguration: GliaSdkConfiguration?
+        engagementConfiguration: com.glia.widgets.core.configuration.EngagementConfiguration?
     ) {
         configuration = createBuildTimeConfiguration(buildTimeTheme)
-        val runTimeTheme = sdkConfiguration?.runTimeTheme ?: return
+        val runTimeTheme = engagementConfiguration?.runTimeTheme ?: return
 
         val builder = ChatHeadConfiguration.builder(configuration)
 
@@ -331,13 +330,12 @@ internal class ChatHeadView @JvmOverloads constructor(
         private fun getNavigationIntent(
             context: Context,
             cls: Class<*>,
-            sdkConfiguration: GliaSdkConfiguration
+            engagementConfiguration: EngagementConfiguration
         ): Intent = Intent(context, cls)
-            .putExtra(GliaWidgets.QUEUE_IDS, sdkConfiguration.queueIds?.let { ArrayList(it) })
-            .putExtra(GliaWidgets.CONTEXT_ASSET_ID, sdkConfiguration.contextAssetId)
-            .putExtra(GliaWidgets.UI_THEME, sdkConfiguration.runTimeTheme)
-            .putExtra(GliaWidgets.USE_OVERLAY, sdkConfiguration.useOverlay)
-            .putExtra(GliaWidgets.SCREEN_SHARING_MODE, sdkConfiguration.screenSharingMode)
+            .putExtra(GliaWidgets.QUEUE_IDS, engagementConfiguration.queueIds?.let { ArrayList(it) })
+            .putExtra(GliaWidgets.CONTEXT_ASSET_ID, engagementConfiguration.contextAssetId)
+            .putExtra(GliaWidgets.UI_THEME, engagementConfiguration.runTimeTheme)
+            .putExtra(GliaWidgets.SCREEN_SHARING_MODE, engagementConfiguration.screenSharingMode)
             .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
@@ -7,7 +7,7 @@ import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharing
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
 import com.glia.widgets.core.chathead.domain.ToggleChatHeadServiceUseCase
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -38,7 +38,7 @@ internal class ServiceChatHeadController(
     private var operatorProfileImgUrl: String? = null
     private var unreadMessagesCount = 0
     private var isOnHold = false
-    private var sdkConfiguration: GliaSdkConfiguration? = null
+    private var engagementConfiguration: EngagementConfiguration? = null
     private var buildTimeTheme: UiTheme? = null
 
     /*
@@ -101,8 +101,8 @@ internal class ServiceChatHeadController(
         updateChatHeadView()
     }
 
-    override fun setSdkConfiguration(configuration: GliaSdkConfiguration?) {
-        sdkConfiguration = configuration
+    override fun setEngagementConfiguration(engagementConfiguration: EngagementConfiguration?) {
+        this.engagementConfiguration = engagementConfiguration
     }
 
     private fun handleEngagementState(state: com.glia.widgets.engagement.State) {
@@ -142,7 +142,7 @@ internal class ServiceChatHeadController(
             updateChatHeadViewState()
             updateOnHold()
             chatHeadView!!.showUnreadMessageCount(unreadMessagesCount)
-            chatHeadView!!.updateConfiguration(buildTimeTheme!!, sdkConfiguration)
+            chatHeadView!!.updateConfiguration(buildTimeTheme!!, engagementConfiguration)
         }
     }
 
@@ -164,8 +164,8 @@ internal class ServiceChatHeadController(
         isOnHold = false
         state = State.ENGAGEMENT
         toggleChatHeadServiceUseCase(resumedViewName)
-        if (sdkConfiguration == null) setSdkConfiguration(
-            Dependencies.sdkConfigurationManager.createWidgetsConfiguration()
+        if (engagementConfiguration == null) setEngagementConfiguration(
+            Dependencies.sdkConfigurationManager.buildEngagementConfiguration()
         )
         updateChatHeadView()
     }
@@ -173,8 +173,8 @@ internal class ServiceChatHeadController(
     private fun queueingStarted() {
         state = State.QUEUEING
         toggleChatHeadServiceUseCase(resumedViewName)
-        if (sdkConfiguration == null) setSdkConfiguration(
-            Dependencies.sdkConfigurationManager.createWidgetsConfiguration()
+        if (engagementConfiguration == null) setEngagementConfiguration(
+            Dependencies.sdkConfigurationManager.buildEngagementConfiguration()
         )
         updateChatHeadView()
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/configuration/EngagementCallConfigurationManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/configuration/EngagementCallConfigurationManagerTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 
 private const val DEFAULT_LOCAL_COMPANY_NAME = "Local Company Name"
 
-class GliaSdkConfigurationManagerTest {
+class EngagementCallConfigurationManagerTest {
 
     private val configurationManager: GliaSdkConfigurationManager = GliaSdkConfigurationManager()
     private val resourceProvider: ResourceProvider = mockk()

--- a/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
@@ -8,7 +8,7 @@ import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.chat.domain.SiteInfoUseCase
 import com.glia.widgets.chat.domain.TakePictureUseCase
 import com.glia.widgets.chat.domain.UriToFileAttachmentUseCase
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.engagement.domain.SetEngagementConfigUseCase
 import com.glia.widgets.core.fileupload.model.FileAttachment
@@ -110,11 +110,11 @@ internal class MessageCenterControllerTest {
     }
 
     @Test
-    fun setConfiguration_setSdkConfiguration_onTrigger() {
-        val configuration = mock<GliaSdkConfiguration>()
+    fun setConfiguration_setEngagementConfiguration_onTrigger() {
+        val configuration = mock<EngagementConfiguration>()
         messageCenterController.setConfiguration(mock(), configuration)
 
-        verify(serviceChatHeadController, times(1)).setSdkConfiguration(configuration)
+        verify(serviceChatHeadController, times(1)).setEngagementConfiguration(configuration)
     }
 
     @Test

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/view/head/ChatHeadViewSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/view/head/ChatHeadViewSnapshotTest.kt
@@ -4,7 +4,7 @@ import com.glia.widgets.R
 import com.glia.widgets.SnapshotTest
 import com.glia.widgets.UiTheme
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
-import com.glia.widgets.core.configuration.GliaSdkConfiguration
+import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.di.ControllerFactory
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.di.UseCaseFactory
@@ -305,7 +305,7 @@ class ChatHeadViewSnapshotTest : SnapshotTest(
         unifiedTheme: UnifiedTheme? = null,
         uiTheme: UiTheme = UiTheme(),
         executor: Executor? = Executor(Runnable::run),
-        sdkConfiguration: GliaSdkConfiguration? = sdkConfiguration(uiTheme),
+        sdkConfiguration: EngagementConfiguration? = sdkConfiguration(uiTheme),
         isCallVisualizerScreenSharingUseCase: Boolean = false
     ): ChatHeadView {
         lottieMock()
@@ -341,7 +341,7 @@ class ChatHeadViewSnapshotTest : SnapshotTest(
     private fun sdkConfiguration(
         uiTheme: UiTheme = UiTheme(),
         chatHeadConfiguration: ChatHeadConfiguration = chatHeadConfiguration()
-    ) = mock<GliaSdkConfiguration>().also {
+    ) = mock<EngagementConfiguration>().also {
         whenever(it.runTimeTheme).thenReturn(uiTheme.copy(chatHeadConfiguration = chatHeadConfiguration))
     }
     private fun chatHeadConfiguration() = ChatHeadConfiguration.Builder()


### PR DESCRIPTION
**Jira issue:**
[[Android] Fix bubble behavior when overlay flag is disabled](https://glia.atlassian.net/browse/MOB-3281)

[Requirements](https://glia.atlassian.net/wiki/spaces/ENG/pages/3305340989/The+Glia+Bubble+for+Mobile)

[Slack discussion](https://salemove.slack.com/archives/CHN6UB7UH/p1719927857421199?thread_ts=1713515423.754129&cid=CHN6UB7UH)

**What was solved?**
1. Deprecated the `use_overlay` setting because currently it’s not just turning off using overlay, but it disables a bubble.
2. Introduced a new configuration for SDK initialization: `enableBubbleOutsideApp(true/false)`. The default value is true.
3. Introduced a new configuration for SDK initialization: `enableBubbleInsideApp(true/false)`. The default value is true.
4. Regardless the passed value, a bubble on chat screen during audio/video engagement is shown all the time. This will allow to get back to Call screen even if bubble is disabled.
5. Renamed configuration classes so that the name gave a better idea of a class purpose. Otherwise, I was not able to deal with bubble configuration.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?): `Provide separate settings to enable/disable a bubble outside or inside an app`
 - [x] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please) `Use GliaWidgetsConfig.isEnableBubbleOutsideApp() and GliaWidgetsConfig.isEnableBubbleInsideApp() instead of GliaWidgetsConfig.setUseOverlay()`

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

I have replaced the original "Use overlay" setting with two new settings:

<img width="271" alt="Screenshot 2024-08-24 at 12 58 00" src="https://github.com/user-attachments/assets/8c9ad73e-5257-4fc1-82d9-4ad907e7cb4f">
