### PR TITLE
Devs want to implement the logic for showing available engagement types

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -39,6 +39,7 @@ import kotlin.concurrent.thread
 import kotlin.properties.Delegates
 
 class MainFragment : Fragment() {
+
     private var containerView: ConstraintLayout? = null
     private var authentication: Authentication? = null
 
@@ -50,7 +51,6 @@ class MainFragment : Fragment() {
 
     private val authToken: String
         get() {
-            val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
             val authTokenFromPrefs = getAuthTokenFromPrefs(sharedPreferences)
             return authTokenFromPrefs.ifEmpty { getString(R.string.glia_jwt) }
         }
@@ -312,13 +312,11 @@ class MainFragment : Fragment() {
 
     private fun saveAuthToken(jwt: String) {
         if (jwt != getString(R.string.glia_jwt)) {
-            val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
             putAuthTokenToPrefs(sharedPreferences, jwt)
         }
     }
 
     private fun clearAuthToken() {
-        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
         putAuthTokenToPrefs(sharedPreferences, null)
     }
 
@@ -505,6 +503,8 @@ class MainFragment : Fragment() {
     private fun prepareAuthentication() {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
         authentication = GliaWidgets.getAuthentication(getAuthenticationBehaviorFromPrefs(sharedPreferences, resources))
+        authentication =
+            GliaWidgets.getAuthentication(getAuthenticationBehaviorFromPrefs(sharedPreferences, resources))
     }
 
     private fun authenticate(
@@ -552,7 +552,6 @@ class MainFragment : Fragment() {
     }
 
     private fun showVisitorCode() {
-        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
         val visitorContext = getContextAssetIdFromPrefs(sharedPreferences)
         val cv = GliaWidgets.getCallVisualizer()
         if (!visitorContext.isNullOrBlank()) {

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -91,7 +91,11 @@ public class GliaWidgets {
      */
     @NonNull
     public synchronized static EntryWidget getEntryWidget(@Nullable List<String> queueIds) {
-        setupQueueIds(queueIds);
+        if (Dependencies.glia().isInitialized()) {
+            setupQueueIds(queueIds);
+        } else {
+            Logger.w(TAG, "Attempt to get EntryWidget before SDK initialization");
+        }
 
         return Dependencies.getEntryWidget();
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/QueueMonitor.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/QueueMonitor.kt
@@ -1,0 +1,98 @@
+package com.glia.widgets.core.queue
+
+import android.annotation.SuppressLint
+import com.glia.androidsdk.RequestCallback
+import com.glia.androidsdk.queuing.Queue
+import com.glia.widgets.core.queue.domain.FetchQueuesUseCase
+import com.glia.widgets.core.queue.domain.SubscribeToQueueUpdatesUseCase
+import com.glia.widgets.core.queue.domain.UnsubscribeFromQueueUpdatesUseCase
+import com.glia.widgets.helper.Data
+import com.glia.widgets.launcher.ConfigurationManager
+import io.reactivex.rxjava3.core.BackpressureStrategy
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.processors.BehaviorProcessor
+import java.util.function.Consumer
+
+internal sealed interface QueueMonitorState {
+    object Loading : QueueMonitorState
+    data class Queues(val queues: List<Queue>) : QueueMonitorState
+    object Empty : QueueMonitorState
+    object Error : QueueMonitorState
+}
+
+internal class QueueMonitor(
+    configurationManager: ConfigurationManager,
+    private val fetchQueuesUseCase: FetchQueuesUseCase,
+    private val subscribeToQueueUpdatesUseCase: SubscribeToQueueUpdatesUseCase,
+    private val unsubscribeFromQueueUpdatesUseCase: UnsubscribeFromQueueUpdatesUseCase
+) {
+
+    // Queues received from an integrator or default queues
+    private val _integratorQueues: Flowable<List<Queue>> = configurationManager.queueIdsObservable
+        .flatMap(::findIntegratorQueues)
+
+    private val _observableIntegratorQueues: BehaviorProcessor<QueueMonitorState> = BehaviorProcessor.createDefault(QueueMonitorState.Loading)
+    val observableIntegratorQueues = _observableIntegratorQueues.hide()
+
+    private val queueUpdateCallback: Consumer<Queue> = Consumer {
+        updateQueuesList(it)
+    }
+
+    init {
+        subscribeToQueueUpdates()
+    }
+
+    private fun findIntegratorQueues(queueIds: Data<List<String>>): Flowable<List<Queue>> =
+        fetchSiteQueues()
+            .map { mapCurrentQueues(it, queueIds) }
+
+    private fun fetchSiteQueues(): Flowable<List<Queue>> = Flowable.create({
+        fetchQueuesUseCase(RequestCallback { queues, exception ->
+            if (exception == null) {
+                it.onNext(queues?.toList().orEmpty())
+            } else {
+                it.onError(exception)
+            }
+        })
+    }, BackpressureStrategy.LATEST)
+
+    @SuppressLint("CheckResult")
+    private fun subscribeToQueueUpdates() {
+        _integratorQueues.subscribe({
+            updateQueuesList(it)
+        }, {
+            _observableIntegratorQueues.onNext(QueueMonitorState.Error)
+        })
+    }
+
+    private fun updateQueuesList(queues: List<Queue>) {
+        unsubscribeFromQueueUpdatesUseCase(null, queueUpdateCallback)
+        if (queues.isEmpty()) {
+            _observableIntegratorQueues.onNext(QueueMonitorState.Empty)
+            return
+        }
+
+        _observableIntegratorQueues.onNext(QueueMonitorState.Queues(queues))
+        subscribeToQueueUpdatesUseCase(queues.map { it.id }.toTypedArray(), {}, queueUpdateCallback)
+    }
+
+    private fun updateQueuesList(queue: Queue) {
+        val updatedQueues = _observableIntegratorQueues.value
+            ?.let { it as? QueueMonitorState.Queues }
+            ?.run { queues.map { if (it.id == queue.id) queue else it } } ?: listOf(queue)
+
+        _observableIntegratorQueues.onNext(QueueMonitorState.Queues(updatedQueues))
+    }
+
+    private fun mapCurrentQueues(siteQueues: List<Queue>, queueIds: Data<List<String>>): List<Queue> {
+        return when (queueIds) {
+            is Data.Value -> {
+                siteQueues.filter { queueIds.result.contains(it.id) }
+            }
+
+            else -> {
+                siteQueues.filter { it.isDefault == true }
+            }
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/domain/FetchQueuesUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/domain/FetchQueuesUseCase.kt
@@ -1,0 +1,15 @@
+package com.glia.widgets.core.queue.domain
+
+import com.glia.androidsdk.RequestCallback
+import com.glia.androidsdk.queuing.Queue
+import com.glia.widgets.di.GliaCore
+
+internal interface FetchQueuesUseCase {
+    operator fun invoke(callback: RequestCallback<Array<Queue>?>)
+}
+
+internal class FetchQueuesUseCaseImpl(private val gliaCore: GliaCore): FetchQueuesUseCase {
+    override fun invoke(callback: RequestCallback<Array<Queue>?>) {
+        gliaCore.getQueues(callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/domain/SubscribeToQueueUpdatesUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/domain/SubscribeToQueueUpdatesUseCase.kt
@@ -1,0 +1,18 @@
+package com.glia.widgets.core.queue.domain
+
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.queuing.Queue
+import com.glia.widgets.di.GliaCore
+import java.util.function.Consumer
+
+internal interface SubscribeToQueueUpdatesUseCase {
+    operator fun invoke(queueIds: Array<String>, onError: Consumer<GliaException>, callback: Consumer<Queue>)
+}
+
+internal class SubscribeToQueueUpdatesUseCaseImpl(
+    private val gliaCore: GliaCore
+) : SubscribeToQueueUpdatesUseCase {
+    override fun invoke(queueIds: Array<String>, onError: Consumer<GliaException>, callback: Consumer<Queue>) {
+        gliaCore.subscribeToQueueStateUpdates(queueIds, onError, callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/domain/UnsubscribeFromQueueUpdatesUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/domain/UnsubscribeFromQueueUpdatesUseCase.kt
@@ -1,0 +1,18 @@
+package com.glia.widgets.core.queue.domain
+
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.queuing.Queue
+import com.glia.widgets.di.GliaCore
+import java.util.function.Consumer
+
+internal interface UnsubscribeFromQueueUpdatesUseCase {
+    operator fun invoke(onError: Consumer<GliaException>?, callback: Consumer<Queue>)
+}
+
+internal class UnsubscribeFromQueueUpdatesUseCaseImpl(
+    private val gliaCore: GliaCore
+) : UnsubscribeFromQueueUpdatesUseCase {
+    override fun invoke(onError: Consumer<GliaException>?, callback: Consumer<Queue>) {
+        gliaCore.unsubscribeFromQueueUpdates(onError, callback)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -14,6 +14,7 @@ import com.glia.widgets.chat.ChatContract;
 import com.glia.widgets.chat.controller.ChatController;
 import com.glia.widgets.core.dialog.DialogContract;
 import com.glia.widgets.core.dialog.DialogController;
+import com.glia.widgets.core.queue.QueueMonitor;
 import com.glia.widgets.engagement.completion.EngagementCompletionContract;
 import com.glia.widgets.engagement.completion.EngagementCompletionController;
 import com.glia.widgets.entrywidget.EntryWidgetContract;
@@ -386,6 +387,11 @@ public class ControllerFactory {
     }
 
     public EntryWidgetContract.Controller getEntryWidgetController() {
-        return new EntryWidgetController();
+        return new EntryWidgetController(new QueueMonitor(
+            configurationManager,
+            useCaseFactory.getFetchQueuesUseCase(),
+            useCaseFactory.getSubscribeToQueueUpdatesUseCase(),
+            useCaseFactory.getUnsubscribeFromQueueUpdatesUseCase()
+        ));
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -82,7 +82,8 @@ internal object Dependencies {
     val engagementLauncher: EngagementLauncher by lazy { EngagementLauncherImpl(activityLauncher) }
 
     @JvmStatic
-    val entryWidget: EntryWidget by lazy { EntryWidgetImpl(activityLauncher, gliaThemeManager) }
+    val entryWidget: EntryWidget
+        get() = EntryWidgetImpl(activityLauncher, gliaThemeManager)
 
     @JvmStatic
     lateinit var repositoryFactory: RepositoryFactory

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -68,4 +68,7 @@ internal interface GliaCore {
             throw GliaException("Glia SDK is not initialized", GliaException.Cause.INVALID_INPUT)
         }
     }
+
+    fun subscribeToQueueStateUpdates(queueIds: Array<String>, onError: Consumer<GliaException> , callback: Consumer<Queue>)
+    fun unsubscribeFromQueueUpdates(onError: Consumer<GliaException>?, callback: Consumer<Queue>)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -128,4 +128,12 @@ internal class GliaCoreImpl : GliaCore {
     override fun getAuthenticationManager(behavior: Authentication.Behavior): AuthenticationManager {
         return AuthenticationManager(Glia.getAuthentication(behavior))
     }
+
+    override fun subscribeToQueueStateUpdates(queueIds: Array<String>, onError: Consumer<GliaException>, callback: Consumer<Queue>) {
+        Glia.subscribeToQueueStateUpdates(queueIds, onError, callback)
+    }
+
+    override fun unsubscribeFromQueueUpdates(onError: Consumer<GliaException>?, callback: Consumer<Queue>) {
+        Glia.unsubscribeFromQueueUpdates(onError, callback)
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -102,6 +102,12 @@ import com.glia.widgets.core.permissions.domain.WithNotificationPermissionUseCas
 import com.glia.widgets.core.permissions.domain.WithNotificationPermissionUseCaseImpl;
 import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCase;
 import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCaseImpl;
+import com.glia.widgets.core.queue.domain.FetchQueuesUseCase;
+import com.glia.widgets.core.queue.domain.FetchQueuesUseCaseImpl;
+import com.glia.widgets.core.queue.domain.SubscribeToQueueUpdatesUseCase;
+import com.glia.widgets.core.queue.domain.SubscribeToQueueUpdatesUseCaseImpl;
+import com.glia.widgets.core.queue.domain.UnsubscribeFromQueueUpdatesUseCase;
+import com.glia.widgets.core.queue.domain.UnsubscribeFromQueueUpdatesUseCaseImpl;
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileAttachmentsObserverUseCase;
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileToAttachmentAndUploadUseCase;
 import com.glia.widgets.core.secureconversations.domain.GetAvailableQueueIdsForSecureMessagingUseCase;
@@ -1100,4 +1106,15 @@ public class UseCaseFactory {
         );
     }
 
+    public FetchQueuesUseCase getFetchQueuesUseCase() {
+        return new FetchQueuesUseCaseImpl(gliaCore);
+    }
+
+    public SubscribeToQueueUpdatesUseCase getSubscribeToQueueUpdatesUseCase() {
+        return new SubscribeToQueueUpdatesUseCaseImpl(gliaCore);
+    }
+
+    public UnsubscribeFromQueueUpdatesUseCase getUnsubscribeFromQueueUpdatesUseCase() {
+        return new UnsubscribeFromQueueUpdatesUseCaseImpl(gliaCore);
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
@@ -31,7 +31,11 @@ interface EntryWidget {
     fun hide()
 }
 
-internal class EntryWidgetImpl(private val activityLauncher: ActivityLauncher, private val themeManager: UnifiedThemeManager) : EntryWidget {
+internal class EntryWidgetImpl(
+    private val activityLauncher: ActivityLauncher,
+    private val themeManager: UnifiedThemeManager
+) : EntryWidget {
+
     override fun show(activity: Activity) = activityLauncher.launchEntryWidget(activity)
 
     override fun createEntryWidgetView(context: Context): View {

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
@@ -12,9 +12,9 @@ internal interface EntryWidgetContract {
     }
 
     enum class ItemType {
-        VIDEO_CALL,
-        AUDIO_CALL,
         CHAT,
+        AUDIO_CALL,
+        VIDEO_CALL,
         SECURE_MESSAGE,
         LOADING_STATE,
         EMPTY_STATE,

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
@@ -48,6 +48,7 @@ internal class EntryWidgetView(
         disableScrolling()
         applyTheme(backgroundTheme, mediaTypeItemsTheme)
         setController(Dependencies.controllerFactory.entryWidgetController)
+        itemAnimator = null
     }
 
     override fun setController(controller: EntryWidgetContract.Controller) {
@@ -56,7 +57,7 @@ internal class EntryWidgetView(
     }
 
     override fun showItems(items: List<EntryWidgetContract.ItemType>) {
-        viewAdapter.items = items
+        viewAdapter.submitList(items)
     }
 
     override fun dismiss() {

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
@@ -2,6 +2,8 @@ package com.glia.widgets.entrywidget.adapter
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.glia.widgets.databinding.EntryWidgetErrorItemBinding
 import com.glia.widgets.databinding.EntryWidgetMediaTypeItemBinding
@@ -19,7 +21,7 @@ internal class EntryWidgetAdapter(
     private val errorTitleTheme: TextTheme? = null,
     private val errorMessageTheme: TextTheme? = null,
     private val errorButtonTheme: ButtonTheme? = null
-) : RecyclerView.Adapter<EntryWidgetAdapter.ViewHolder>() {
+) : ListAdapter<EntryWidgetContract.ItemType, EntryWidgetAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     constructor(viewType: EntryWidgetContract.ViewType, entryWidgetTheme: EntryWidgetTheme?): this(
         viewType,
@@ -29,17 +31,31 @@ internal class EntryWidgetAdapter(
         entryWidgetTheme?.errorButton
     )
 
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<EntryWidgetContract.ItemType>() {
+            override fun areItemsTheSame(
+                oldItem: EntryWidgetContract.ItemType,
+                newItem: EntryWidgetContract.ItemType
+            ): Boolean {
+                // Whether items are the same
+                return oldItem.ordinal == newItem.ordinal
+            }
+
+            override fun areContentsTheSame(
+                oldItem: EntryWidgetContract.ItemType,
+                newItem: EntryWidgetContract.ItemType
+            ): Boolean {
+                // Whether content is the same
+                return oldItem.ordinal == newItem.ordinal
+            }
+        }
+    }
+
     enum class ViewType {
         CONTACT_ITEM,
         ERROR_ITEM,
         PROVIDED_BY_ITEM
     }
-
-    var items: List<EntryWidgetContract.ItemType>? = null
-        set(value) {
-            field = value
-            notifyDataSetChanged()
-        }
 
     var onItemClickListener: ((EntryWidgetContract.ItemType) -> Unit)? = null
 
@@ -63,7 +79,7 @@ internal class EntryWidgetAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        items?.get(position)?.let { item ->
+        getItem(position)?.let { item ->
             holder.bind(item) {
                 onItemClickListener?.invoke(item)
             }
@@ -71,16 +87,12 @@ internal class EntryWidgetAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        return when (items?.get(position)) {
+        return when (getItem(position)) {
             EntryWidgetContract.ItemType.EMPTY_STATE,
             EntryWidgetContract.ItemType.ERROR_STATE -> ViewType.ERROR_ITEM.ordinal
             EntryWidgetContract.ItemType.PROVIDED_BY -> ViewType.PROVIDED_BY_ITEM.ordinal
             else -> ViewType.CONTACT_ITEM.ordinal
         }
-    }
-
-    override fun getItemCount(): Int {
-        return items?.size ?: 0
     }
 
     abstract class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetItemDecoration.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetItemDecoration.kt
@@ -20,6 +20,9 @@ internal class EntryWidgetItemDecoration(
         for (i in 0 until childCount) {
             val child = parent.getChildAt(i)
             val position = parent.getChildAdapterPosition(child)
+            if (position == RecyclerView.NO_POSITION) {
+                continue
+            }
 
             val viewType = parent.adapter?.getItemViewType(position)
 
@@ -42,8 +45,10 @@ internal class EntryWidgetItemDecoration(
         state: RecyclerView.State
     ) {
         val position = parent.getChildAdapterPosition(view)
+        if (position == RecyclerView.NO_POSITION) {
+            return
+        }
         val viewType = parent.adapter?.getItemViewType(position)
-
         if (isContactItem(viewType)) {
             outRect.bottom = divider.intrinsicHeight
         } else {


### PR DESCRIPTION
[[Android] Devs want to implement the logic for showing available engagement types](https://glia.atlassian.net/browse/MOB-3411)

**What was solved?**
- Passing queues specified by integrator OR default queues to QueueMonitoring component
- Queue monitoring component subscribes to queue updates
- Each time queue is updated, the Queue monitoring component notifies the subscriber(s)
- Entry Widget Controller refreshes the available engagement types

**What has to be done?**
- Maybe extract standalone MonitorAvailableEngagementTypes component - separate PR
- Add unit tests - separate PR
- Add logs and align them with iOS (in "Devs want to add logging and telemetry" tickets)

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screen recording:**


https://github.com/user-attachments/assets/c7031e6f-564a-4d34-8251-a9bea118a3c7

