### PR TITLE
Rename bubble use cases to align the terminology

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayBubbleInsideAppUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayBubbleInsideAppUseCase.kt
@@ -7,14 +7,14 @@ import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCa
 import com.glia.widgets.engagement.domain.IsQueueingOrEngagementUseCase
 import com.glia.widgets.engagement.domain.ScreenSharingUseCase
 
-internal class IsDisplayApplicationChatHeadUseCase(
+internal class IsDisplayBubbleInsideAppUseCase(
     isQueueingOrEngagementUseCase: IsQueueingOrEngagementUseCase,
     isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase,
     screenSharingUseCase: ScreenSharingUseCase,
     permissionManager: PermissionManager,
     configurationManager: GliaSdkConfigurationManager,
     engagementTypeUseCase: EngagementTypeUseCase
-) : IsDisplayChatHeadUseCase(
+) : IsDisplayBubbleUseCase(
     isQueueingOrEngagementUseCase,
     isCurrentEngagementCallVisualizerUseCase,
     screenSharingUseCase,

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayBubbleOutsideAppUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayBubbleOutsideAppUseCase.kt
@@ -15,7 +15,7 @@ import com.glia.widgets.helper.TAG
  * 1) determines whether the chat head (bubble) should be displayed
  * 2) starts or stops the chat head service (bubble outside the app)
  */
-internal class ToggleChatHeadServiceUseCase(
+internal class IsDisplayBubbleOutsideAppUseCase(
     isQueueingOrEngagementUseCase: IsQueueingOrEngagementUseCase,
     isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase,
     screenSharingUseCase: ScreenSharingUseCase,
@@ -23,7 +23,7 @@ internal class ToggleChatHeadServiceUseCase(
     permissionManager: PermissionManager,
     configurationManager: GliaSdkConfigurationManager,
     engagementTypeUseCase: EngagementTypeUseCase
-) : IsDisplayChatHeadUseCase(
+) : IsDisplayBubbleUseCase(
     isQueueingOrEngagementUseCase,
     isCurrentEngagementCallVisualizerUseCase,
     screenSharingUseCase,

--- a/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayBubbleUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/chathead/domain/IsDisplayBubbleUseCase.kt
@@ -13,7 +13,7 @@ import com.glia.widgets.filepreview.ui.FilePreviewView
 import com.glia.widgets.helper.DialogHolderView
 import com.glia.widgets.messagecenter.MessageCenterView
 
-internal abstract class IsDisplayChatHeadUseCase(
+internal abstract class IsDisplayBubbleUseCase(
     private val isQueueingOrEngagementUseCase: IsQueueingOrEngagementUseCase,
     private val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase,
     private val screenSharingUseCase: ScreenSharingUseCase,

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -65,9 +65,9 @@ import com.glia.widgets.core.audio.domain.TurnSpeakerphoneUseCase;
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase;
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeViewBuilderUseCase;
 import com.glia.widgets.core.chathead.ChatHeadManager;
-import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase;
+import com.glia.widgets.core.chathead.domain.IsDisplayBubbleInsideAppUseCase;
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase;
-import com.glia.widgets.core.chathead.domain.ToggleChatHeadServiceUseCase;
+import com.glia.widgets.core.chathead.domain.IsDisplayBubbleOutsideAppUseCase;
 import com.glia.widgets.core.configuration.GliaSdkConfigurationManager;
 import com.glia.widgets.core.dialog.DialogContract;
 import com.glia.widgets.core.dialog.PermissionDialogManager;
@@ -201,8 +201,8 @@ public class UseCaseFactory {
     private static CallNotificationUseCase callNotificationUseCase;
     private static ShowScreenSharingNotificationUseCase showScreenSharingNotificationUseCase;
     private static RemoveScreenSharingNotificationUseCase removeScreenSharingNotificationUseCase;
-    private static ToggleChatHeadServiceUseCase toggleChatHeadServiceUseCase;
-    private static IsDisplayApplicationChatHeadUseCase isDisplayApplicationChatHeadUseCase;
+    private static IsDisplayBubbleOutsideAppUseCase isDisplayBubbleOutsideAppUseCase;
+    private static IsDisplayBubbleInsideAppUseCase isDisplayBubbleInsideAppUseCase;
     private static ResolveChatHeadNavigationUseCase resolveChatHeadNavigationUseCase;
     private static VisitorCodeViewBuilderUseCase visitorCodeViewBuilderUseCase;
     private final RepositoryFactory repositoryFactory;
@@ -270,9 +270,9 @@ public class UseCaseFactory {
     }
 
     @NonNull
-    public ToggleChatHeadServiceUseCase getToggleChatHeadServiceUseCase() {
-        if (toggleChatHeadServiceUseCase == null) {
-            toggleChatHeadServiceUseCase = new ToggleChatHeadServiceUseCase(
+    public IsDisplayBubbleOutsideAppUseCase getToggleChatHeadServiceUseCase() {
+        if (isDisplayBubbleOutsideAppUseCase == null) {
+            isDisplayBubbleOutsideAppUseCase = new IsDisplayBubbleOutsideAppUseCase(
                 getIsQueueingOrEngagementUseCase(),
                 getIsCurrentEngagementCallVisualizer(),
                 getScreenSharingUseCase(),
@@ -282,13 +282,13 @@ public class UseCaseFactory {
                 getEngagementTypeUseCase()
             );
         }
-        return toggleChatHeadServiceUseCase;
+        return isDisplayBubbleOutsideAppUseCase;
     }
 
     @NonNull
-    public IsDisplayApplicationChatHeadUseCase getIsDisplayApplicationChatHeadUseCase() {
-        if (isDisplayApplicationChatHeadUseCase == null) {
-            isDisplayApplicationChatHeadUseCase = new IsDisplayApplicationChatHeadUseCase(
+    public IsDisplayBubbleInsideAppUseCase getIsDisplayApplicationChatHeadUseCase() {
+        if (isDisplayBubbleInsideAppUseCase == null) {
+            isDisplayBubbleInsideAppUseCase = new IsDisplayBubbleInsideAppUseCase(
                 getIsQueueingOrEngagementUseCase(),
                 getIsCurrentEngagementCallVisualizer(),
                 getScreenSharingUseCase(),
@@ -297,7 +297,7 @@ public class UseCaseFactory {
                 getEngagementTypeUseCase()
             );
         }
-        return isDisplayApplicationChatHeadUseCase;
+        return isDisplayBubbleInsideAppUseCase;
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/DialogHolderActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/DialogHolderActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.View
 import com.glia.widgets.R
 import com.glia.widgets.base.FadeTransitionActivity
-import com.glia.widgets.core.chathead.domain.IsDisplayChatHeadUseCase
 import com.glia.widgets.view.head.ActivityWatcherForChatHead
 
 /**
@@ -39,7 +38,6 @@ internal class DialogHolderActivity : FadeTransitionActivity() {
  *
  * This is a view used to make the [DialogHolderActivity] recognizable by the services that draw the chat bubble.
  * @see [ActivityWatcherForChatHead.fetchGliaOrRootView]
- * @see [IsDisplayChatHeadUseCase.isNotInListOfGliaViewsExceptChat]
  */
 internal class DialogHolderView(context: Context) : View(context) {
     init {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -2,7 +2,7 @@ package com.glia.widgets.view.head.controller
 
 import com.glia.androidsdk.Operator
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
-import com.glia.widgets.core.chathead.domain.IsDisplayApplicationChatHeadUseCase
+import com.glia.widgets.core.chathead.domain.IsDisplayBubbleInsideAppUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
 import com.glia.widgets.engagement.ScreenSharingState
@@ -17,7 +17,7 @@ import com.glia.widgets.view.head.ChatHeadLayoutContract
 import com.glia.widgets.engagement.State as EngagementState
 
 internal class ApplicationChatHeadLayoutController(
-    private val isDisplayApplicationChatHeadUseCase: IsDisplayApplicationChatHeadUseCase,
+    private val isDisplayBubbleInsideAppUseCase: IsDisplayBubbleInsideAppUseCase,
     private val navigationDestinationUseCase: ResolveChatHeadNavigationUseCase,
     private val messagesNotSeenHandler: MessagesNotSeenHandler,
     private val isCallVisualizerScreenSharingUseCase: IsCallVisualizerScreenSharingUseCase,
@@ -110,7 +110,7 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     override fun shouldShow(gliaOrRootViewName: String?): Boolean {
-        return isDisplayApplicationChatHeadUseCase(gliaOrRootViewName)
+        return isDisplayBubbleInsideAppUseCase(gliaOrRootViewName)
     }
 
     override fun onResume(viewName: String) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.UiTheme
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
-import com.glia.widgets.core.chathead.domain.ToggleChatHeadServiceUseCase
+import com.glia.widgets.core.chathead.domain.IsDisplayBubbleOutsideAppUseCase
 import com.glia.widgets.core.configuration.EngagementConfiguration
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
@@ -23,7 +23,7 @@ import com.glia.widgets.view.head.ChatHeadPosition
 import com.glia.widgets.engagement.State as EngagementState
 
 internal class ServiceChatHeadController(
-    private val toggleChatHeadServiceUseCase: ToggleChatHeadServiceUseCase,
+    private val isDisplayBubbleOutsideAppUseCase: IsDisplayBubbleOutsideAppUseCase,
     private val resolveChatHeadNavigationUseCase: ResolveChatHeadNavigationUseCase,
     messagesNotSeenHandler: MessagesNotSeenHandler,
     private var _chatHeadPosition: ChatHeadPosition,
@@ -67,7 +67,7 @@ internal class ServiceChatHeadController(
 
         // see the comment on the resumedViewName field declaration above
         if (!isResumedView(view)) return
-        toggleChatHeadServiceUseCase(view?.javaClass?.simpleName)
+        isDisplayBubbleOutsideAppUseCase(view?.javaClass?.simpleName)
     }
 
     override fun onPause(gliaOrRootView: View?) {
@@ -80,7 +80,7 @@ internal class ServiceChatHeadController(
 
     override fun onApplicationStop() {
         d(TAG, "onApplicationStop()")
-        toggleChatHeadServiceUseCase(null)
+        isDisplayBubbleOutsideAppUseCase(null)
     }
 
     override fun onChatHeadPositionChanged(x: Int, y: Int) {
@@ -134,7 +134,7 @@ internal class ServiceChatHeadController(
     }
 
     private fun toggleChatHead() {
-        toggleChatHeadServiceUseCase(resumedViewName)
+        isDisplayBubbleOutsideAppUseCase(resumedViewName)
     }
 
     override fun updateChatHeadView() {
@@ -151,7 +151,7 @@ internal class ServiceChatHeadController(
     }
 
     private fun engagementEnded() {
-        toggleChatHeadServiceUseCase.onDestroy()
+        isDisplayBubbleOutsideAppUseCase.onDestroy()
         isOnHold = false
         state = State.ENDED
         operatorProfileImgUrl = null
@@ -163,7 +163,7 @@ internal class ServiceChatHeadController(
     private fun newEngagementLoaded() {
         isOnHold = false
         state = State.ENGAGEMENT
-        toggleChatHeadServiceUseCase(resumedViewName)
+        isDisplayBubbleOutsideAppUseCase(resumedViewName)
         if (engagementConfiguration == null) setEngagementConfiguration(
             Dependencies.sdkConfigurationManager.buildEngagementConfiguration()
         )
@@ -172,7 +172,7 @@ internal class ServiceChatHeadController(
 
     private fun queueingStarted() {
         state = State.QUEUEING
-        toggleChatHeadServiceUseCase(resumedViewName)
+        isDisplayBubbleOutsideAppUseCase(resumedViewName)
         if (engagementConfiguration == null) setEngagementConfiguration(
             Dependencies.sdkConfigurationManager.buildEngagementConfiguration()
         )


### PR DESCRIPTION
[[Android] Fix bubble behavior when overlay flag is disabled](https://glia.atlassian.net/browse/MOB-3281)

**What was solved?**
- Renamed 3 classes, nothing else

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

