### PR TITLE
Unified UI customization for Entry Widget and SCv2

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
@@ -11,6 +11,8 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import com.glia.widgets.R
 import com.glia.widgets.databinding.EntryWidgetFragmentBinding
+import com.glia.widgets.di.Dependencies
+import com.glia.widgets.entrywidget.adapter.EntryWidgetAdapter
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -32,7 +34,14 @@ internal class EntryWidgetFragment : BottomSheetDialogFragment() {
     ): View {
         val binding = EntryWidgetFragmentBinding.inflate(inflater, container, false)
 
-        EntryWidgetView(requireContext(), EntryWidgetContract.ViewType.BOTTOM_SHEET).also {
+        val entryWidgetsTheme = Dependencies.gliaThemeManager.theme?.entryWidgetTheme
+        val entryWidgetAdapter = EntryWidgetAdapter(EntryWidgetContract.ViewType.BOTTOM_SHEET, entryWidgetsTheme)
+
+        EntryWidgetView(
+            requireContext(),
+            entryWidgetAdapter,
+            entryWidgetsTheme
+        ).also {
             binding.container.addView(it)
             it.onDismissListener = {
                 dismiss()

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
@@ -8,10 +8,26 @@ import com.glia.widgets.databinding.EntryWidgetMediaTypeItemBinding
 import com.glia.widgets.databinding.EntryWidgetPoweredByItemBinding
 import com.glia.widgets.entrywidget.EntryWidgetContract
 import com.glia.widgets.helper.layoutInflater
+import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemsTheme
 
 internal class EntryWidgetAdapter(
-    private val viewType: EntryWidgetContract.ViewType
+    private val viewType: EntryWidgetContract.ViewType,
+    private val mediaTypeItemsTheme: MediaTypeItemsTheme? = null,
+    private val errorTitleTheme: TextTheme? = null,
+    private val errorMessageTheme: TextTheme? = null,
+    private val errorButtonTheme: ButtonTheme? = null
 ) : RecyclerView.Adapter<EntryWidgetAdapter.ViewHolder>() {
+
+    constructor(viewType: EntryWidgetContract.ViewType, entryWidgetTheme: EntryWidgetTheme?): this(
+        viewType,
+        entryWidgetTheme?.mediaTypeItems,
+        entryWidgetTheme?.errorTitle,
+        entryWidgetTheme?.errorMessage,
+        entryWidgetTheme?.errorButton
+    )
 
     enum class ViewType {
         CONTACT_ITEM,
@@ -31,13 +47,17 @@ internal class EntryWidgetAdapter(
         return when (viewType) {
             ViewType.ERROR_ITEM.ordinal -> EntryWidgetErrorStateViewHolder(
                 EntryWidgetErrorItemBinding.inflate(parent.layoutInflater, parent, false),
-                viewType = this.viewType
+                viewType = this.viewType,
+                errorTitleTheme = errorTitleTheme,
+                errorMessageTheme = errorMessageTheme,
+                errorButtonTheme = errorButtonTheme
             )
             ViewType.PROVIDED_BY_ITEM.ordinal -> EntryWidgetPoweredByViewHolder(
                 EntryWidgetPoweredByItemBinding.inflate(parent.layoutInflater, parent, false)
             )
             else -> EntryWidgetMediaTypeItemViewHolder(
-                EntryWidgetMediaTypeItemBinding.inflate(parent.layoutInflater, parent, false)
+                EntryWidgetMediaTypeItemBinding.inflate(parent.layoutInflater, parent, false),
+                itemTheme = mediaTypeItemsTheme?.mediaTypeItem
             )
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetErrorStateViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetErrorStateViewHolder.kt
@@ -6,11 +6,24 @@ import com.glia.widgets.R
 import com.glia.widgets.databinding.EntryWidgetErrorItemBinding
 import com.glia.widgets.entrywidget.EntryWidgetContract
 import com.glia.widgets.helper.setLocaleText
+import com.glia.widgets.view.unifiedui.applyButtonTheme
+import com.glia.widgets.view.unifiedui.applyTextTheme
+import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal class EntryWidgetErrorStateViewHolder(
     private val binding: EntryWidgetErrorItemBinding,
-    private val viewType: EntryWidgetContract.ViewType
+    private val viewType: EntryWidgetContract.ViewType,
+    errorTitleTheme: TextTheme? = null,
+    errorMessageTheme: TextTheme? = null,
+    errorButtonTheme: ButtonTheme? = null
 ) : EntryWidgetAdapter.ViewHolder(binding.root) {
+
+    init {
+        errorTitleTheme?.let { binding.title.applyTextTheme(it) }
+        errorMessageTheme?.let { binding.description.applyTextTheme(it) }
+        errorButtonTheme?.let { binding.button.applyButtonTheme(it) }
+    }
 
     override fun bind(itemType: EntryWidgetContract.ItemType, onClickListener: View.OnClickListener) {
         when (itemType) {

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetMediaTypeItemViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetMediaTypeItemViewHolder.kt
@@ -7,10 +7,24 @@ import com.glia.widgets.databinding.EntryWidgetMediaTypeItemBinding
 import com.glia.widgets.entrywidget.EntryWidgetContract
 import com.glia.widgets.helper.setLocaleContentDescription
 import com.glia.widgets.helper.setLocaleText
+import com.glia.widgets.view.unifiedui.applyImageColorTheme
+import com.glia.widgets.view.unifiedui.applyLayerTheme
+import com.glia.widgets.view.unifiedui.applyTextTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemTheme
 
 internal class EntryWidgetMediaTypeItemViewHolder(
-    private val binding: EntryWidgetMediaTypeItemBinding
+    private val binding: EntryWidgetMediaTypeItemBinding,
+    itemTheme: MediaTypeItemTheme?
 ) : EntryWidgetAdapter.ViewHolder(binding.root) {
+
+    init {
+        itemTheme?.let {
+            binding.root.applyLayerTheme(it.background)
+            binding.title.applyTextTheme(it.title)
+            binding.description.applyTextTheme(it.message)
+            binding.icon.applyImageColorTheme(it.iconColor)
+        }
+    }
 
     override fun bind(itemType: EntryWidgetContract.ItemType, onClickListener: View.OnClickListener) {
         binding.root.setOnClickListener(onClickListener)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/RemoteConfiguration.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/RemoteConfiguration.kt
@@ -5,6 +5,7 @@ import com.glia.widgets.view.unifiedui.config.bubble.BubbleRemoteConfig
 import com.glia.widgets.view.unifiedui.config.call.CallRemoteConfig
 import com.glia.widgets.view.unifiedui.config.callvisualizer.CallVisualizerConfig
 import com.glia.widgets.view.unifiedui.config.chat.ChatRemoteConfig
+import com.glia.widgets.view.unifiedui.config.entrywidget.EntryWidgetRemoteConfig
 import com.glia.widgets.view.unifiedui.config.secureconversations.SecureConversationsConfirmationScreenRemoteConfig
 import com.glia.widgets.view.unifiedui.config.secureconversations.SecureConversationsWelcomeScreenRemoteConfig
 import com.glia.widgets.view.unifiedui.config.snackbar.SnackBarRemoteConfig
@@ -47,7 +48,10 @@ internal data class RemoteConfiguration(
     val snackBarRemoteConfig: SnackBarRemoteConfig?,
 
     @SerializedName("webBrowserScreen")
-    val webBrowserRemoteConfig: WebBrowserRemoteConfig?
+    val webBrowserRemoteConfig: WebBrowserRemoteConfig?,
+
+    @SerializedName("entryWidget")
+    val entryWidgetRemoteConfig: EntryWidgetRemoteConfig?
 ) {
     fun toUnifiedTheme(): UnifiedTheme? {
         val defaultTheme = DefaultTheme(globalColorsConfig?.toColorPallet())
@@ -63,7 +67,8 @@ internal data class RemoteConfiguration(
             secureConversationsConfirmationScreenTheme = secureConversationsConfirmationScreenRemoteConfig
                 ?.toSecureConversationsConfirmationScreenTheme(),
             snackBarTheme = snackBarRemoteConfig?.toSnackBarTheme(),
-            webBrowserTheme = webBrowserRemoteConfig?.toWebBrowserTheme()
+            webBrowserTheme = webBrowserRemoteConfig?.toWebBrowserTheme(),
+            entryWidgetTheme = entryWidgetRemoteConfig?.toEntryWidgetTheme()
         )
 
         return defaultTheme merge unifiedTheme

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/alert/AlertRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/alert/AlertRemoteConfig.kt
@@ -32,6 +32,9 @@ internal data class AlertRemoteConfig(
     @SerializedName("negativeButton")
     val negativeButtonRemoteConfig: ButtonRemoteConfig?,
 
+    @SerializedName("negativeNeutralButton")
+    val negativeNeutralButtonRemoteConfig: ButtonRemoteConfig?,
+
     @SerializedName("buttonAxis")
     val buttonAxisRemoteConfig: AxisRemoteConfig?
 ) {
@@ -44,6 +47,7 @@ internal data class AlertRemoteConfig(
         linkButton = linkButtonRemoteConfig?.toButtonTheme(),
         positiveButton = positiveButtonRemoteConfig?.toButtonTheme(),
         negativeButton = negativeButtonRemoteConfig?.toButtonTheme(),
+        negativeNeutralButton = negativeNeutralButtonRemoteConfig?.toButtonTheme(),
         isVerticalAxis = buttonAxisRemoteConfig?.isVertical
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/chat/ChatRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/chat/ChatRemoteConfig.kt
@@ -6,6 +6,7 @@ import com.glia.widgets.view.unifiedui.config.base.LayerRemoteConfig
 import com.glia.widgets.view.unifiedui.config.base.TextRemoteConfig
 import com.glia.widgets.view.unifiedui.config.bubble.BubbleRemoteConfig
 import com.glia.widgets.view.unifiedui.config.gva.GvaRemoteConfig
+import com.glia.widgets.view.unifiedui.config.secureconversations.SecureConversationsRemoteConfig
 import com.glia.widgets.view.unifiedui.theme.chat.ChatTheme
 import com.google.gson.annotations.SerializedName
 
@@ -56,7 +57,10 @@ internal data class ChatRemoteConfig(
     val newMessagesDividerTextRemoteConfig: TextRemoteConfig?,
 
     @SerializedName("gva")
-    val gvaRemoteConfig: GvaRemoteConfig?
+    val gvaRemoteConfig: GvaRemoteConfig?,
+
+    @SerializedName("secureConversations")
+    val secureConversationsRemoteConfig: SecureConversationsRemoteConfig?
 ) {
     fun toChatTheme(): ChatTheme = ChatTheme(
         background = background?.toLayerTheme(),
@@ -74,6 +78,7 @@ internal data class ChatRemoteConfig(
         typingIndicator = typingIndicator?.toColorTheme(),
         newMessagesDividerColorTheme = newMessagesDividerColorRemoteConfig?.toColorTheme(),
         newMessagesDividerTextTheme = newMessagesDividerTextRemoteConfig?.toTextTheme(),
-        gva = gvaRemoteConfig?.toGvaTheme()
+        gva = gvaRemoteConfig?.toGvaTheme(),
+        secureConversations = secureConversationsRemoteConfig?.toSecureConversationsTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/EntryWidgetRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/EntryWidgetRemoteConfig.kt
@@ -1,0 +1,28 @@
+package com.glia.widgets.view.unifiedui.config.entrywidget
+
+import com.glia.widgets.view.unifiedui.config.base.LayerRemoteConfig
+import com.glia.widgets.view.unifiedui.config.base.TextRemoteConfig
+import com.glia.widgets.view.unifiedui.config.base.ButtonRemoteConfig
+import com.google.gson.annotations.SerializedName
+import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
+
+internal data class EntryWidgetRemoteConfig(
+    @SerializedName("background")
+    val background: LayerRemoteConfig?,
+    @SerializedName("mediaTypeItems")
+    val mediaTypeItems: MediaTypeItemsRemoteConfig?,
+    @SerializedName("errorTitle")
+    val errorTitle: TextRemoteConfig?,
+    @SerializedName("errorMessage")
+    val errorMessage: TextRemoteConfig?,
+    @SerializedName("errorButton")
+    val errorButton: ButtonRemoteConfig?
+) {
+    fun toEntryWidgetTheme(): EntryWidgetTheme = EntryWidgetTheme(
+        background = background?.toLayerTheme(),
+        mediaTypeItems = mediaTypeItems?.toMediaTypeItemsTheme(),
+        errorTitle = errorTitle?.toTextTheme(),
+        errorMessage = errorMessage?.toTextTheme(),
+        errorButton = errorButton?.toButtonTheme()
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/MediaTypeItemRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/MediaTypeItemRemoteConfig.kt
@@ -1,0 +1,25 @@
+package com.glia.widgets.view.unifiedui.config.entrywidget
+
+import com.glia.widgets.view.unifiedui.config.base.ColorRemoteConfig
+import com.glia.widgets.view.unifiedui.config.base.LayerRemoteConfig
+import com.glia.widgets.view.unifiedui.config.base.TextRemoteConfig
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemTheme
+import com.google.gson.annotations.SerializedName
+
+internal data class MediaTypeItemRemoteConfig(
+    @SerializedName("background")
+    val background: LayerRemoteConfig?,
+    @SerializedName("iconColor")
+    val iconColor: ColorRemoteConfig?,
+    @SerializedName("title")
+    val title: TextRemoteConfig?,
+    @SerializedName("message")
+    val message: TextRemoteConfig?
+) {
+    fun toMediaTypeItemTheme(): MediaTypeItemTheme = MediaTypeItemTheme(
+        background = background?.toLayerTheme(),
+        iconColor = iconColor?.toColorTheme(),
+        title = title?.toTextTheme(),
+        message = message?.toTextTheme()
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/MediaTypeItemsRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/MediaTypeItemsRemoteConfig.kt
@@ -1,0 +1,17 @@
+package com.glia.widgets.view.unifiedui.config.entrywidget
+
+import com.glia.widgets.view.unifiedui.config.base.ColorRemoteConfig
+import com.google.gson.annotations.SerializedName
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemsTheme
+
+internal data class MediaTypeItemsRemoteConfig(
+    @SerializedName("mediaTypeItem")
+    val mediaTypeItem: MediaTypeItemRemoteConfig?,
+    @SerializedName("dividerColor")
+    val dividerColor: ColorRemoteConfig?
+) {
+    fun toMediaTypeItemsTheme(): MediaTypeItemsTheme = MediaTypeItemsTheme(
+        mediaTypeItem = mediaTypeItem?.toMediaTypeItemTheme(),
+        dividerColor = dividerColor?.toColorTheme()
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/secureconversations/SecureConversationsRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/secureconversations/SecureConversationsRemoteConfig.kt
@@ -1,0 +1,44 @@
+package com.glia.widgets.view.unifiedui.config.secureconversations
+
+import com.glia.widgets.view.unifiedui.config.base.LayerRemoteConfig
+import com.glia.widgets.view.unifiedui.config.base.TextRemoteConfig
+import com.glia.widgets.view.unifiedui.config.base.ColorRemoteConfig
+import com.glia.widgets.view.unifiedui.config.entrywidget.MediaTypeItemsRemoteConfig
+import com.glia.widgets.view.unifiedui.theme.secureconversations.SecureConversationsTheme
+import com.google.gson.annotations.SerializedName
+
+internal data class SecureConversationsRemoteConfig(
+    @SerializedName("unavailableStatusBackground")
+    val unavailableStatusBackground: LayerRemoteConfig?,
+    @SerializedName("unavailableStatusText")
+    val unavailableStatusText: TextRemoteConfig?,
+    @SerializedName("bottomBannerBackground")
+    val bottomBannerBackground: LayerRemoteConfig?,
+    @SerializedName("bottomBannerText")
+    val bottomBannerText: TextRemoteConfig?,
+    @SerializedName("bottomBannerDividerColor")
+    val bottomBannerDividerColor: ColorRemoteConfig?,
+    @SerializedName("topBannerBackground")
+    val topBannerBackground: LayerRemoteConfig?,
+    @SerializedName("topBannerText")
+    val topBannerText: TextRemoteConfig?,
+    @SerializedName("topBannerDividerColor")
+    val topBannerDividerColor: ColorRemoteConfig?,
+    @SerializedName("topBannerDropDownIconColor")
+    val topBannerDropDownIconColor: ColorRemoteConfig?,
+    @SerializedName("mediaTypeItems")
+    val mediaTypeItems: MediaTypeItemsRemoteConfig?
+) {
+    fun toSecureConversationsTheme(): SecureConversationsTheme = SecureConversationsTheme(
+        unavailableStatusBackground = unavailableStatusBackground?.toLayerTheme(),
+        unavailableStatusText = unavailableStatusText?.toTextTheme(),
+        bottomBannerBackground = bottomBannerBackground?.toLayerTheme(),
+        bottomBannerText = bottomBannerText?.toTextTheme(),
+        bottomBannerDividerColor = bottomBannerDividerColor?.toColorTheme(),
+        topBannerBackground = topBannerBackground?.toLayerTheme(),
+        topBannerText = topBannerText?.toTextTheme(),
+        topBannerDividerColor = topBannerDividerColor?.toColorTheme(),
+        topBannerDropDownIconColor = topBannerDropDownIconColor?.toColorTheme(),
+        mediaTypeItems = mediaTypeItems?.toMediaTypeItemsTheme()
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/webbrowser/WebBrowserRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/webbrowser/WebBrowserRemoteConfig.kt
@@ -1,7 +1,7 @@
 package com.glia.widgets.view.unifiedui.config.webbrowser
 
 import com.glia.widgets.view.unifiedui.config.base.HeaderRemoteConfig
-import com.glia.widgets.view.unifiedui.webbrowser.WebBrowserTheme
+import com.glia.widgets.view.unifiedui.theme.webbrowser.WebBrowserTheme
 import com.google.gson.annotations.SerializedName
 
 internal data class WebBrowserRemoteConfig(

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/UnifiedTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/UnifiedTheme.kt
@@ -7,10 +7,11 @@ import com.glia.widgets.view.unifiedui.theme.bubble.BubbleTheme
 import com.glia.widgets.view.unifiedui.theme.call.CallTheme
 import com.glia.widgets.view.unifiedui.theme.callvisulaizer.CallVisualizerTheme
 import com.glia.widgets.view.unifiedui.theme.chat.ChatTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
 import com.glia.widgets.view.unifiedui.theme.secureconversations.SecureConversationsConfirmationScreenTheme
 import com.glia.widgets.view.unifiedui.theme.secureconversations.SecureConversationsWelcomeScreenTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyTheme
-import com.glia.widgets.view.unifiedui.webbrowser.WebBrowserTheme
+import com.glia.widgets.view.unifiedui.theme.webbrowser.WebBrowserTheme
 
 internal data class UnifiedTheme(
     val alertTheme: AlertTheme? = null,
@@ -22,7 +23,8 @@ internal data class UnifiedTheme(
     val secureConversationsWelcomeScreenTheme: SecureConversationsWelcomeScreenTheme? = null,
     val secureConversationsConfirmationScreenTheme: SecureConversationsConfirmationScreenTheme? = null,
     val snackBarTheme: SnackBarTheme? = null,
-    val webBrowserTheme: WebBrowserTheme? = null
+    val webBrowserTheme: WebBrowserTheme? = null,
+    val entryWidgetTheme: EntryWidgetTheme? = null
 ) : Mergeable<UnifiedTheme> {
     override fun merge(other: UnifiedTheme): UnifiedTheme = UnifiedTheme(
         alertTheme = alertTheme merge other.alertTheme,
@@ -34,7 +36,8 @@ internal data class UnifiedTheme(
         secureConversationsWelcomeScreenTheme = secureConversationsWelcomeScreenTheme merge other.secureConversationsWelcomeScreenTheme,
         secureConversationsConfirmationScreenTheme = secureConversationsConfirmationScreenTheme merge other.secureConversationsConfirmationScreenTheme,
         snackBarTheme = snackBarTheme merge other.snackBarTheme,
-        webBrowserTheme = webBrowserTheme merge other.webBrowserTheme
+        webBrowserTheme = webBrowserTheme merge other.webBrowserTheme,
+        entryWidgetTheme = entryWidgetTheme merge other.entryWidgetTheme
     )
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/alert/AlertTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/alert/AlertTheme.kt
@@ -15,6 +15,7 @@ internal data class AlertTheme(
     val linkButton: ButtonTheme? = null,
     val positiveButton: ButtonTheme? = null,
     val negativeButton: ButtonTheme? = null,
+    val negativeNeutralButton: ButtonTheme? = null,
     val isVerticalAxis: Boolean? = null
 ) : Mergeable<AlertTheme> {
     override fun merge(other: AlertTheme): AlertTheme = AlertTheme(
@@ -26,6 +27,7 @@ internal data class AlertTheme(
         linkButton = linkButton merge other.linkButton,
         positiveButton = positiveButton merge other.positiveButton,
         negativeButton = negativeButton merge other.negativeButton,
+        negativeNeutralButton = negativeNeutralButton merge other.negativeNeutralButton,
         isVerticalAxis = isVerticalAxis merge other.isVerticalAxis
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ChatTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/chat/ChatTheme.kt
@@ -8,6 +8,7 @@ import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.glia.widgets.view.unifiedui.theme.bubble.BubbleTheme
 import com.glia.widgets.view.unifiedui.theme.gva.GvaTheme
+import com.glia.widgets.view.unifiedui.theme.secureconversations.SecureConversationsTheme
 
 internal data class ChatTheme(
     val background: LayerTheme? = null,
@@ -25,7 +26,8 @@ internal data class ChatTheme(
     val typingIndicator: ColorTheme? = null,
     val newMessagesDividerColorTheme: ColorTheme? = null,
     val newMessagesDividerTextTheme: TextTheme? = null,
-    val gva: GvaTheme? = null
+    val gva: GvaTheme? = null,
+    val secureConversations: SecureConversationsTheme? = null
 ) : Mergeable<ChatTheme> {
     override fun merge(other: ChatTheme): ChatTheme = ChatTheme(
         background = background merge other.background,
@@ -43,6 +45,7 @@ internal data class ChatTheme(
         typingIndicator = typingIndicator merge other.typingIndicator,
         newMessagesDividerColorTheme = newMessagesDividerColorTheme merge other.newMessagesDividerColorTheme,
         newMessagesDividerTextTheme = newMessagesDividerTextTheme merge other.newMessagesDividerTextTheme,
-        gva = gva merge other.gva
+        gva = gva merge other.gva,
+        secureConversations = secureConversations merge other.secureConversations
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Base.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Base.kt
@@ -19,6 +19,7 @@ internal fun DefaultTheme(pallet: ColorPallet?): UnifiedTheme? = pallet?.let {
         secureConversationsWelcomeScreenTheme = SecureConversationsWelcomeScreenTheme(it),
         secureConversationsConfirmationScreenTheme = SecureConversationsConfirmationScreenTheme(it),
         snackBarTheme = DefaultSnackBarTheme(it),
-        webBrowserTheme = WebBrowserTheme(it)
+        webBrowserTheme = WebBrowserTheme(it),
+        entryWidgetTheme = EntryWidgetTheme(it)
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/EntryWidget.kt
@@ -1,0 +1,45 @@
+@file:Suppress("FunctionName")
+
+package com.glia.widgets.view.unifiedui.theme.defaulttheme
+
+import com.glia.widgets.view.unifiedui.theme.ColorPallet
+import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemsTheme
+
+internal fun EntryWidgetTheme(pallet: ColorPallet?): EntryWidgetTheme? = pallet?.run {
+    EntryWidgetTheme(
+        background = LayerTheme(baseLightColorTheme),
+        mediaTypeItems = DefaultMediaTypeItemsTheme(this),
+        errorTitle = TextTheme(
+            textColor = baseDarkColorTheme
+        ),
+        errorMessage = TextTheme(
+            textColor = baseShadeColorTheme
+        ),
+        errorButton = LinkDefaultButtonTheme(this)
+    )
+}
+
+internal fun DefaultMediaTypeItemsTheme(pallet: ColorPallet?): MediaTypeItemsTheme? =
+    pallet?.run {
+        MediaTypeItemsTheme(
+            mediaTypeItem = DefaultMediaItemTypeTheme(this),
+            dividerColor = baseNormalColorTheme
+        )
+    }
+
+internal fun DefaultMediaItemTypeTheme(pallet: ColorPallet?): MediaTypeItemTheme? =
+    pallet?.run {
+        MediaTypeItemTheme(
+            iconColor = primaryColorTheme,
+            title = TextTheme(
+                textColor = baseDarkColorTheme
+            ),
+            message = TextTheme(
+                textColor = baseShadeColorTheme
+            )
+        )
+    }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/WebBrowser.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/WebBrowser.kt
@@ -1,7 +1,7 @@
 package com.glia.widgets.view.unifiedui.theme.defaulttheme
 
 import com.glia.widgets.view.unifiedui.theme.ColorPallet
-import com.glia.widgets.view.unifiedui.webbrowser.WebBrowserTheme
+import com.glia.widgets.view.unifiedui.theme.webbrowser.WebBrowserTheme
 
 /**
  * Default theme for Chat screen

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/EntryWidgetTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/EntryWidgetTheme.kt
@@ -1,0 +1,23 @@
+package com.glia.widgets.view.unifiedui.theme.entrywidget
+
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+import com.glia.widgets.view.unifiedui.theme.base.ButtonTheme
+import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
+
+internal data class EntryWidgetTheme(
+    val background: LayerTheme? = null,
+    val mediaTypeItems: MediaTypeItemsTheme? = null,
+    val errorTitle: TextTheme? = null,
+    val errorMessage: TextTheme? = null,
+    val errorButton: ButtonTheme? = null
+) : Mergeable<EntryWidgetTheme> {
+    override fun merge(other: EntryWidgetTheme): EntryWidgetTheme = EntryWidgetTheme(
+        background = background merge other.background,
+        mediaTypeItems = mediaTypeItems merge other.mediaTypeItems,
+        errorTitle = errorTitle merge other.errorTitle,
+        errorMessage = errorMessage merge other.errorMessage,
+        errorButton = errorButton merge other.errorButton
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/MediaTypeItemTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/MediaTypeItemTheme.kt
@@ -1,0 +1,21 @@
+package com.glia.widgets.view.unifiedui.theme.entrywidget
+
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
+import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
+
+internal data class MediaTypeItemTheme(
+    val background: LayerTheme? = null,
+    val iconColor: ColorTheme? = null,
+    val title: TextTheme? = null,
+    val message: TextTheme? = null
+) : Mergeable<MediaTypeItemTheme> {
+    override fun merge(other: MediaTypeItemTheme): MediaTypeItemTheme = MediaTypeItemTheme(
+        background = background merge other.background,
+        iconColor = iconColor merge other.iconColor,
+        title = title merge other.title,
+        message = message merge other.message
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/MediaTypeItemsTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/MediaTypeItemsTheme.kt
@@ -1,0 +1,15 @@
+package com.glia.widgets.view.unifiedui.theme.entrywidget
+
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
+
+internal data class MediaTypeItemsTheme(
+    val mediaTypeItem: MediaTypeItemTheme? = null,
+    val dividerColor: ColorTheme? = null
+) : Mergeable<MediaTypeItemsTheme> {
+    override fun merge(other: MediaTypeItemsTheme): MediaTypeItemsTheme = MediaTypeItemsTheme(
+        mediaTypeItem = mediaTypeItem merge other.mediaTypeItem,
+        dividerColor = dividerColor merge other.dividerColor
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/secureconversations/SecureConversationsTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/secureconversations/SecureConversationsTheme.kt
@@ -1,0 +1,34 @@
+package com.glia.widgets.view.unifiedui.theme.secureconversations
+
+import com.glia.widgets.view.unifiedui.Mergeable
+import com.glia.widgets.view.unifiedui.merge
+import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
+import com.glia.widgets.view.unifiedui.theme.base.TextTheme
+import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemsTheme
+
+internal data class SecureConversationsTheme(
+    val unavailableStatusBackground: LayerTheme?,
+    val unavailableStatusText: TextTheme?,
+    val bottomBannerBackground: LayerTheme?,
+    val bottomBannerText: TextTheme?,
+    val bottomBannerDividerColor: ColorTheme?,
+    val topBannerBackground: LayerTheme?,
+    val topBannerText: TextTheme?,
+    val topBannerDividerColor: ColorTheme?,
+    val topBannerDropDownIconColor: ColorTheme?,
+    val mediaTypeItems: MediaTypeItemsTheme?
+) : Mergeable<SecureConversationsTheme> {
+    override fun merge(other: SecureConversationsTheme): SecureConversationsTheme = SecureConversationsTheme(
+        unavailableStatusBackground = unavailableStatusBackground merge other.unavailableStatusBackground,
+        unavailableStatusText = unavailableStatusText merge other.unavailableStatusText,
+        bottomBannerBackground = bottomBannerBackground merge other.bottomBannerBackground,
+        bottomBannerText = bottomBannerText merge other.bottomBannerText,
+        bottomBannerDividerColor = bottomBannerDividerColor merge other.bottomBannerDividerColor,
+        topBannerBackground = topBannerBackground merge other.topBannerBackground,
+        topBannerText = topBannerText merge other.topBannerText,
+        topBannerDividerColor = topBannerDividerColor merge other.topBannerDividerColor,
+        topBannerDropDownIconColor = topBannerDropDownIconColor merge other.topBannerDropDownIconColor,
+        mediaTypeItems = mediaTypeItems merge other.mediaTypeItems
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/webbrowser/WebBrowserTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/webbrowser/WebBrowserTheme.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.view.unifiedui.webbrowser
+package com.glia.widgets.view.unifiedui.theme.webbrowser
 
 import com.glia.widgets.view.unifiedui.Mergeable
 import com.glia.widgets.view.unifiedui.merge

--- a/widgetssdk/src/main/res/layout/entry_widget_error_item.xml
+++ b/widgetssdk/src/main/res/layout/entry_widget_error_item.xml
@@ -28,6 +28,7 @@
         android:letterSpacing="-0.02"
         style="@style/Application.Glia.Body"
         android:textColor="@color/glia_base_normal_color"
+        android:gravity="center"
         app:layout_constraintTop_toBottomOf="@id/title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3591
https://glia.atlassian.net/browse/MOB-3593

**What was solved?**
Added Unified UI customization support for Entry Widget and Secure Conversations v2

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
