### PR TITLE
Make queueIds list non-nullable, so only empty list means that default queues should be used

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -284,10 +284,10 @@ class MainFragment : Fragment() {
         }
     }
 
-    private fun getQueueIdsFromPrefs(sharedPreferences: SharedPreferences): List<String>? {
+    private fun getQueueIdsFromPrefs(sharedPreferences: SharedPreferences): List<String> {
         val defaultQueues = sharedPreferences.getBoolean(resources.getString(R.string.pref_default_queues), false)
         if (defaultQueues) {
-            return null
+            return emptyList()
         }
         return listOf(getQueueIdFromPrefs(sharedPreferences))
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -65,12 +65,12 @@ public class GliaWidgets {
      * Retrieves an instance of {@link EngagementLauncher}.
      *
      * @param queueIds A list of queue IDs to be used for the engagement launcher.
-     *                 When null, the default queues will be used.
+     *                 When empty, the default queues will be used.
      * @return An instance of {@link EngagementLauncher}.
      * @throws GliaException with the {@link GliaException.Cause#INVALID_INPUT} if the SDK is not initialized.
      */
     @NonNull
-    public synchronized static EngagementLauncher getEngagementLauncher(@Nullable List<String> queueIds) {
+    public synchronized static EngagementLauncher getEngagementLauncher(@NonNull List<String> queueIds) {
         setupQueueIds(queueIds);
 
         return Dependencies.getEngagementLauncher();
@@ -80,12 +80,12 @@ public class GliaWidgets {
      * Retrieves an instance of {@link EntryWidget}.
      *
      * @param queueIds A list of queue IDs to be used for the entry widget.
-     *                 When null, the default queues will be used.
+     *                 When empty, the default queues will be used.
      * @return An instance of {@link EntryWidget}.
      * @throws GliaException with the {@link GliaException.Cause#INVALID_INPUT} if the SDK is not initialized.
      */
     @NonNull
-    public synchronized static EntryWidget getEntryWidget(@Nullable List<String> queueIds) {
+    public synchronized static EntryWidget getEntryWidget(@NonNull List<String> queueIds) {
         if (!Dependencies.glia().isInitialized()) {
             Logger.e(TAG, "Attempt to get EntryWidget before SDK initialization");
         }
@@ -94,7 +94,7 @@ public class GliaWidgets {
         return Dependencies.getEntryWidget();
     }
 
-    private static void setupQueueIds(@Nullable List<String> queueIds) {
+    private static void setupQueueIds(@NonNull List<String> queueIds) {
         Dependencies.glia().ensureInitialized();
 
         Dependencies.getConfigurationManager().setQueueIds(queueIds);


### PR DESCRIPTION
[MOB-3657](https://glia.atlassian.net/browse/MOB-3657)

Based on the [discussion](https://salemove.slack.com/archives/C07DM3JD8R1/p1728642904648499).

**What was solved?**
- Make queueIds list non-nullable, so only empty list means that default queues should be used

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-3657]: https://glia.atlassian.net/browse/MOB-3657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ