### PR TITLE
Implement bottom banner for secure conversation

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -61,6 +61,7 @@ import com.glia.widgets.helper.layoutInflater
 import com.glia.widgets.helper.requireActivity
 import com.glia.widgets.helper.setLocaleContentDescription
 import com.glia.widgets.helper.setLocaleHint
+import com.glia.widgets.helper.setLocaleText
 import com.glia.widgets.launcher.ActivityLauncher
 import com.glia.widgets.locale.LocaleString
 import com.glia.widgets.view.Dialogs
@@ -76,6 +77,7 @@ import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.glia.widgets.view.unifiedui.theme.base.HeaderTheme
 import com.glia.widgets.view.unifiedui.theme.chat.InputTheme
 import com.glia.widgets.view.unifiedui.theme.chat.UnreadIndicatorTheme
+import com.glia.widgets.view.unifiedui.theme.securemessaging.SecureMessagingTheme
 import com.google.android.material.shape.MarkerEdgeTreatment
 import com.google.android.material.theme.overlay.MaterialThemeOverlay
 import java.util.concurrent.Executor
@@ -494,9 +496,12 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
             showToolbar(LocaleString(R.string.message_center_header))
             binding.appBarView.hideBackButton()
             binding.appBarView.showXButton()
+            binding.secureConversationsBottomBanner.visibility = View.VISIBLE
+            binding.scBottomBannerLabel.setLocaleText(R.string.secure_messaging_chat_banner_bottom)
         } else {
             showToolbar(LocaleString(R.string.engagement_chat_title))
             binding.appBarView.showBackButton()
+            binding.secureConversationsBottomBanner.visibility = View.GONE
         }
     }
 
@@ -593,7 +598,9 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         theme.baseLightColor?.let(::getColorCompat)?.also(binding.newMessagesBadgeView::setTextColor)
 
         // colors
-        theme.baseShadeColor?.let(::getColorCompat)?.also(binding.dividerView::setBackgroundColor)
+        theme.baseShadeColor?.let(::getColorCompat)
+            ?.also(binding.chatDivider::setBackgroundColor)
+            ?.also(binding.scBottomBannerDivider::setBackgroundColor)
 
         theme.brandPrimaryColor?.let(::getColorStateListCompat)?.also {
             binding.newMessagesBadgeView.backgroundTintList = it
@@ -601,7 +608,10 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         binding.sendButton.imageTintList = theme.sendMessageButtonTintColor?.let(::getColorStateListCompat)
 
         theme.baseDarkColor?.let(::getColorCompat)?.also(binding.chatEditText::setTextColor)
-        theme.baseNormalColor?.let(::getColorCompat)?.also(binding.chatEditText::setHintTextColor)
+        theme.baseNormalColor?.let(::getColorCompat)
+            ?.also(binding.chatEditText::setHintTextColor)
+            ?.also(binding.scBottomBannerLabel::setTextColor)
+        theme.systemAgentBubbleColor?.let(::getColorCompat)?.also(binding.scBottomBannerLabel::setBackgroundColor)
 
         theme.gliaChatBackgroundColor?.let(::getColorCompat)?.also(::setBackgroundColor)
 
@@ -770,6 +780,8 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         chatTheme.typingIndicator?.primaryColor?.also(binding.operatorTypingAnimationView::addColorFilter)
 
         chatTheme.unreadIndicator?.also(::applyUnreadMessagesTheme)
+
+        chatTheme.secureMessaging?.also(::applySecureMessagingTheme)
     }
 
     private fun applyHeaderTheme(headerTheme: HeaderTheme) {
@@ -779,7 +791,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
     private fun applyInputTheme(inputTheme: InputTheme) {
         binding.sendButton.applyButtonTheme(inputTheme.sendButton)
         binding.addAttachmentButton.applyButtonTheme(inputTheme.mediaButton)
-        binding.dividerView.applyColorTheme(inputTheme.divider)
+        binding.chatDivider.applyColorTheme(inputTheme.divider)
         binding.chatMessageLayout.applyLayerTheme(inputTheme.background)
         binding.chatEditText.applyTextTheme(textTheme = inputTheme.text, withAlignment = false)
         inputTheme.placeholder?.textColor?.primaryColor?.also(binding.chatEditText::setHintTextColor)
@@ -789,6 +801,12 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         unreadIndicatorTheme.bubble?.badge?.also(binding.newMessagesBadgeView::applyBadgeTheme)
         unreadIndicatorTheme.bubble?.userImage?.also(binding.newMessagesIndicatorImage::applyUserImageTheme)
         unreadIndicatorTheme.background?.primaryColor?.also(binding.newMessagesIndicatorCard::setCardBackgroundColor)
+    }
+
+    private fun applySecureMessagingTheme(secureMessagingTheme: SecureMessagingTheme) {
+        binding.scBottomBannerLabel.applyTextTheme(secureMessagingTheme.bottomBannerText)
+        binding.scBottomBannerLabel.applyLayerTheme(secureMessagingTheme.bottomBannerBackground)
+        binding.scBottomBannerDivider.applyColorTheme(secureMessagingTheme.bottomBannerDividerColor)
     }
 
     private fun showChatUnavailableView() = showDialog {

--- a/widgetssdk/src/main/res/layout/chat_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_view.xml
@@ -9,7 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@+id/chat_recycler_view"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
@@ -30,7 +29,8 @@
         android:paddingVertical="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/chat_recycler_view" />
+        app:layout_constraintTop_toBottomOf="@id/chat_recycler_view"
+        app:layout_constraintBottom_toTopOf="@+id/operator_typing_animation_view"/>
 
 
     <RelativeLayout
@@ -40,10 +40,10 @@
         android:clipChildren="false"
         android:clipToPadding="false"
         android:padding="@dimen/glia_large"
-        app:layout_constraintBottom_toTopOf="@id/divider_view"
+        app:layout_constraintBottom_toTopOf="@id/chat_bottom_divider_barrier"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        tools:visibility="gone">
+        tools:visibility="visible">
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/new_messages_indicator_card"
@@ -81,22 +81,52 @@
         android:layout_height="36dp"
         android:layout_marginStart="@dimen/glia_medium"
         android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@+id/divider_view"
+        app:layout_constraintBottom_toTopOf="@+id/chat_bottom_divider_barrier"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/gva_quick_replies_layout"
         app:lottie_autoPlay="true"
         app:lottie_loop="true"
         app:lottie_rawRes="@raw/chat_typing_indicator"
         tools:visibility="visible" />
 
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/chat_bottom_divider_barrier"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:barrierDirection="top"
+        app:constraint_referenced_ids="sc_bottom_banner_divider, chat_divider"/>
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/secure_conversations_bottom_banner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:constraint_referenced_ids="sc_bottom_banner_divider, sc_bottom_banner_label" />
+
     <View
-        android:id="@+id/divider_view"
+        android:id="@+id/sc_bottom_banner_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="?attr/gliaBaseShadeColor"
-        app:layout_constraintBottom_toTopOf="@+id/add_attachment_queue"
-        app:layout_constraintTop_toBottomOf="@+id/operator_typing_animation_view"
-        tools:background="@android:color/holo_red_dark" />
+        app:layout_constraintBottom_toTopOf="@+id/sc_bottom_banner_label"/>
+
+    <TextView
+        android:id="@+id/sc_bottom_banner_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/chat_divider"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:background="?attr/gliaSystemAgentBubbleColor"
+        android:textAppearance="?attr/textAppearanceCaption"
+        tools:text="@string/secure_messaging_chat_banner_bottom" />
+
+    <View
+        android:id="@+id/chat_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?attr/gliaBaseShadeColor"
+        app:layout_constraintBottom_toTopOf="@+id/add_attachment_queue" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/add_attachment_queue"
@@ -105,7 +135,6 @@
         android:scrollbars="vertical"
         app:layout_constraintBottom_toTopOf="@+id/chat_message_layout"
         app:layout_constraintHeight_max="216dp"
-        app:layout_constraintTop_toBottomOf="@+id/divider_view"
         tools:itemCount="6"
         tools:listitem="@layout/chat_attachment_uploaded_item" />
 
@@ -114,8 +143,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/add_attachment_queue">
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <EditText
             android:id="@+id/chat_edit_text"

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -167,6 +167,7 @@
     <string name="general_sending">@string/message_center_progress_bar_content_description</string>
     <string name="general_send">@string/message_center_send_message_btn</string>
     <string name="message_center_welcome_file_picker_accessibility_label">File picker</string>
+    <string name="secure_messaging_chat_banner_bottom">@string/message_center_bottom_banner</string>
 
     <!-- General -->
     <string name="general_refresh">@string/glia_visitor_code_refresh_button</string>

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="message_center_message_edit_text_hint">Enter message</string>
     <string name="glia_message_center_title">Secure Messaging</string>
     <string name="message_center_confirmation_screen_message">Your message has been sent. We will get back to you within 1 business day.</string>
+    <string name="message_center_bottom_banner">Secure messaging has an expected response time of 1 business day.</string>
     <string name="call_visualizer_screen_sharing_title">Screen Sharing</string>
     <string name="call_visualizer_label">Your Screen is Being Shared</string>
     <string name="glia_chat_file_download_success_message">The file has been downloaded.</string>

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessaging.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessaging.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c828774f8f6c1bd1624b2e9b63537c9fa71fd624d0116cfb87025f8dc664ae3
-size 14393
+oid sha256:85f0f896e4d07499a812dd98d7188b455e81ee01265fc1d14f8875c0e17fcb10
+size 18449

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:351c993f8e08af7808568e08f24f0d934020d6c43937ae26453a43ccddba550d
-size 14205
+oid sha256:114aa1445cfc36b5b932aee940fd0a467d954611490de1a3d46ad90f440ae986
+size 18247

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb026458867d18c65ccef485d4977edd3da89966aa7f1562707475d6c4eaa9db
-size 21589
+oid sha256:f65d37ff9375539fbc5a733057466ffb7a1cb8c175e99ad884022e9eaf8a81c9
+size 30501

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingWithUnifiedThemeWithoutChat.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingWithUnifiedThemeWithoutChat.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c828774f8f6c1bd1624b2e9b63537c9fa71fd624d0116cfb87025f8dc664ae3
-size 14393
+oid sha256:85f0f896e4d07499a812dd98d7188b455e81ee01265fc1d14f8875c0e17fcb10
+size 18449

--- a/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
+++ b/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
@@ -1435,6 +1435,35 @@
           "value": ["84d9f7", "#4a6bac"]
         }
       }
+    },
+    "secureMessaging": {
+      "bottomBannerBackground": {
+        "color": {
+          "type": "gradient",
+          "value": ["#ff55e0", "#e7a518"]
+        },
+        "border": {
+          "type": "fill",
+          "value": ["#a2522f"]
+        },
+        "borderWidth": 4,
+        "cornerRadius": 30
+      },
+      "bottomBannerText": {
+        "alignment": "center",
+        "font": {
+          "size": 16,
+          "style": "italic"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#288726"]
+        }
+      },
+      "bottomBannerDividerColor": {
+        "type": "fill",
+        "value": ["b9000d"]
+      }
     }
   },
   "snackBar": {


### PR DESCRIPTION



**Jira issue:**
https://glia.atlassian.net/browse/MOB-3633

**What was solved?**


**Release notes:**

 - [x] Feature
 - [x] Ignore: **Part of secure conversation v2 project**
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
![Screenshot_20241024_133740](https://github.com/user-attachments/assets/a2bad782-1bbe-48b4-b646-aa304125c0cf)

