### PR TITLE
Update Entry Widget texts

### DIFF
--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -219,10 +219,10 @@
     <string name="entry_widget_live_chat_button_description">For the texter in all of us</string>
     <string name="entry_widget_live_chat_button_accessibility">Chat with us</string>
     <string name="entry_widget_audio_button_label">Audio</string>
-    <string name="entry_widget_audio_button_description">Speak through your phone</string>
+    <string name="entry_widget_audio_button_description">Speak through your device</string>
     <string name="entry_widget_audio_button_accessibility">Call with us</string>
     <string name="entry_widget_video_button_label">Video</string>
-    <string name="entry_widget_video_button_description">You’ll see us, but we won’t see you</string>
+    <string name="entry_widget_video_button_description">Face-to-face, just like in person</string>
     <string name="entry_widget_video_button_accessibility">Video call with us</string>
     <string name="entry_widget_secure_messaging_button_label">Secure Messaging</string>
     <string name="entry_widget_secure_messaging_button_description">Start a conversation, we’ll get back to you</string>


### PR DESCRIPTION

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3615

**What was solved?**
Texts have changed, updating according to [the Figma designs](https://www.figma.com/design/x5BLxm2UWpm3TuerdqmYi8/Glia-Mobile-App-Pages?node-id=12574-7393&node-type=frame&t=orLGIl8J9voTjKrd-0).

**Release notes:**

 - [x] Feature: part of the Entry Widgets feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
![Screenshot_20241003_114345](https://github.com/user-attachments/assets/ba212be9-0f0a-418e-892c-8edb31e288fd)


