### PR TITLE
Remove no history flag for file preview activity

### DIFF
--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -45,7 +45,6 @@
         <activity
             android:name=".filepreview.ui.FilePreviewActivity"
             android:launchMode="singleTop"
-            android:noHistory="true"
             android:parentActivityName=".chat.ChatActivity"
             android:theme="@style/Application.Glia.FilePreview.Activity" />
         <activity


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3528

**What was solved?**
With this noHistory flag, the FilePreview screen will be closed when the app is returned from the background.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
