### PR TITLE
Hide 'Secure Messaging' engagement type from Entry Widget if visitor is not authenticated

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -382,6 +382,9 @@ public class ControllerFactory {
     }
 
     public EntryWidgetContract.Controller getEntryWidgetController() {
-        return new EntryWidgetController(repositoryFactory.getQueueRepository());
+        return new EntryWidgetController(
+            repositoryFactory.getQueueRepository(),
+            useCaseFactory.createIsAuthenticatedUseCase()
+        );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -4,14 +4,17 @@ import android.annotation.SuppressLint
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.queuing.Queue
 import com.glia.androidsdk.queuing.QueueState
+import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.queue.QueuesState
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 
-internal class EntryWidgetController(private val queueRepository: QueueRepository) :
-    EntryWidgetContract.Controller {
+internal class EntryWidgetController(
+    private val queueRepository: QueueRepository,
+    private val isAuthenticatedUseCase: IsAuthenticatedUseCase
+) : EntryWidgetContract.Controller {
     private lateinit var view: EntryWidgetContract.View
 
     @SuppressLint("CheckResult")
@@ -48,7 +51,7 @@ internal class EntryWidgetController(private val queueRepository: QueueRepositor
                     if (allMedias.contains(Engagement.MediaType.TEXT)) add(EntryWidgetContract.ItemType.CHAT)
                     if (allMedias.contains(Engagement.MediaType.AUDIO)) add(EntryWidgetContract.ItemType.AUDIO_CALL)
                     if (allMedias.contains(Engagement.MediaType.VIDEO)) add(EntryWidgetContract.ItemType.VIDEO_CALL)
-                    if (allMedias.contains(Engagement.MediaType.MESSAGING)) add(EntryWidgetContract.ItemType.SECURE_MESSAGE)
+                    if (allMedias.contains(Engagement.MediaType.MESSAGING) && isAuthenticatedUseCase()) add(EntryWidgetContract.ItemType.SECURE_MESSAGE)
 
                     if (allMedias.isEmpty()) {
                         add(EntryWidgetContract.ItemType.EMPTY_STATE)


### PR DESCRIPTION
[MOB-3659](https://glia.atlassian.net/browse/MOB-3659)

**What was solved?**
- Hide 'Secure Messaging' engagement type from Entry Widget if visitor is not authenticated

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

https://github.com/user-attachments/assets/b7aeba7c-8ca1-4283-9e05-9a336622ce61




[MOB-3659]: https://glia.atlassian.net/browse/MOB-3659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ