### PR TITLE
Send error event if Glia is not initialized before getting an Entry Widget

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -86,12 +86,11 @@ public class GliaWidgets {
      */
     @NonNull
     public synchronized static EntryWidget getEntryWidget(@Nullable List<String> queueIds) {
-        if (Dependencies.glia().isInitialized()) {
-            setupQueueIds(queueIds);
-        } else {
-            Logger.w(TAG, "Attempt to get EntryWidget before SDK initialization");
+        if (!Dependencies.glia().isInitialized()) {
+            Logger.e(TAG, "Attempt to get EntryWidget before SDK initialization");
         }
 
+        Dependencies.getConfigurationManager().setQueueIds(queueIds);
         return Dependencies.getEntryWidget();
     }
 


### PR DESCRIPTION
[MOB-3408](https://glia.atlassian.net/browse/MOB-3408)

**What was solved?**
According to requirements:

> Integrators can launch the Entry Widget view after the SDK setup. If SDK hasn’t been initialized or was initialized with an error - Widgets SDK should not crash, it should show an Entry Widget with an error state.

- Send an error event if Glia is not initialized before getting an Entry Widget
- Setup queues each time get Entry Widget is called

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-3408]: https://glia.atlassian.net/browse/MOB-3408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ