### PR TITLE
Fix! Messages are not added to the chat immediately after input

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -52,8 +52,8 @@ import com.glia.widgets.core.notification.domain.CallNotificationUseCase
 import com.glia.widgets.core.permissions.domain.RequestNotificationPermissionIfPushNotificationsSetUpUseCase
 import com.glia.widgets.core.permissions.domain.WithCameraPermissionUseCase
 import com.glia.widgets.core.permissions.domain.WithReadWritePermissionsUseCase
-import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase
 import com.glia.widgets.core.secureconversations.domain.GetAvailableQueueIdsForSecureMessagingUseCase
+import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.engagement.EngagementUpdateState
 import com.glia.widgets.engagement.ScreenSharingState
@@ -153,8 +153,12 @@ internal class ChatController(
             emitViewState { chatState.setLastTypedText("").setShowSendButton(isShowSendButtonUseCase("")) }
         }
 
-        override fun errorOperatorNotOnline(message: Unsent) {
-            onSendMessageOperatorOffline(message)
+        override fun onMessagePrepared(message: Unsent) {
+            appendUnsentMessage(message)
+        }
+
+        override fun errorOperatorOffline() {
+            onSendMessageOperatorOffline()
         }
 
         override fun error(ex: GliaException, message: Unsent) {
@@ -374,8 +378,7 @@ internal class ChatController(
         scrollChatToBottom()
     }
 
-    private fun onSendMessageOperatorOffline(message: Unsent) {
-        appendUnsentMessage(message)
+    private fun onSendMessageOperatorOffline() {
         if (!chatState.engagementRequested) {
             viewInitPreQueueing()
         }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3664

**What was solved?**
### Before

https://github.com/user-attachments/assets/cc791fef-0324-4b41-a68c-58e8071e9a69
### After

https://github.com/user-attachments/assets/b3da1f36-2e9a-4303-93b5-231094efa8c4


**Release notes:**
Visitor messages will appear immediately after the send button is clicked.

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
