### PR TITLE
Added loading tint color customization

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetMediaTypeItemViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetMediaTypeItemViewHolder.kt
@@ -5,6 +5,7 @@ import androidx.core.view.isVisible
 import com.glia.widgets.R
 import com.glia.widgets.databinding.EntryWidgetMediaTypeItemBinding
 import com.glia.widgets.entrywidget.EntryWidgetContract
+import com.glia.widgets.helper.applyShadow
 import com.glia.widgets.helper.setLocaleContentDescription
 import com.glia.widgets.helper.setLocaleText
 import com.glia.widgets.view.unifiedui.applyImageColorTheme
@@ -23,6 +24,11 @@ internal class EntryWidgetMediaTypeItemViewHolder(
             binding.title.applyTextTheme(it.title)
             binding.description.applyTextTheme(it.message)
             binding.icon.applyImageColorTheme(it.iconColor)
+            it.loadingTintColor?.primaryColorStateList?.let { tintList ->
+                binding.iconLoading.backgroundTintList = tintList
+                binding.titleLoading.backgroundTintList = tintList
+                binding.descriptionLoading.backgroundTintList = tintList
+            }
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/MediaTypeItemRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/entrywidget/MediaTypeItemRemoteConfig.kt
@@ -14,12 +14,15 @@ internal data class MediaTypeItemRemoteConfig(
     @SerializedName("title")
     val title: TextRemoteConfig?,
     @SerializedName("message")
-    val message: TextRemoteConfig?
+    val message: TextRemoteConfig?,
+    @SerializedName("loadingTintColor")
+    val loadingTintColor: ColorLayerRemoteConfig?
 ) {
     fun toMediaTypeItemTheme(): MediaTypeItemTheme = MediaTypeItemTheme(
         background = background?.toLayerTheme(),
         iconColor = iconColor?.toColorTheme(),
         title = title?.toTextTheme(),
-        message = message?.toTextTheme()
+        message = message?.toTextTheme(),
+        loadingTintColor = loadingTintColor?.toColorTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/EntryWidget.kt
@@ -39,7 +39,8 @@ internal fun DefaultMediaItemTypeTheme(pallet: ColorPallet?): MediaTypeItemTheme
                 textColor = baseDarkColorTheme
             ),
             message = TextTheme(
-                textColor = baseShadeColorTheme
-            )
+                textColor = baseNormalColorTheme
+            ),
+            loadingTintColor = baseShadeColorTheme
         )
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/MediaTypeItemTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/entrywidget/MediaTypeItemTheme.kt
@@ -10,12 +10,14 @@ internal data class MediaTypeItemTheme(
     val background: LayerTheme? = null,
     val iconColor: ColorTheme? = null,
     val title: TextTheme? = null,
-    val message: TextTheme? = null
+    val message: TextTheme? = null,
+    val loadingTintColor: ColorTheme? = null
 ) : Mergeable<MediaTypeItemTheme> {
     override fun merge(other: MediaTypeItemTheme): MediaTypeItemTheme = MediaTypeItemTheme(
         background = background merge other.background,
         iconColor = iconColor merge other.iconColor,
         title = title merge other.title,
-        message = message merge other.message
+        message = message merge other.message,
+        loadingTintColor = loadingTintColor merge other.loadingTintColor
     )
 }

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_contactsWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_contactsWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68b51dffdeb10da6fce5d29f20b9969878be2188fa61ffe3c4829e0874d39543
-size 188391
+oid sha256:d4151fe5a85a84d89530b48b6dcd02b681872c5acff52dceef6ea01cc03a8f8e
+size 188393

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_contactsWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_contactsWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d487b28f90037897240bf03066f36e854013c4e8ae78bfe5ac6b49e11c6eb3bf
-size 123544
+oid sha256:40852e0be7bf416ae03fc79be77d2a33745018d8c276a5c1a6757d50d418b8c2
+size 125375

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_loadingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_loadingWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44c4c05adf2e29730030db6ec2cef450e06f6c6db6781bbcfe1c12451c511524
-size 54160
+oid sha256:c49be404d586bb5870b9f4d86ceb820bb91453f356dc5e71296a29ab6c01199d
+size 54850

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_loadingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewBottomSheetTypeTest_loadingWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:350f88a3145518131535314a8ebd09d3f218ef752cc5ea26144c554f3f931a21
-size 25670
+oid sha256:b8c070cc1edfe1a3bad302fb39d935b015ac2cd099c69bbab63848e72b146741
+size 27081

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_contactsWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_contactsWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68b51dffdeb10da6fce5d29f20b9969878be2188fa61ffe3c4829e0874d39543
-size 188391
+oid sha256:d4151fe5a85a84d89530b48b6dcd02b681872c5acff52dceef6ea01cc03a8f8e
+size 188393

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_contactsWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_contactsWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d487b28f90037897240bf03066f36e854013c4e8ae78bfe5ac6b49e11c6eb3bf
-size 123544
+oid sha256:40852e0be7bf416ae03fc79be77d2a33745018d8c276a5c1a6757d50d418b8c2
+size 125375

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_loadingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_loadingWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44c4c05adf2e29730030db6ec2cef450e06f6c6db6781bbcfe1c12451c511524
-size 54160
+oid sha256:c49be404d586bb5870b9f4d86ceb820bb91453f356dc5e71296a29ab6c01199d
+size 54850

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_loadingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetViewEmbeddedViewTypeTest_loadingWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:350f88a3145518131535314a8ebd09d3f218ef752cc5ea26144c554f3f931a21
-size 25670
+oid sha256:b8c070cc1edfe1a3bad302fb39d935b015ac2cd099c69bbab63848e72b146741
+size 27081

--- a/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
+++ b/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
@@ -4019,6 +4019,10 @@
             "type": "fill",
             "value": ["#687022"]
           }
+        },
+        "loadingTintColor": {
+          "type": "gradient",
+          "value": ["#FF8E45", "#FF7CB9"]
         }
       },
       "dividerColor": {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3591

**What was solved?**
Added loading tint color customization for the Entry Widget

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img src="https://github.com/user-attachments/assets/8efb78c5-1be1-407b-bef0-9deacc3c1539" width="350" />

<img src="https://github.com/user-attachments/assets/27f39f9e-359f-4219-b726-6392949564b2" width="350" />
