### PR TITLE
Implement the hide() interface

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -18,6 +18,7 @@ import com.glia.widgets.engagement.completion.EngagementCompletionContract;
 import com.glia.widgets.engagement.completion.EngagementCompletionController;
 import com.glia.widgets.entrywidget.EntryWidgetContract;
 import com.glia.widgets.entrywidget.EntryWidgetController;
+import com.glia.widgets.entrywidget.EntryWidgetHideController;
 import com.glia.widgets.filepreview.ui.ImagePreviewContract;
 import com.glia.widgets.filepreview.ui.ImagePreviewController;
 import com.glia.widgets.helper.Logger;
@@ -66,6 +67,7 @@ public class ControllerFactory {
     private CallVisualizerContract.Controller callVisualizerController;
     private ActivityWatcherForChatHeadController activityWatcherForChatHeadController;
     private ActivityWatcherForLiveObservationController activityWatcherForLiveObservationController;
+    private EntryWidgetHideController entryWidgetHideController;
 
     public ControllerFactory(
         RepositoryFactory repositoryFactory,
@@ -390,5 +392,12 @@ public class ControllerFactory {
             useCaseFactory.createIsAuthenticatedUseCase(),
             core
         );
+    }
+
+    public EntryWidgetHideController getEntryWidgetHideController() {
+        if (entryWidgetHideController == null) {
+            entryWidgetHideController = new EntryWidgetHideController();
+        }
+        return entryWidgetHideController;
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -83,7 +83,11 @@ internal object Dependencies {
 
     @JvmStatic
     val entryWidget: EntryWidget
-        get() = EntryWidgetImpl(activityLauncher, gliaThemeManager)
+        get() = EntryWidgetImpl(
+            activityLauncher,
+            gliaThemeManager,
+            controllerFactory.entryWidgetHideController
+        )
 
     @JvmStatic
     lateinit var repositoryFactory: RepositoryFactory

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
@@ -33,7 +33,8 @@ interface EntryWidget {
 
 internal class EntryWidgetImpl(
     private val activityLauncher: ActivityLauncher,
-    private val themeManager: UnifiedThemeManager
+    private val themeManager: UnifiedThemeManager,
+    private val entryWidgetHideController: EntryWidgetHideController
 ) : EntryWidget {
 
     override fun show(activity: Activity) = activityLauncher.launchEntryWidget(activity)
@@ -44,6 +45,6 @@ internal class EntryWidgetImpl(
     }
 
     override fun hide() {
-        TODO("Will be implemented later, in scope of EntryWidget feature")
+        entryWidgetHideController.hide()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetActivity.kt
@@ -2,11 +2,15 @@ package com.glia.widgets.entrywidget
 
 import android.os.Bundle
 import com.glia.widgets.base.FadeTransitionActivity
+import com.glia.widgets.di.Dependencies
+import io.reactivex.rxjava3.disposables.CompositeDisposable
 
 /**
  * EntryWidgetActivity provides a way to display the EntryWidget bottom sheet.
  */
 internal class EntryWidgetActivity : FadeTransitionActivity(), EntryWidgetFragment.OnDismissListener {
+
+    private var disposable: CompositeDisposable = CompositeDisposable()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -14,11 +18,20 @@ internal class EntryWidgetActivity : FadeTransitionActivity(), EntryWidgetFragme
         if (savedInstanceState == null) {
             EntryWidgetFragment().show(supportFragmentManager)
         }
+
+        disposable.add(Dependencies.controllerFactory.entryWidgetHideController.onHide.subscribe {
+            finish()
+        })
     }
 
     override fun onEntryWidgetDismiss() {
         if (!isChangingConfigurations) {
             finish()
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        disposable.dispose()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import com.glia.widgets.R
@@ -42,7 +43,8 @@ internal class EntryWidgetFragment : BottomSheetDialogFragment() {
         return binding.root
     }
 
-    internal fun setupView(
+    @VisibleForTesting
+    fun setupView(
         context: Context,
         binding: EntryWidgetFragmentBinding,
         entryWidgetsTheme: EntryWidgetTheme?

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetHideController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetHideController.kt
@@ -1,0 +1,12 @@
+package com.glia.widgets.entrywidget
+
+import io.reactivex.rxjava3.processors.PublishProcessor
+
+internal class EntryWidgetHideController {
+    private val _onHide: PublishProcessor<Unit> = PublishProcessor.create<Unit>()
+
+    val onHide = _onHide
+    fun hide() {
+        onHide.onNext(Unit)
+    }
+}


### PR DESCRIPTION
[[Android] Devs want to add interfaces to show/hide the Entry Widget](https://glia.atlassian.net/browse/MOB-3408)


**What was solved?**
Implemented the `hide()` interface. To avoid asking for an Activity from the integrator, `ActivityWatcher` solution is used.

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
