### PR TITLE
Fix chat back button listener race condition

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatContract.kt
@@ -21,6 +21,7 @@ internal interface ChatContract {
         val isChatVisible: Boolean
 
         fun setView(view: View)
+        fun getView(): View?
         fun onDestroy(retain: Boolean)
         fun onMessageClicked(messageId: String)
         fun onGvaButtonClicked(button: GvaButton)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -593,7 +593,11 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
     }
 
     private fun destroyController() {
-        controller?.onDestroy(context.asActivity() is ChatActivity)
+        controller?.let {
+            if (it.getView() == this) {
+                it.onDestroy(context.asActivity() is ChatActivity)
+            }
+        }
         controller = null
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -470,6 +470,11 @@ internal class ChatController(
         view.scrollToBottomImmediate()
     }
 
+    @Synchronized
+    override fun getView(): ChatContract.View? {
+        return this.view
+    }
+
     override fun setOnBackClickedListener(finishCallback: ChatView.OnBackClickedListener?) {
         this.backClickedListener = finishCallback
     }


### PR DESCRIPTION

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3524

**What was solved?**
There was a race condition where sometimes the old instance of ChatView was accessing and destroying the ChatController *after* a newer instance of ChatView had just set up the ChatController (same instance) causing the broken state of ChatController.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes: Fix the back button in the chat screen sometimes stoping working
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
