### PR TITLE
Add gliaBrandPrimaryColor tint to entry widget icon tint.

### DIFF
--- a/widgetssdk/src/main/res/layout/entry_widget_media_type_item.xml
+++ b/widgetssdk/src/main/res/layout/entry_widget_media_type_item.xml
@@ -12,6 +12,7 @@
         android:layout_height="@dimen/glia_large_x_large"
         android:layout_marginStart="@dimen/glia_large"
         android:layout_marginEnd="@dimen/glia_large"
+        app:tint="?attr/gliaBrandPrimaryColor"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/title"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
