### PR TITLE
Pass null instead of an empty list if "Default Queues" toggle is enabled in Example App settings

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -284,10 +284,10 @@ class MainFragment : Fragment() {
         }
     }
 
-    private fun getQueueIdsFromPrefs(sharedPreferences: SharedPreferences): List<String> {
+    private fun getQueueIdsFromPrefs(sharedPreferences: SharedPreferences): List<String>? {
         val defaultQueues = sharedPreferences.getBoolean(resources.getString(R.string.pref_default_queues), false)
         if (defaultQueues) {
-            return emptyList()
+            return null
         }
         return listOf(getQueueIdFromPrefs(sharedPreferences))
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/launcher/ConfigurationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/launcher/ConfigurationManager.kt
@@ -63,6 +63,6 @@ internal class ConfigurationManagerImpl : ConfigurationManager {
     }
 
     override fun setQueueIds(queueIds: List<String>?) {
-        _queueIdsObservable.onNext(Data.from(queueIds))
+        _queueIdsObservable.onNext(Data.from(queueIds?.takeIf { it.isNotEmpty() }))
     }
 }


### PR DESCRIPTION
[MOB-3657](https://glia.atlassian.net/browse/MOB-3657)

**What was solved?**
1. Fixed the issue: enabled "Default Queues" toggle in Example App ends up with an empty Entry Widget state instead of a list of engagement types for default queues
2. Work with default queues if an integrator passes an empty queue list (the same as if null is passed)

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-3657]: https://glia.atlassian.net/browse/MOB-3657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ