### PR TITLE
Devs want to always fallback to default queues

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -65,7 +65,7 @@ public class GliaWidgets {
      * Retrieves an instance of {@link EngagementLauncher}.
      *
      * @param queueIds A list of queue IDs to be used for the engagement launcher.
-     *                 When empty, the default queues will be used.
+     *                 When empty or invalid, the default queues will be used.
      * @return An instance of {@link EngagementLauncher}.
      * @throws GliaException with the {@link GliaException.Cause#INVALID_INPUT} if the SDK is not initialized.
      */
@@ -80,7 +80,7 @@ public class GliaWidgets {
      * Retrieves an instance of {@link EntryWidget}.
      *
      * @param queueIds A list of queue IDs to be used for the entry widget.
-     *                 When empty, the default queues will be used.
+     *                 When empty or invalid, the default queues will be used.
      * @return An instance of {@link EntryWidget}.
      * @throws GliaException with the {@link GliaException.Cause#INVALID_INPUT} if the SDK is not initialized.
      */

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
@@ -24,7 +24,7 @@ internal class SecureConversationsRepository(private val secureConversations: Se
 
     fun send(payload: SendMessagePayload, callback: RequestCallback<VisitorMessage?>) {
         _messageSendingObservable.onNext(true)
-        secureConversations.send(payload.payload, queueRepository.integratorQueueIds.toTypedArray(), handleResult(callback))
+        secureConversations.send(payload.payload, queueRepository.relevantQueueIds.toTypedArray(), handleResult(callback))
     }
 
     fun send(payload: SendMessagePayload, listener: GliaSendMessageUseCase.Listener) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCase.kt
@@ -9,7 +9,7 @@ import io.reactivex.rxjava3.core.Flowable
 
 internal class IsMessagingAvailableUseCase(private val queueRepository: QueueRepository) {
 
-    operator fun invoke(): Flowable<Result<Boolean>> = queueRepository.observableIntegratorQueues
+    operator fun invoke(): Flowable<Result<Boolean>> = queueRepository.queuesState
         .filter { it !is QueuesState.Loading }
         .map { mapResult(it) }
         .distinctUntilChanged()

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -10,6 +10,7 @@ import com.glia.widgets.core.engagement.GliaOperatorRepositoryImpl;
 import com.glia.widgets.core.fileupload.FileAttachmentRepository;
 import com.glia.widgets.core.fileupload.SecureFileAttachmentRepository;
 import com.glia.widgets.core.queue.QueueRepository;
+import com.glia.widgets.core.queue.QueueRepositoryImpl;
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository;
 import com.glia.widgets.core.secureconversations.SendMessageRepository;
 import com.glia.widgets.core.survey.GliaSurveyRepository;
@@ -58,7 +59,7 @@ public class RepositoryFactory {
 
     public QueueRepository getQueueRepository() {
         if (queueRepository == null) {
-            queueRepository = new QueueRepository(gliaCore, configurationManager);
+            queueRepository = new QueueRepositoryImpl(gliaCore, configurationManager);
         }
         return queueRepository;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -20,7 +20,7 @@ internal class EntryWidgetController(
     @SuppressLint("CheckResult")
     override fun setView(view: EntryWidgetContract.View) {
         this.view = view
-        queueRepository.observableIntegratorQueues
+        queueRepository.queuesState
             .map(::mapState)
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(view::showItems)

--- a/widgetssdk/src/main/java/com/glia/widgets/launcher/ConfigurationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/launcher/ConfigurationManager.kt
@@ -3,8 +3,6 @@ package com.glia.widgets.launcher
 import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.widgets.GliaWidgets
 import com.glia.widgets.GliaWidgetsConfig
-import com.glia.widgets.helper.Data
-import com.glia.widgets.helper.from
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.processors.BehaviorProcessor
 
@@ -14,7 +12,7 @@ internal interface ConfigurationManager {
     val enableBubbleOutsideApp: Boolean
     val enableBubbleInsideApp: Boolean
 
-    val queueIdsObservable: Flowable<Data<List<String>>>
+    val queueIdsObservable: Flowable<List<String>>
     val queueIds: List<String>?
 
     /**
@@ -25,9 +23,9 @@ internal interface ConfigurationManager {
     /**
      * Retrives queue IDs
      * [queueIds] A list of queue IDs to be used for the engagement launcher.
-     * When null, the default queues will be used.
+     * When empty or invalid, the default queues will be used.
      */
-    fun setQueueIds(queueIds: List<String>?)
+    fun setQueueIds(queueIds: List<String>)
 }
 
 internal class ConfigurationManagerImpl : ConfigurationManager {
@@ -43,11 +41,11 @@ internal class ConfigurationManagerImpl : ConfigurationManager {
     override val enableBubbleInsideApp: Boolean
         get() = _enableBubbleInsideApp
 
-    private var _queueIdsObservable: BehaviorProcessor<Data<List<String>>> = BehaviorProcessor.create()
-    override val queueIdsObservable: Flowable<Data<List<String>>> = _queueIdsObservable.onBackpressureLatest()
+    private var _queueIdsObservable: BehaviorProcessor<List<String>> = BehaviorProcessor.create()
+    override val queueIdsObservable: Flowable<List<String>> = _queueIdsObservable.onBackpressureLatest()
 
     override val queueIds: List<String>?
-        get() = _queueIdsObservable.value?.valueOrNull
+        get() = _queueIdsObservable.value
 
     override fun applyConfiguration(config: GliaWidgetsConfig) {
         config.screenSharingMode?.also { _screenSharingMode = it }
@@ -55,7 +53,7 @@ internal class ConfigurationManagerImpl : ConfigurationManager {
         config.enableBubbleOutsideApp?.also { _enableBubbleOutsideApp = it }
     }
 
-    override fun setQueueIds(queueIds: List<String>?) {
-        _queueIdsObservable.onNext(Data.from(queueIds?.takeIf { it.isNotEmpty() }))
+    override fun setQueueIds(queueIds: List<String>) {
+        _queueIdsObservable.onNext(queueIds)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCaseTest.kt
@@ -37,7 +37,7 @@ class IsMessagingAvailableUseCaseTest {
     fun `invoke returns true when queue with messaging exists`() {
         val messagingQueue = createQueueWithStatus(QueueState.Status.OPEN, true)
         val queuesState = QueuesState.Queues(listOf(messagingQueue))
-        every { queueRepository.observableIntegratorQueues } returns Flowable.just(queuesState)
+        every { queueRepository.queuesState } returns Flowable.just(queuesState)
 
         val testSubscriber = TestSubscriber<Result<Boolean>>()
         isMessagingAvailableUseCase().subscribe(testSubscriber)
@@ -49,7 +49,7 @@ class IsMessagingAvailableUseCaseTest {
     fun `invoke returns false when no queue with messaging exists`() {
         val nonMessagingQueue = createQueueWithStatus(QueueState.Status.OPEN, false)
         val queuesState = QueuesState.Queues(listOf(nonMessagingQueue))
-        every { queueRepository.observableIntegratorQueues } returns Flowable.just(queuesState)
+        every { queueRepository.queuesState } returns Flowable.just(queuesState)
 
         val testSubscriber = TestSubscriber<Result<Boolean>>()
         isMessagingAvailableUseCase().subscribe(testSubscriber)
@@ -61,7 +61,7 @@ class IsMessagingAvailableUseCaseTest {
     fun `invoke returns false when queue state is closed`() {
         val closedQueue = createQueueWithStatus(QueueState.Status.CLOSED, true)
         val queuesState = QueuesState.Queues(listOf(closedQueue))
-        every { queueRepository.observableIntegratorQueues } returns Flowable.just(queuesState)
+        every { queueRepository.queuesState } returns Flowable.just(queuesState)
 
         val testSubscriber = TestSubscriber<Result<Boolean>>()
         isMessagingAvailableUseCase().subscribe(testSubscriber)
@@ -73,7 +73,7 @@ class IsMessagingAvailableUseCaseTest {
     fun `invoke returns false when queue state is unknown`() {
         val unknownQueue = createQueueWithStatus(QueueState.Status.UNKNOWN, true)
         val queuesState = QueuesState.Queues(listOf(unknownQueue))
-        every { queueRepository.observableIntegratorQueues } returns Flowable.just(queuesState)
+        every { queueRepository.queuesState } returns Flowable.just(queuesState)
 
         val testSubscriber = TestSubscriber<Result<Boolean>>()
         isMessagingAvailableUseCase().subscribe(testSubscriber)
@@ -84,7 +84,7 @@ class IsMessagingAvailableUseCaseTest {
     @Test
     fun `invoke returns error when queue state is error`() {
         val errorState = QueuesState.Error(Throwable("Error"))
-        every { queueRepository.observableIntegratorQueues } returns Flowable.just(errorState)
+        every { queueRepository.queuesState } returns Flowable.just(errorState)
 
         val testSubscriber = TestSubscriber<Result<Boolean>>()
         isMessagingAvailableUseCase().subscribe(testSubscriber)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3673

**What was solved?**
- Always fallback to default queues when integrator queues are empty or don't match
- Fix tests
- Add additional Logs.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
