### PR TITLE
Change 'Try again' button style for Entry Widget error state according to design

### DIFF
--- a/widgetssdk/src/main/res/layout/entry_widget_error_item.xml
+++ b/widgetssdk/src/main/res/layout/entry_widget_error_item.xml
@@ -36,14 +36,16 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button"
+        style="?android:attr/borderlessButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/glia_large"
         android:textAllCaps="false"
-        android:textAppearance="?attr/textAppearanceBody1"
-        app:layout_constraintTop_toBottomOf="@id/description"
-        app:layout_constraintStart_toStartOf="parent"
+        android:textColor="?attr/gliaBrandPrimaryColor"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/description" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
[MOB-3478](https://glia.atlassian.net/browse/MOB-3478)

**What was solved?**
- Change 'Try again' button style for Entry Widget error state according to design

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img width="282" alt="Screenshot 2024-10-04 at 20 34 57" src="https://github.com/user-attachments/assets/8d02aa8b-5e45-48a8-8c4f-47b6277a6891">


[MOB-3478]: https://glia.atlassian.net/browse/MOB-3478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ