### PR TITLE
Downgrade 'one-way audio calls' error to info

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/CallNotificationUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/domain/CallNotificationUseCase.kt
@@ -17,7 +17,7 @@ internal class CallNotificationUseCase(
             video = getVideoDirection(visitorMedia, operatorMedia)
         } catch (error: IllegalStateException) {
             // One of the impossible scenario was detected during parsing of the states which is not supported by current GliaHub
-            Logger.e(TAG, "Unsupported request to show/update/hide media call notification", error)
+            Logger.i(TAG, "Unsupported request to show/update/hide media call notification \nDetails: ${error.message}")
             return
         }
 


### PR DESCRIPTION



**Jira issue:**
https://glia.atlassian.net/browse/MOB-3583

**What was solved?**

This problame consists of multiple parts:
- At the moment it should be impossible to start one-way audio
- Visitor and Operator media states are received from different APIs and are async
- ChatController does not care about visitor media state

As a result, this error is 'expected' so I decided to downgrade it to an info log


**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
