### PR TITLE
Improve `chat_view.xml` layout preview

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/GvaChip.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/GvaChip.kt
@@ -77,6 +77,15 @@ internal class GvaChipGroup @JvmOverloads constructor(
         isSelectionRequired = false
         isSingleLine = false
         isSingleSelection = false
+
+        if (isInEditMode) {
+            // Add dummy content to show on Studio layout previews
+            setButtons(listOf(
+                GvaButton(text = "GVA Option 1"),
+                GvaButton(text = "GVA Option 2"),
+                GvaButton(text = "GVA Option 3")
+            ))
+        }
     }
 
     internal fun updateTheme(theme: UiTheme?) {

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ViewExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ViewExtensions.kt
@@ -35,6 +35,7 @@ import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.model.KeyPath
 import com.glia.widgets.di.Dependencies
+import com.glia.widgets.locale.LocaleProvider
 import com.glia.widgets.locale.LocaleString
 import com.glia.widgets.locale.StringKeyPair
 import com.google.android.material.button.MaterialButton
@@ -213,7 +214,7 @@ internal fun View.removeAccessibilityClickAction() {
 }
 
 private fun View.registerLocaleListener(@StringRes stringKey: Int, vararg values: StringKeyPair, listener: (String) -> Unit) {
-    val localeManager = Dependencies.localeProvider
+    val localeManager = if (isInEditMode) LocaleProvider(ResourceProvider(context)) else Dependencies.localeProvider
     val disposable = localeManager.getLocaleObservable()
         .startWithItem("stub")
         .map { localeManager.getString(stringKey, values.toList()) }

--- a/widgetssdk/src/main/java/com/glia/widgets/locale/LocaleProvider.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/locale/LocaleProvider.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.locale.LocaleManager
+import com.glia.widgets.BuildConfig
 import com.glia.widgets.R
 import com.glia.widgets.StringProvider
 import com.glia.widgets.helper.IResourceProvider
@@ -42,6 +43,7 @@ internal open class LocaleProvider @JvmOverloads constructor(
     private val localeObservable: Observable<String>
     private val localeEmitter: Observer<String>
     private lateinit var localeManager: LocaleManager
+    private val isSnapshotTestMode = BuildConfig.BUILD_TYPE == "snapshot"
 
     init {
         val localeSubject = PublishSubject.create<String>()
@@ -99,6 +101,9 @@ internal open class LocaleProvider @JvmOverloads constructor(
     @OpenForTesting
     open fun getStringInternal(stringKey: Int, values: List<StringKeyPair> = emptyList()): String {
         val key = resourceProvider.getResourceKey(stringKey)
+        if (isSnapshotTestMode) {
+            return key
+        }
         return try {
             getLocaleManager().getRemoteString(key)?.let {
                 values.fold(it, ::replaceInsertedValues).run(::cleanupRemainingReferences)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/button/BaseConfigurableButton.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/button/BaseConfigurableButton.java
@@ -5,7 +5,9 @@ import android.util.AttributeSet;
 
 import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
+import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
+import com.glia.widgets.helper.ResourceProvider;
 import com.glia.widgets.view.configuration.ButtonConfiguration;
 import com.glia.widgets.view.configuration.TextConfiguration;
 import com.google.android.material.button.MaterialButton;
@@ -17,6 +19,7 @@ public abstract class BaseConfigurableButton extends MaterialButton {
     private final String TAG = BaseConfigurableButton.class.getSimpleName();
 
     private ButtonConfiguration buttonConfiguration;
+    private final ResourceProvider resourceProvider;
 
     public abstract ButtonConfiguration getButtonConfigurationFromTheme(UiTheme theme);
 
@@ -30,6 +33,12 @@ public abstract class BaseConfigurableButton extends MaterialButton {
 
     public BaseConfigurableButton(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        if (isInEditMode()) {
+            resourceProvider = new ResourceProvider(getContext());
+        } else {
+            resourceProvider = Dependencies.getResourceProvider();
+        }
+
         createBuildTimeConfiguration();
         updateView();
     }
@@ -71,7 +80,7 @@ public abstract class BaseConfigurableButton extends MaterialButton {
                 .textColorHighlight(getHighlightColor())
                 .hintColor(getHintTextColors())
                 .textSize(getTextSize())
-                .build();
+                .build(resourceProvider);
 
         buttonConfiguration = ButtonConfiguration
                 .builder()
@@ -79,7 +88,7 @@ public abstract class BaseConfigurableButton extends MaterialButton {
                 .backgroundColor(getBackgroundTintList())
                 .strokeColor(getStrokeColor())
                 .strokeWidth(getStrokeWidth())
-                .build();
+                .build(resourceProvider);
     }
 
     @Deprecated
@@ -97,7 +106,7 @@ public abstract class BaseConfigurableButton extends MaterialButton {
             builder.strokeColor(runTimeConfiguration.getStrokeColor());
         if (runTimeConfiguration.getStrokeWidth() != null)
             builder.strokeWidth(runTimeConfiguration.getStrokeWidth());
-        buttonConfiguration = builder.build();
+        buttonConfiguration = builder.build(resourceProvider);
         updateView();
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ButtonConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/ButtonConfiguration.java
@@ -8,7 +8,6 @@ import android.os.Parcelable;
 import androidx.annotation.Nullable;
 
 import com.glia.widgets.R;
-import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.ResourceProvider;
 
@@ -143,13 +142,12 @@ public class ButtonConfiguration implements Parcelable {
             return this;
         }
 
-        public ButtonConfiguration build() {
+        public ButtonConfiguration build(ResourceProvider resourceProvider) {
             Logger.logDeprecatedClassUse(ButtonConfiguration.class.getSimpleName() + "." + TAG);
             if (textConfiguration == null) {
-                ResourceProvider resourceProvider = Dependencies.getResourceProvider();
                 textConfiguration = new TextConfiguration.Builder()
                         .textColor(resourceProvider.getColorStateList(R.color.glia_base_light_color))
-                        .build();
+                        .build(resourceProvider);
             }
             return new ButtonConfiguration(this);
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/OptionButtonConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/OptionButtonConfiguration.java
@@ -141,7 +141,7 @@ public class OptionButtonConfiguration implements Parcelable {
             return new TextConfiguration.Builder()
                     .textColor(resourceProvider.getColorStateList(textColor))
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/TextConfiguration.java
@@ -6,7 +6,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import com.glia.widgets.R;
-import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.helper.ResourceProvider;
 
@@ -152,9 +151,8 @@ public class TextConfiguration implements Parcelable {
             return this;
         }
 
-        public TextConfiguration build() {
+        public TextConfiguration build(ResourceProvider resourceProvider) {
             Logger.logDeprecatedClassUse(TextConfiguration.class.getSimpleName() + "." + TAG);
-            ResourceProvider resourceProvider = Dependencies.getResourceProvider();
             // Default configuration
             if (this.textSize == 0) {
                 this.textSize = resourceProvider.getDimension(R.dimen.glia_survey_default_text_size);

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/BooleanQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/BooleanQuestionConfiguration.java
@@ -83,15 +83,15 @@ public class BooleanQuestionConfiguration implements Parcelable {
             TextConfiguration normalText = new TextConfiguration.Builder()
                     .textColor(normalTextColor)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
             TextConfiguration selectedText = new TextConfiguration.Builder()
                     .textColor(selectedTextColor)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
             TextConfiguration highlightedText = new TextConfiguration.Builder()
                     .textColor(normalTextColor)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
 
             LayerConfiguration normalLayer = new LayerConfiguration.Builder()
                     .backgroundColor(resourceProvider.getString(R.color.glia_base_light_color))
@@ -124,7 +124,7 @@ public class BooleanQuestionConfiguration implements Parcelable {
                     .textColor(normalTextColor)
                     .bold(true)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_title_text_size))
-                    .build();
+                    .build(resourceProvider);
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
@@ -99,7 +99,7 @@ public class InputQuestionConfiguration implements Parcelable {
                     .textColor(color)
                     .bold(true)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_title_text_size))
-                    .build();
+                    .build(resourceProvider);
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/ScaleQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/ScaleQuestionConfiguration.java
@@ -83,15 +83,15 @@ public class ScaleQuestionConfiguration implements Parcelable {
             TextConfiguration normalText = new TextConfiguration.Builder()
                     .textColor(normalTextColor)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
             TextConfiguration selectedText = new TextConfiguration.Builder()
                     .textColor(selectedTextColor)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
             TextConfiguration highlightedText = new TextConfiguration.Builder()
                     .textColor(normalTextColor)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
 
             LayerConfiguration normalLayer = new LayerConfiguration.Builder()
                     .backgroundColor(resourceProvider.getString(R.color.glia_base_light_color))
@@ -125,7 +125,7 @@ public class ScaleQuestionConfiguration implements Parcelable {
                     .textColor(normalTextColor)
                     .bold(true)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_title_text_size))
-                    .build();
+                    .build(resourceProvider);
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SingleQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SingleQuestionConfiguration.java
@@ -100,7 +100,7 @@ public class SingleQuestionConfiguration implements Parcelable {
             return new TextConfiguration.Builder()
                     .textColor(optionTextColor)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
         }
 
         private TextConfiguration prepareDefaultTitleConfiguration(ResourceProvider resourceProvider) {
@@ -109,7 +109,7 @@ public class SingleQuestionConfiguration implements Parcelable {
                     .textColor(titleColor)
                     .bold(true)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_text_size))
-                    .build();
+                    .build(resourceProvider);
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SurveyStyle.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/SurveyStyle.java
@@ -213,11 +213,11 @@ public class SurveyStyle implements Parcelable {
                                                                       int backgroundColorId) {
             ColorStateList buttonTexColor = resourceProvider.getColorStateList(R.color.glia_base_light_color);
             TextConfiguration textConfiguration =
-                    new TextConfiguration.Builder().textColor(buttonTexColor).build();
+                    new TextConfiguration.Builder().textColor(buttonTexColor).build(resourceProvider);
             return new ButtonConfiguration.Builder()
                     .backgroundColor(resourceProvider.getColorStateList(backgroundColorId))
                     .textConfiguration(textConfiguration)
-                    .build();
+                    .build(resourceProvider);
         }
 
         private TextConfiguration prepareDefaultTitleConfiguration(ResourceProvider resourceProvider) {
@@ -225,7 +225,7 @@ public class SurveyStyle implements Parcelable {
             return new TextConfiguration.Builder()
                     .textColor(color)
                     .textSize(resourceProvider.getDimension(R.dimen.glia_survey_default_survey_title_text_size))
-                    .build();
+                    .build(resourceProvider);
         }
 
         private LayerConfiguration prepareDefaultBackgroundConfiguration(ResourceProvider resourceProvider) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/header/AppBarView.kt
@@ -15,6 +15,7 @@ import com.glia.widgets.R
 import com.glia.widgets.UiTheme
 import com.glia.widgets.databinding.AppBarBinding
 import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.ResourceProvider
 import com.glia.widgets.helper.Utils
 import com.glia.widgets.helper.applyButtonTheme
 import com.glia.widgets.helper.applyIconColorTheme
@@ -29,6 +30,7 @@ import com.glia.widgets.helper.setLocaleNavigationContentDescription
 import com.glia.widgets.helper.setLocaleText
 import com.glia.widgets.helper.setText
 import com.glia.widgets.helper.setTintCompat
+import com.glia.widgets.locale.LocaleProvider
 import com.glia.widgets.locale.LocaleString
 import com.glia.widgets.view.unifiedui.applyButtonTheme
 import com.glia.widgets.view.unifiedui.applyColorTheme
@@ -49,7 +51,13 @@ internal class AppBarView @JvmOverloads constructor(
 
     @DrawableRes
     private var iconAppBarBackRes: Int? = null
-    private val localeProvider = Dependencies.localeProvider
+    private val localeProvider by lazy {
+        if (isInEditMode) {
+            LocaleProvider(ResourceProvider(context))
+        } else {
+            Dependencies.localeProvider
+        }
+    }
 
     init {
         setDefaults(attrs)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/textview/BaseConfigurableTextView.java
@@ -12,7 +12,9 @@ import androidx.core.content.res.ResourcesCompat;
 
 import com.glia.widgets.R;
 import com.glia.widgets.UiTheme;
+import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.helper.ContextExtensions;
+import com.glia.widgets.helper.ResourceProvider;
 import com.glia.widgets.view.configuration.TextConfiguration;
 import com.google.android.material.textview.MaterialTextView;
 
@@ -21,6 +23,7 @@ import com.google.android.material.textview.MaterialTextView;
  */
 public abstract class BaseConfigurableTextView extends MaterialTextView {
     private TextConfiguration textConfiguration;
+    private final ResourceProvider resourceProvider;
 
     public BaseConfigurableTextView(@NonNull Context context) {
         this(context, null);
@@ -36,6 +39,12 @@ public abstract class BaseConfigurableTextView extends MaterialTextView {
 
     public BaseConfigurableTextView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
+        if (isInEditMode()) {
+            resourceProvider = new ResourceProvider(getContext());
+        } else {
+            resourceProvider = Dependencies.getResourceProvider();
+        }
+
         createBuildTimeConfiguration();
         updateView();
     }
@@ -49,7 +58,7 @@ public abstract class BaseConfigurableTextView extends MaterialTextView {
                 .textColorHighlight(getHighlightColor())
                 .hintColor(getHintTextColors())
             .textSize(ContextExtensions.pxToSp(getContext(), getTextSize()))
-                .build();
+                .build(resourceProvider);
     }
 
     public void setTheme(UiTheme theme) {
@@ -69,7 +78,7 @@ public abstract class BaseConfigurableTextView extends MaterialTextView {
         if (runTimeConfiguration.getFontFamily() != textConfiguration.getFontFamily())
             builder.fontFamily(runTimeConfiguration.getFontFamily());
 
-        textConfiguration = builder.build();
+        textConfiguration = builder.build(resourceProvider);
         updateView();
     }
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/SnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/SnapshotTest.kt
@@ -11,6 +11,7 @@ import app.cash.paparazzi.Paparazzi
 import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 import com.glia.widgets.snapshotutils.OnTestEnded
 import com.glia.widgets.snapshotutils.SnapshotContent
+import com.glia.widgets.snapshotutils.SnapshotProviderImp
 import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.snapshotutils.SnapshotStrings
 import com.glia.widgets.snapshotutils.SnapshotTestLifecycle
@@ -24,7 +25,7 @@ import org.mockito.kotlin.whenever
 import java.io.BufferedReader
 
 @Suppress("MemberVisibilityCanBePrivate")
-open class SnapshotTest(
+internal open class SnapshotTest(
     val deviceConfig: DeviceConfig = DeviceConfig.PIXEL_4A,
     val renderingMode: RenderingMode = RenderingMode.SHRINK,
     val showSystemUi: Boolean = false,
@@ -58,7 +59,7 @@ open class SnapshotTest(
         }
     }
 
-    override val snapshotLocales: MutableMap<Int, String> = mutableMapOf()
+    override var _snapshotProvider:SnapshotProviderImp = SnapshotProviderImp(mock<Context>())
 
     fun snapshot(
         view: View,
@@ -75,13 +76,14 @@ open class SnapshotTest(
     }
 
     @Before
-    open fun setUp() {}
+    open fun setUp() {
+        providerMockReset()
+    }
 
     @After
     open fun tearDown() {
         onEndListeners.forEach { it() }
         onEndListeners.clear()
-        snapshotLocales.clear()
     }
 
     private val onEndListeners: MutableList<OnTestEnded> = mutableListOf()

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/call/SnapshotCallView.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/call/SnapshotCallView.kt
@@ -50,8 +50,6 @@ internal interface SnapshotCallView : SnapshotContent, SnapshotTheme, SnapshotAc
         val schedulersMock = schedulersMock()
 
         lottieMock()
-        localeProviderMock()
-        resourceProviderMock()
 
         val controllerFactoryMock = mock<ControllerFactory>()
         val callControllerMock = mock<CallContract.Controller>()

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/AttachmentPopupSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/AttachmentPopupSnapshotTest.kt
@@ -9,7 +9,7 @@ import com.glia.widgets.view.unifiedui.theme.chat.AttachmentsPopupTheme
 import org.junit.Test
 import org.mockito.kotlin.mock
 
-class AttachmentPopupSnapshotTest : SnapshotTest(), SnapshotTheme, SnapshotProviders {
+internal class AttachmentPopupSnapshotTest : SnapshotTest(), SnapshotTheme, SnapshotProviders {
 
     // MARK: Tests
 
@@ -53,7 +53,6 @@ class AttachmentPopupSnapshotTest : SnapshotTest(), SnapshotTheme, SnapshotProvi
         unifiedTheme: AttachmentsPopupTheme? = null,
         viewCallback: (View) -> Unit
     ) : AttachmentPopup {
-        localeProviderMock()
 
         val anchor = LinearLayout(context)
         return AttachmentPopup(

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaGalleryItemViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaGalleryItemViewHolderSnapshotTest.kt
@@ -14,7 +14,7 @@ import com.glia.widgets.snapshotutils.SnapshotPicasso
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class GvaGalleryItemViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotPicasso {
+internal class GvaGalleryItemViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotPicasso {
 
     // MARK: tests with all views
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaGalleryViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaGalleryViewHolderSnapshotTest.kt
@@ -12,7 +12,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class GvaGalleryViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotProviders {
+internal class GvaGalleryViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotProviders {
 
     private fun galleryCardList() = listOf(
         GvaGalleryCard(
@@ -136,8 +136,6 @@ class GvaGalleryViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotPr
     private data class ViewData(val binding: ChatGvaGalleryLayoutBinding, val viewHolder: GvaGalleryViewHolder)
 
     private fun setupView(galleryCards: GvaGalleryCards, unifiedTheme: UnifiedTheme? = null): ViewData {
-        localeProviderMock()
-
         val heightManager = ChatItemHeightManager(UiTheme(), layoutInflater, resources, unifiedTheme)
         heightManager.measureHeight(listOf(galleryCards))
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaPersistentButtonsViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaPersistentButtonsViewHolderSnapshotTest.kt
@@ -11,7 +11,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotProviders {
+internal class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotProviders {
 
     private fun gvaPersistentButtons(showChatHead: Boolean = false) = GvaPersistentButtons(
         content = gvaLongSubtitle(),
@@ -121,8 +121,6 @@ class GvaPersistentButtonsViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, 
         card: GvaPersistentButtons,
         unifiedTheme: UnifiedTheme? = null
     ): ViewData {
-        localeProviderMock()
-
         val chatOperatorMessageLayoutBinding = ChatOperatorMessageLayoutBinding.inflate(layoutInflater)
         val gvaPersistentButtonsContentBinding = ChatGvaPersistentButtonsContentBinding.inflate(
             layoutInflater,

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaResponseTextViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/GvaResponseTextViewHolderSnapshotTest.kt
@@ -10,7 +10,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class GvaResponseTextViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotProviders {
+internal class GvaResponseTextViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, SnapshotProviders {
 
     private fun gvaResponseText(showChatHead: Boolean = false) = GvaResponseText(
         content = gvaLongSubtitle(),
@@ -94,8 +94,6 @@ class GvaResponseTextViewHolderSnapshotTest : SnapshotTest(), SnapshotGva, Snaps
     )
 
     private fun setupView(card: GvaResponseText, unifiedTheme: UnifiedTheme? = null): ViewData {
-        localeProviderMock()
-
         val chatOperatorMessageLayoutBinding = ChatOperatorMessageLayoutBinding.inflate(layoutInflater)
         val gvaPersistentButtonsContentBinding = ChatReceiveMessageContentBinding.inflate(
             layoutInflater,

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/MediaUpgradeStartedViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/MediaUpgradeStartedViewHolderSnapshotTest.kt
@@ -12,7 +12,7 @@ import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.google.gson.JsonObject
 import org.junit.Test
 
-class MediaUpgradeStartedViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders {
+internal class MediaUpgradeStartedViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders {
 
     // MARK: Audio
 
@@ -95,7 +95,6 @@ class MediaUpgradeStartedViewHolderSnapshotTest : SnapshotTest(), SnapshotChatSc
     // MARK: utils for tests
 
     private fun setupView(item: MediaUpgradeStartedTimerItem, unifiedTheme: UnifiedTheme? = null): MediaUpgradeStartedViewHolder {
-        localeProviderMock()
         unifiedTheme?.let { Dependencies.gliaThemeManager.theme = it }
 
         setOnEndListener {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/NewMessagesDividerViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/NewMessagesDividerViewHolderSnapshotTest.kt
@@ -10,7 +10,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class NewMessagesDividerViewHolderSnapshotTest : SnapshotTest(
+internal class NewMessagesDividerViewHolderSnapshotTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotChatScreen, SnapshotChatView, SnapshotProviders {
 
@@ -53,7 +53,6 @@ class NewMessagesDividerViewHolderSnapshotTest : SnapshotTest(
     // MARK: utils for tests
 
     private fun setupView(unifiedTheme: UnifiedTheme? = null): NewMessagesDividerViewHolder {
-        localeProviderMock()
         unifiedTheme?.let { Dependencies.gliaThemeManager.theme = it }
 
         setOnEndListener {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorFileAttachmentViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorFileAttachmentViewHolderSnapshotTest.kt
@@ -17,7 +17,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class OperatorFileAttachmentViewHolderSnapshotTest : SnapshotTest(
+internal class OperatorFileAttachmentViewHolderSnapshotTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotChatScreen, SnapshotAttachment, SnapshotProviders, SnapshotPicasso {
 
@@ -152,7 +152,6 @@ class OperatorFileAttachmentViewHolderSnapshotTest : SnapshotTest(
     // MARK: utils for tests
 
     private fun setupView(item: OperatorAttachmentItem.File, unifiedTheme: UnifiedTheme? = null): OperatorFileAttachmentViewHolder {
-        localeProviderMock()
         picassoMock(listOf(R.drawable.test_launcher2))
         unifiedTheme?.let { Dependencies.gliaThemeManager.theme = it }
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorImageAttachmentViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorImageAttachmentViewHolderSnapshotTest.kt
@@ -20,7 +20,7 @@ import com.glia.widgets.snapshotutils.SnapshotSchedulers
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class OperatorImageAttachmentViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotAttachment, SnapshotGetImageFile,
+internal class OperatorImageAttachmentViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotAttachment, SnapshotGetImageFile,
     SnapshotSchedulers, SnapshotProviders, SnapshotPicasso {
 
     // MARK: without header
@@ -159,7 +159,6 @@ class OperatorImageAttachmentViewHolderSnapshotTest : SnapshotTest(), SnapshotCh
         picassoMock(listOf(R.drawable.test_launcher2))
         val imageFileMock = getImageFileMock(R.drawable.test_banner)
         val schedulersMock = schedulersMock()
-        localeProviderMock()
 
         val binding = ChatAttachmentOperatorImageLayoutBinding.inflate(layoutInflater)
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorMessageViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorMessageViewHolderSnapshotTest.kt
@@ -15,7 +15,7 @@ import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.google.gson.JsonObject
 import org.junit.Test
 
-class OperatorMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders, SnapshotPicasso, SnapshotOperatorMessage, SnapshotStrings {
+internal class OperatorMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders, SnapshotPicasso, SnapshotOperatorMessage, SnapshotStrings {
 
     // MARK: Plain text
 
@@ -151,7 +151,6 @@ class OperatorMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen
     // MARK: utils for tests
 
     private fun setupView(item: OperatorMessageItem, unifiedTheme: UnifiedTheme? = null): OperatorMessageViewHolder {
-        localeProviderMock()
         picassoMock(listOf(R.drawable.test_banner, R.drawable.test_launcher2))
         unifiedTheme?.let { Dependencies.gliaThemeManager.theme = it }
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorStatusViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/OperatorStatusViewHolderSnapshotTest.kt
@@ -13,7 +13,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class OperatorStatusViewHolderSnapshotTest : SnapshotTest(
+internal class OperatorStatusViewHolderSnapshotTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotChatScreen, SnapshotChatView, SnapshotProviders, SnapshotPicasso, SnapshotLottie {
 
@@ -215,7 +215,6 @@ class OperatorStatusViewHolderSnapshotTest : SnapshotTest(
         unifiedTheme: UnifiedTheme? = null
     ): ViewData {
         lottieMock()
-        localeProviderMock()
         picassoMock(imageLoadError = imageLoadError)
 
         unifiedTheme?.let { Dependencies.gliaThemeManager.theme = it }

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/SystemMessageViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/SystemMessageViewHolderSnapshotTest.kt
@@ -10,7 +10,7 @@ import com.glia.widgets.snapshotutils.SnapshotStrings
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class SystemMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders, SnapshotStrings {
+internal class SystemMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders, SnapshotStrings {
 
     // MARK: Tests
 
@@ -54,7 +54,6 @@ class SystemMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, 
         message: String = mediumLengthTexts().joinToString(separator = " "),
         unifiedTheme: UnifiedTheme? = null
     ): SystemMessageViewHolder {
-        localeProviderMock()
         unifiedTheme?.let { Dependencies.gliaThemeManager.theme = it }
 
         setOnEndListener {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/VisitorImageAttachmentViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/VisitorImageAttachmentViewHolderSnapshotTest.kt
@@ -18,7 +18,7 @@ import com.glia.widgets.snapshotutils.SnapshotSchedulers
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class VisitorImageAttachmentViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotAttachment,
+internal class VisitorImageAttachmentViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotAttachment,
     SnapshotGetImageFile, SnapshotSchedulers, SnapshotProviders {
 
     // MARK: without labels

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolderSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolderSnapshotTest.kt
@@ -10,7 +10,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class VisitorMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders {
+internal class VisitorMessageViewHolderSnapshotTest : SnapshotTest(), SnapshotChatScreen, SnapshotProviders {
 
     // MARK: without labels
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/ConfirmationDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/ConfirmationDialogTest.kt
@@ -6,8 +6,10 @@ import com.glia.widgets.snapshotutils.SnapshotDialog
 import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogType
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
 
-class ConfirmationDialogTest : SnapshotTest(
+internal class ConfirmationDialogTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotDialog {
 
@@ -28,8 +30,10 @@ class ConfirmationDialogTest : SnapshotTest(
     )
 
     private fun disableLinkButton(vararg links: Link) {
-        links.forEach {
-            snapshotLocales[it.url.stringKey] = ""
+        links.forEach { item ->
+            localeProviderMock().stub {
+                on { getStringInternal(item.url.stringKey) } doReturn ""
+            }
         }
     }
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/OptionDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/OptionDialogTest.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogType
 import org.junit.Test
 
-class OptionDialogTest : SnapshotTest(
+internal class OptionDialogTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotDialog {
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/ReversedOptionDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/ReversedOptionDialogTest.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogType
 import org.junit.Test
 
-class ReversedOptionDialogTest : SnapshotTest(
+internal class ReversedOptionDialogTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotDialog {
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/ScreenSharingDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/ScreenSharingDialogTest.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogType
 import org.junit.Test
 
-class ScreenSharingDialogTest : SnapshotTest(
+internal class ScreenSharingDialogTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotDialog {
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/UpgradeDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/UpgradeDialogTest.kt
@@ -6,7 +6,7 @@ import com.glia.widgets.view.dialog.base.DialogPayload
 import com.glia.widgets.view.dialog.base.DialogType
 import org.junit.Test
 
-class UpgradeDialogTest : SnapshotTest(
+internal class UpgradeDialogTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotDialog {
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/VisitorCodeDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/VisitorCodeDialogTest.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.concurrent.Executor
 
-class VisitorCodeDialogTest : SnapshotTest(
+internal class VisitorCodeDialogTest : SnapshotTest(
     renderingMode = fullWidthRenderMode
 ), SnapshotProviders, SnapshotThemeConfiguration {
 
@@ -180,8 +180,6 @@ class VisitorCodeDialogTest : SnapshotTest(
         executor: Executor? = Executor(Runnable::run)
     ): VisitorCodeView {
         setUnifiedTheme(unifiedTheme)
-        localeProviderMock()
-        resourceProviderMock()
 
         val controllerFactoryMock: ControllerFactory = mock<ControllerFactory>().also {
             whenever(it.visitorCodeController).thenReturn(mock())

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetBottomSheetTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetBottomSheetTest.kt
@@ -11,8 +11,6 @@ internal class EntryWidgetBottomSheetTest : EntryWidgetEmbeddedViewTest() {
         viewType: EntryWidgetContract.ViewType,
         unifiedTheme: UnifiedTheme?
     ): View {
-        localeProviderMock()
-
         val entryWidgetFragment = EntryWidgetFragment()
         val binding = EntryWidgetFragmentBinding.inflate(layoutInflater)
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
@@ -259,8 +259,6 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         viewType: EntryWidgetContract.ViewType = EntryWidgetContract.ViewType.EMBEDDED_VIEW,
         unifiedTheme: UnifiedTheme? = null
     ) : View {
-        localeProviderMock()
-
         val entryWidgetTheme = unifiedTheme?.entryWidgetTheme
 
         return EntryWidgetView(

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/filepreview/ImagePreviewTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/filepreview/ImagePreviewTest.kt
@@ -27,8 +27,6 @@ internal class ImagePreviewTest : SnapshotTest(
         showShareIcon: Boolean = false,
         @DrawableRes imageRes: Int? = R.drawable.test_banner
     ): ImagePreviewActivityBinding {
-        localeProviderMock()
-
         val imagePreviewActivityBinding = ImagePreviewActivityBinding.inflate(layoutInflater)
 
         imagePreviewActivityBinding.toolbar.title = title

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/liveobservation/CallActivitySnackBarTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/liveobservation/CallActivitySnackBarTest.kt
@@ -5,7 +5,7 @@ import com.glia.widgets.call.CallActivity
 import com.glia.widgets.snapshotutils.SnapshotSnackBar
 import org.junit.Test
 
-class CallActivitySnackBarTest : SnapshotTest(), SnapshotSnackBar {
+internal class CallActivitySnackBarTest : SnapshotTest(), SnapshotSnackBar {
 
     @Test
     fun withDefaultTheme() {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/liveobservation/ChatActivitySnackBarTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/liveobservation/ChatActivitySnackBarTest.kt
@@ -5,7 +5,7 @@ import com.glia.widgets.chat.ChatActivity
 import com.glia.widgets.snapshotutils.SnapshotSnackBar
 import org.junit.Test
 
-class ChatActivitySnackBarTest : SnapshotTest(), SnapshotSnackBar {
+internal class ChatActivitySnackBarTest : SnapshotTest(), SnapshotSnackBar {
 
     @Test
     fun withDefaultTheme() {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/liveobservation/CommonSnackBarTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/liveobservation/CommonSnackBarTest.kt
@@ -5,7 +5,7 @@ import com.glia.widgets.SnapshotTest
 import com.glia.widgets.snapshotutils.SnapshotSnackBar
 import org.junit.Test
 
-class CommonSnackBarTest : SnapshotTest(), SnapshotSnackBar {
+internal class CommonSnackBarTest : SnapshotTest(), SnapshotSnackBar {
 
     @Test
     fun withDefaultTheme() {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotChatView.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotChatView.kt
@@ -38,8 +38,6 @@ internal interface SnapshotChatView : SnapshotContent, SnapshotTheme, SnapshotAc
         val schedulersMock = schedulersMock()
 
         lottieMock()
-        localeProviderMock()
-        resourceProviderMock()
 
         val controllerFactoryMock = mock<ControllerFactory>()
         val chatControllerMock = mock<ChatController>()

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotDialog.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotDialog.kt
@@ -54,7 +54,6 @@ internal interface SnapshotDialog: SnapshotTheme, SnapshotProviders {
         get() = LocaleString(R.string.dialog_button_description)
 
     fun inflateView(context: Context, unifiedTheme: UnifiedTheme? = null, dialogType: DialogType): View {
-        localeProviderMock()
         return DialogViewFactory(context, UiTheme(whiteLabel = unifiedTheme != null), unifiedTheme).createView(dialogType)
     }
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotMessageCenterView.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotMessageCenterView.kt
@@ -29,9 +29,6 @@ internal interface SnapshotMessageCenterView : SnapshotTestLifecycle, SnapshotCo
     fun messageCenterViewMock(): Mock {
         val activityMock = activityWindowMock()
 
-        localeProviderMock()
-        resourceProviderMock()
-
         val messageCenterControllerMock = mock<MessageCenterController>()
         val controllerFactoryMock = mock<ControllerFactory>()
         whenever(controllerFactoryMock.messageCenterController).thenReturn(messageCenterControllerMock)

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotSnackBar.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotSnackBar.kt
@@ -24,8 +24,6 @@ internal interface SnapshotSnackBar : SnapshotContent, SnapshotTestLifecycle, Sn
     )
 
     fun <T : Activity> snackBarMock(kClass: KClass<T>): Mock<T> {
-        val stringProvider = localeProviderMock()
-
         val rootLayout = FrameLayout(context).apply {
             layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         }
@@ -38,7 +36,7 @@ internal interface SnapshotSnackBar : SnapshotContent, SnapshotTestLifecycle, Sn
             rootLayout.removeAllViews()
         }
 
-        return Mock(stringProvider, rootLayout, mockActivity)
+        return Mock(localeProviderMock(), rootLayout, mockActivity)
     }
 
     fun <T : Activity> setupView(

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/view/head/ChatHeadViewSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/view/head/ChatHeadViewSnapshotTest.kt
@@ -18,7 +18,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.concurrent.Executor
 
-class ChatHeadViewSnapshotTest : SnapshotTest(
+internal class ChatHeadViewSnapshotTest : SnapshotTest(
     maxPercentDifference = 0.01
 ), SnapshotChatView, SnapshotProviders, SnapshotLottie, SnapshotPicasso, SnapshotThemeConfiguration {
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/webbrowser/WebBrowserViewSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/webbrowser/WebBrowserViewSnapshotTest.kt
@@ -9,7 +9,7 @@ import com.glia.widgets.snapshotutils.SnapshotProviders
 import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import org.junit.Test
 
-class WebBrowserViewSnapshotTest : SnapshotTest(
+internal class WebBrowserViewSnapshotTest : SnapshotTest(
     renderingMode = SessionParams.RenderingMode.FULL_EXPAND
 ), SnapshotProviders {
 
@@ -49,9 +49,6 @@ class WebBrowserViewSnapshotTest : SnapshotTest(
         title: LocaleString = LocaleString(R.string.dialog_link2_text),
         unifiedTheme: UnifiedTheme? = null
     ): WebBrowserView {
-        localeProviderMock()
-        resourceProviderMock()
-
         unifiedTheme?.let { Dependencies.gliaThemeManager.theme = it }
 
         setOnEndListener {


### PR DESCRIPTION
**Jira issue:**
 - no ticket -

**What was solved?**
These changes were made specifically to preview chat_view.xml. Here are some key points:
- AppBarView and its sub-views were throwing NullPointException because of `Dependencies.localeProvider`
- Added dummy content for the `GvaChipGroup` view

**Release notes:**

 - [ ] Feature
 - [x] Ignore: **no effect for client**
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

**Before**
![Screenshot 2024-10-23 at 15 43 54](https://github.com/user-attachments/assets/d502eba6-d3ab-433f-8e96-a0bb957c1921)

**After**
![Screenshot 2024-10-23 at 15 45 25](https://github.com/user-attachments/assets/96408561-7261-4df5-af7e-0a36f338e733)

