### PR TITLE
Entry Widget bottom sheet scrolling

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
@@ -45,7 +45,12 @@ internal class EntryWidgetView(
             controller.onItemClicked(it)
         }
 
-        disableScrolling()
+        val isBottomSheet = viewAdapter.viewType == EntryWidgetContract.ViewType.BOTTOM_SHEET
+        // Entry Widget might be embedded in scrolling views, disabling the scroll for
+        // itself would prevent unintended scrolling behavior in such cases.
+        // Scrolling is only applicable for bottom sheet view.
+        enableScrolling(isBottomSheet)
+
         applyTheme(backgroundTheme, mediaTypeItemsTheme)
         setController(Dependencies.controllerFactory.entryWidgetController)
         itemAnimator = null
@@ -64,12 +69,14 @@ internal class EntryWidgetView(
         onDismissListener?.invoke()
     }
 
-    private fun disableScrolling() {
-        // Entry Widget might be embedded in scrolling views, disabling the scroll for
-        // itself would prevent unintended scrolling behavior in such cases
-        isNestedScrollingEnabled = false
+    private fun enableScrolling(enable: Boolean) {
+        if (!enable) {
+            // setNestedScrollingEnabled() broke scrolling in some cases (bottom sheet).
+            // By default, it is enabled. So we can only disable it if needed.
+            isNestedScrollingEnabled = false
+        }
         layoutManager = object : LinearLayoutManager(context) {
-            override fun canScrollVertically() = false
+            override fun canScrollVertically() = enable
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
@@ -16,7 +16,7 @@ import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
 import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemsTheme
 
 internal class EntryWidgetAdapter(
-    private val viewType: EntryWidgetContract.ViewType,
+    val viewType: EntryWidgetContract.ViewType,
     private val mediaTypeItemsTheme: MediaTypeItemsTheme? = null,
     private val errorTitleTheme: TextTheme? = null,
     private val errorMessageTheme: TextTheme? = null,


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3642

**What was solved?**
Enabled scrolling for the Entry Widget bottom sheet content.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

https://github.com/user-attachments/assets/a0b936ef-1267-4507-aaf0-8f01c067496f