### PR TITLE
Refactor queue management to avoid race conditions

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -11,7 +11,7 @@
     <!-- Must be included for dialog styling -->
     <style name="Application.Glia.Activity.Style" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- example usage of compile time styling -->
-        <item name="gliaChatStyle">@style/Theme.GliaAndroidSdkWidgetsExample.Chat</item>
+        <!--        <item name="gliaChatStyle">@style/Theme.GliaAndroidSdkWidgetsExample.Chat</item>-->
     </style>
 
     <style name="Theme.GliaAndroidSdkWidgetsExample.Chat" parent="Application.Glia.Chat">

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.java
@@ -10,6 +10,7 @@ import com.glia.widgets.chat.model.SendMessagePayload;
 import com.glia.widgets.chat.model.Unsent;
 import com.glia.widgets.di.GliaCore;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -26,7 +27,7 @@ public class GliaChatRepository {
      * @hide
      */
     public interface HistoryLoadedListener {
-        void loaded(ChatMessage[] messages, Throwable error);
+        void loaded(List<ChatMessage> messages, Throwable error);
     }
 
     public void loadHistory(HistoryLoadedListener historyLoadedListener) {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaLoadHistoryUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaLoadHistoryUseCase.kt
@@ -32,7 +32,7 @@ internal class GliaLoadHistoryUseCase(
     ) { messages, count -> ChatHistoryResponse(messages, count) }
 
     private fun loadHistoryAndMapOperator(): Single<MutableList<ChatMessageInternal>> = loadHistory()
-        .flatMapPublisher { Flowable.fromArray(*it) }
+        .flatMapPublisher { Flowable.fromIterable(it) }
         .concatMapSingle { mapOperatorUseCase(chatMessage = it) }
         .toSortedList(Comparator.comparingLong { it.chatMessage.timestamp })
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -58,6 +58,7 @@ public class ControllerFactory {
     private final UseCaseFactory useCaseFactory;
     private final ImagePreviewContract.Controller filePreviewController;
     private final ManagerFactory managerFactory;
+    private final GliaCore core;
     private EngagementCompletionContract.Controller engagementCompletionController;
     private ChatContract.Controller retainedChatController;
     private CallContract.Controller retainedCallController;
@@ -69,7 +70,8 @@ public class ControllerFactory {
     public ControllerFactory(
         RepositoryFactory repositoryFactory,
         UseCaseFactory useCaseFactory,
-        ManagerFactory managerFactory
+        ManagerFactory managerFactory,
+        GliaCore core
     ) {
         this.repositoryFactory = repositoryFactory;
         messagesNotSeenHandler = new MessagesNotSeenHandler(
@@ -77,6 +79,7 @@ public class ControllerFactory {
         );
 
         this.useCaseFactory = useCaseFactory;
+        this.core = core;
         this.dialogController = new DialogController();
         this.filePreviewController = new ImagePreviewController(
             useCaseFactory.createGetImageFileFromDownloadsUseCase(),
@@ -384,7 +387,8 @@ public class ControllerFactory {
     public EntryWidgetContract.Controller getEntryWidgetController() {
         return new EntryWidgetController(
             repositoryFactory.getQueueRepository(),
-            useCaseFactory.createIsAuthenticatedUseCase()
+            useCaseFactory.createIsAuthenticatedUseCase(),
+            core
         );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -126,6 +126,7 @@ internal object Dependencies {
             repositoryFactory,
             useCaseFactory,
             managerFactory,
+            gliaCore
         )
         initApplicationLifecycleObserver(
             ApplicationLifecycleManager(),
@@ -186,6 +187,7 @@ internal object Dependencies {
         gliaCore.init(gliaConfig)
         controllerFactory.init()
         repositoryFactory.engagementRepository.initialize()
+        repositoryFactory.queueRepository.initialize()
         configurationManager.applyConfiguration(gliaWidgetsConfig)
         localeProvider.setCompanyName(gliaWidgetsConfig.companyName)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -41,11 +41,11 @@ internal interface GliaCore {
     fun <T> off(event: OmnicoreEvent<T>, listener: Consumer<T>)
     fun <T> off(event: OmnicoreEvent<T>)
     fun fetchFile(attachmentFile: AttachmentFile, callback: RequestCallback<InputStream?>)
-    fun getChatHistory(callback: RequestCallback<Array<ChatMessage>?>)
-    fun getQueues(requestCallback: RequestCallback<Array<Queue>?>)
+    fun getChatHistory(callback: RequestCallback<List<ChatMessage>?>)
+    fun getQueues(requestCallback: RequestCallback<List<Queue>?>)
 
     fun queueForEngagement(
-        queueIds: Array<String>,
+        queueIds: List<String>,
         mediaType: Engagement.MediaType,
         visitorContextAssetId: String?,
         engagementOptions: EngagementOptions?,
@@ -69,6 +69,6 @@ internal interface GliaCore {
         }
     }
 
-    fun subscribeToQueueStateUpdates(queueIds: Array<String>, onError: Consumer<GliaException> , callback: Consumer<Queue>)
+    fun subscribeToQueueStateUpdates(queueIds: List<String>, onError: Consumer<GliaException>, callback: Consumer<Queue>)
     fun unsubscribeFromQueueUpdates(onError: Consumer<GliaException>?, callback: Consumer<Queue>)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -78,23 +78,23 @@ internal class GliaCoreImpl : GliaCore {
         Glia.fetchFile(attachmentFile, callback)
     }
 
-    override fun getChatHistory(callback: RequestCallback<Array<ChatMessage>?>) {
-        Glia.getChatHistory(callback)
+    override fun getChatHistory(callback: RequestCallback<List<ChatMessage>?>) {
+        Glia.getChatHistory { messages, exception -> callback.onResult(messages?.toList(), exception) }
     }
 
-    override fun getQueues(requestCallback: RequestCallback<Array<Queue>?>) {
-        Glia.getQueues(requestCallback)
+    override fun getQueues(requestCallback: RequestCallback<List<Queue>?>) {
+        Glia.getQueues { queues, exception -> requestCallback.onResult(queues?.toList(), exception) }
     }
 
     override fun queueForEngagement(
-        queueIds: Array<String>,
+        queueIds: List<String>,
         mediaType: Engagement.MediaType,
         visitorContextAssetId: String?,
         engagementOptions: EngagementOptions?,
         mediaPermissionRequestCode: Int,
         callback: Consumer<GliaException?>
     ) {
-        Glia.queueForEngagement(queueIds, mediaType, visitorContextAssetId, engagementOptions, mediaPermissionRequestCode, callback)
+        Glia.queueForEngagement(queueIds.toTypedArray(), mediaType, visitorContextAssetId, engagementOptions, mediaPermissionRequestCode, callback)
     }
 
     override fun cancelQueueTicket(queueTicketId: String, callback: Consumer<GliaException?>) {
@@ -129,8 +129,8 @@ internal class GliaCoreImpl : GliaCore {
         return AuthenticationManager(Glia.getAuthentication(behavior))
     }
 
-    override fun subscribeToQueueStateUpdates(queueIds: Array<String>, onError: Consumer<GliaException>, callback: Consumer<Queue>) {
-        Glia.subscribeToQueueStateUpdates(queueIds, onError, callback)
+    override fun subscribeToQueueStateUpdates(queueIds: List<String>, onError: Consumer<GliaException>, callback: Consumer<Queue>) {
+        Glia.subscribeToQueueStateUpdates(queueIds.toTypedArray(), onError, callback)
     }
 
     override fun unsubscribeFromQueueUpdates(onError: Consumer<GliaException>?, callback: Consumer<Queue>) {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -149,7 +149,7 @@ public class RepositoryFactory {
 
     public EngagementRepository getEngagementRepository() {
         if (engagementRepository == null) {
-            engagementRepository = new EngagementRepositoryImpl(gliaCore, getOperatorRepository());
+            engagementRepository = new EngagementRepositoryImpl(gliaCore, getOperatorRepository(), getQueueRepository());
         }
         return engagementRepository;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -956,7 +956,7 @@ public class UseCaseFactory {
 
     @NonNull
     public EnqueueForEngagementUseCase getQueueForEngagementUseCase() {
-        return new EnqueueForEngagementUseCaseImpl(repositoryFactory.getEngagementRepository(), repositoryFactory.getQueueRepository());
+        return new EnqueueForEngagementUseCaseImpl(repositoryFactory.getEngagementRepository());
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
@@ -45,7 +45,7 @@ internal interface EngagementRepository {
     fun reset()
     fun resetQueueing()
     fun endEngagement(silently: Boolean)
-    fun queueForEngagement(queueIds: List<String>, mediaType: MediaType)
+    fun queueForEngagement(mediaType: MediaType)
     fun cancelQueuing()
     fun acceptCurrentEngagementRequest(visitorContextAssetId: String)
     fun declineCurrentEngagementRequest()

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
@@ -6,16 +6,16 @@ import com.glia.androidsdk.engagement.EngagementState
 import com.glia.androidsdk.engagement.Survey
 
 internal sealed interface State {
-    object NoEngagement : State
-    data class PreQueuing(val queueIds: List<String>, val mediaType: MediaType) : State
-    data class Queuing(val queueIds: List<String>, val queueTicketId: String, val mediaType: MediaType) : State
-    object QueueUnstaffed : State
-    object UnexpectedErrorHappened : State
-    object QueueingCanceled : State
-    object StartedOmniCore : State
-    object StartedCallVisualizer : State
-    object FinishedOmniCore : State
-    object FinishedCallVisualizer : State
+    data object NoEngagement : State
+    data class PreQueuing(val mediaType: MediaType) : State
+    data class Queuing(val queueTicketId: String, val mediaType: MediaType) : State
+    data object QueueUnstaffed : State
+    data object UnexpectedErrorHappened : State
+    data object QueueingCanceled : State
+    data object StartedOmniCore : State
+    data object StartedCallVisualizer : State
+    data object FinishedOmniCore : State
+    data object FinishedCallVisualizer : State
     data class Update(val state: EngagementState, val updateState: EngagementUpdateState) : State
 
     val queueingMediaType: MediaType?
@@ -27,23 +27,23 @@ internal sealed interface State {
 }
 
 internal sealed interface EngagementUpdateState {
-    object Transferring : EngagementUpdateState
+    data object Transferring : EngagementUpdateState
     data class Ongoing(val operator: Operator) : EngagementUpdateState
     data class OperatorConnected(val operator: Operator) : EngagementUpdateState
     data class OperatorChanged(val operator: Operator) : EngagementUpdateState
 }
 
 internal sealed interface SurveyState {
-    object Empty : SurveyState
-    object EmptyFromOperatorRequest : SurveyState
+    data object Empty : SurveyState
+    data object EmptyFromOperatorRequest : SurveyState
     data class Value(val survey: Survey) : SurveyState
 }
 
 internal sealed interface ScreenSharingState {
-    object Requested : ScreenSharingState
-    object Started : ScreenSharingState
-    object RequestAccepted : ScreenSharingState
-    object RequestDeclined : ScreenSharingState
+    data object Requested : ScreenSharingState
+    data object Started : ScreenSharingState
+    data object RequestAccepted : ScreenSharingState
+    data object RequestDeclined : ScreenSharingState
     data class FailedToAcceptRequest(val message: String) : ScreenSharingState
-    object Ended : ScreenSharingState
+    data object Ended : ScreenSharingState
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EnqueueForEngagementUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EnqueueForEngagementUseCase.kt
@@ -1,16 +1,12 @@
 package com.glia.widgets.engagement.domain
 
 import com.glia.androidsdk.Engagement
-import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.engagement.EngagementRepository
 
 internal interface EnqueueForEngagementUseCase {
     operator fun invoke(mediaType: Engagement.MediaType = Engagement.MediaType.TEXT)
 }
 
-internal class EnqueueForEngagementUseCaseImpl(
-    private val engagementRepository: EngagementRepository,
-    private val queueRepository: QueueRepository
-) : EnqueueForEngagementUseCase {
-    override fun invoke(mediaType: Engagement.MediaType) = engagementRepository.queueForEngagement(queueRepository.relevantQueueIds, mediaType)
+internal class EnqueueForEngagementUseCaseImpl(private val engagementRepository: EngagementRepository) : EnqueueForEngagementUseCase {
+    override fun invoke(mediaType: Engagement.MediaType) = engagementRepository.queueForEngagement(mediaType)
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
@@ -6,10 +6,12 @@ import com.glia.androidsdk.GliaConfig
 import com.glia.androidsdk.SiteApiKey
 import com.glia.androidsdk.omnibrowse.Omnibrowse
 import com.glia.widgets.callvisualizer.controller.CallVisualizerController
+import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.di.ControllerFactory
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.di.RepositoryFactory
+import com.glia.widgets.engagement.EngagementRepository
 import org.junit.Assert
 import org.junit.Before
 import org.junit.ClassRule
@@ -69,11 +71,16 @@ class GliaWidgetsTest {
         whenever(gliaCore.callVisualizer).thenReturn(callVisualizer)
         val callVisualizerController = mock<CallVisualizerController>()
         whenever(controllerFactory.callVisualizerController).thenReturn(callVisualizerController)
-        whenever(repositoryFactory.engagementRepository) doReturn mock()
+        val engagementRepository = mock<EngagementRepository>()
+        whenever(repositoryFactory.engagementRepository) doReturn engagementRepository
         whenever(repositoryFactory.engagementConfigRepository) doReturn mock()
+        val queueRepository = mock<QueueRepository>()
+        whenever(repositoryFactory.queueRepository) doReturn queueRepository
         GliaWidgets.init(widgetsConfig)
         val captor = argumentCaptor<GliaConfig>()
         verify(gliaCore).init(captor.capture())
+        verify(engagementRepository).initialize()
+        verify(queueRepository).initialize()
         val gliaConfig = captor.lastValue
         Assert.assertEquals(siteApiKey, gliaConfig.siteApiKey)
         Assert.assertEquals(siteId, gliaConfig.siteId)

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionControllerTest.kt
@@ -103,8 +103,8 @@ class EngagementCompletionControllerTest {
         val testState = controller.state.test()
 
         engagementStateProcessor.onNext(State.NoEngagement)
-        engagementStateProcessor.onNext(State.PreQueuing(listOf("queueId"), Engagement.MediaType.TEXT))
-        engagementStateProcessor.onNext(State.Queuing(listOf("queueId"), "queueTicketId", Engagement.MediaType.TEXT))
+        engagementStateProcessor.onNext(State.PreQueuing(Engagement.MediaType.TEXT))
+        engagementStateProcessor.onNext(State.Queuing("queueTicketId", Engagement.MediaType.TEXT))
         engagementStateProcessor.onNext(State.QueueingCanceled)
         engagementStateProcessor.onNext(State.StartedOmniCore)
         engagementStateProcessor.onNext(State.StartedCallVisualizer)

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementDomainTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementDomainTest.kt
@@ -18,7 +18,6 @@ import com.glia.widgets.core.engagement.GliaEngagementConfigRepository
 import com.glia.widgets.core.fileupload.FileAttachmentRepository
 import com.glia.widgets.core.notification.domain.CallNotificationUseCase
 import com.glia.widgets.core.permissions.PermissionManager
-import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.screensharing.MEDIA_PROJECTION_SERVICE_ACTION_START
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.engagement.EngagementRepository
@@ -316,12 +315,10 @@ class EngagementDomainTest {
         val queueIds = listOf("queueId1", "queueId2")
         val mediaType: Engagement.MediaType = mockk(relaxUnitFun = true)
 
-        val queueRepository = mockk<QueueRepository>()
-        every { queueRepository.relevantQueueIds } returns queueIds
-        val useCase: EnqueueForEngagementUseCase = EnqueueForEngagementUseCaseImpl(engagementRepository = repository, queueRepository)
+        val useCase: EnqueueForEngagementUseCase = EnqueueForEngagementUseCaseImpl(engagementRepository = repository)
         useCase(mediaType)
 
-        verify { repository.queueForEngagement(queueIds, mediaType) }
+        verify { repository.queueForEngagement(mediaType) }
     }
 
     @Test

--- a/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
@@ -142,7 +142,7 @@ internal class ActivityWatcherForChatHeadTest {
     fun `bubble will be updated when PreQueuing`() {
         mockShouldShowChatHead()
 
-        engagementStateFlowable.onNext(State.PreQueuing(listOf(""), Engagement.MediaType.TEXT))
+        engagementStateFlowable.onNext(State.PreQueuing(Engagement.MediaType.TEXT))
         verifyBubbleIsShowed(times = 2)
     }
 
@@ -150,7 +150,7 @@ internal class ActivityWatcherForChatHeadTest {
     fun `bubble will be updated when Queueing is started`() {
         mockShouldShowChatHead()
 
-        engagementStateFlowable.onNext(State.Queuing(listOf(""), "", Engagement.MediaType.TEXT))
+        engagementStateFlowable.onNext(State.Queuing("", Engagement.MediaType.TEXT))
         verifyBubbleIsShowed(times = 2)
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3698

**What was solved?**
In my previous change, I didn't consider that, in some circumstances, we're requesting relevant queues before we receive the site queues from the server. Therefore, I made everything reactive, improved readability and added an initialization check in EntryWidgetController to show an `Error` state immediately if the SDK is not initialized.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
