### PR TITLE
Handle edge cases

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
@@ -40,7 +40,10 @@ internal class EntryWidgetImpl(
     override fun show(activity: Activity) = activityLauncher.launchEntryWidget(activity)
 
     override fun getView(context: Context): View {
-        val adapter = EntryWidgetAdapter(EntryWidgetContract.ViewType.EMBEDDED_VIEW, themeManager.theme?.entryWidgetTheme)
+        val adapter = EntryWidgetAdapter(
+            EntryWidgetContract.ViewType.EMBEDDED_VIEW,
+            themeManager.theme?.entryWidgetTheme
+        )
         return EntryWidgetView(context, adapter)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
@@ -19,6 +19,7 @@ internal interface EntryWidgetContract {
         SECURE_MESSAGE,
         LOADING_STATE,
         EMPTY_STATE,
+        SDK_NOT_INITIALIZED_STATE,
         ERROR_STATE,
         PROVIDED_BY
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -29,12 +29,12 @@ internal class EntryWidgetController(
         if (core.isInitialized) {
             subscribeToQueueState()
         } else {
-            initErrorState()
+            showSdkNotInitializedState()
         }
     }
 
-    private fun initErrorState() {
-        view.showItems(listOf(EntryWidgetContract.ItemType.ERROR_STATE))
+    private fun showSdkNotInitializedState() {
+        view.showItems(listOf(EntryWidgetContract.ItemType.SDK_NOT_INITIALIZED_STATE))
     }
 
     private fun subscribeToQueueState() {
@@ -72,13 +72,16 @@ internal class EntryWidgetController(
                     if (allMedias.contains(Engagement.MediaType.VIDEO)) add(EntryWidgetContract.ItemType.VIDEO_CALL)
                     if (allMedias.contains(Engagement.MediaType.MESSAGING) && isAuthenticatedUseCase()) add(EntryWidgetContract.ItemType.SECURE_MESSAGE)
 
-                    if (allMedias.isEmpty()) {
+                    if (allMedias.isEmpty() || allMedias.hasOnlyMessagingAndIsNotAuthenticated()) {
                         add(EntryWidgetContract.ItemType.EMPTY_STATE)
                     } else {
                         add(EntryWidgetContract.ItemType.PROVIDED_BY)
                     }
                 }
             }
+
+    private fun List<Engagement.MediaType>.hasOnlyMessagingAndIsNotAuthenticated(): Boolean =
+        this.size == 1 && this.contains(Engagement.MediaType.MESSAGING) && !isAuthenticatedUseCase()
 
     override fun onItemClicked(itemType: EntryWidgetContract.ItemType, activity: Activity) {
         Logger.d(TAG, "Item clicked: $itemType")

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
@@ -49,7 +49,10 @@ internal class EntryWidgetFragment : BottomSheetDialogFragment() {
         binding: EntryWidgetFragmentBinding,
         entryWidgetsTheme: EntryWidgetTheme?
     ) {
-        val entryWidgetAdapter = EntryWidgetAdapter(EntryWidgetContract.ViewType.BOTTOM_SHEET, entryWidgetsTheme)
+        val entryWidgetAdapter = EntryWidgetAdapter(
+            EntryWidgetContract.ViewType.BOTTOM_SHEET,
+            entryWidgetsTheme
+        )
 
         EntryWidgetView(
             context = context,

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
@@ -23,7 +23,10 @@ internal class EntryWidgetAdapter(
     private val errorButtonTheme: ButtonTheme? = null
 ) : ListAdapter<EntryWidgetContract.ItemType, EntryWidgetAdapter.ViewHolder>(DIFF_CALLBACK) {
 
-    constructor(viewType: EntryWidgetContract.ViewType, entryWidgetTheme: EntryWidgetTheme?): this(
+    constructor(
+        viewType: EntryWidgetContract.ViewType,
+        entryWidgetTheme: EntryWidgetTheme?
+    ) : this(
         viewType,
         entryWidgetTheme?.mediaTypeItems,
         entryWidgetTheme?.errorTitle,
@@ -89,6 +92,7 @@ internal class EntryWidgetAdapter(
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
             EntryWidgetContract.ItemType.EMPTY_STATE,
+            EntryWidgetContract.ItemType.SDK_NOT_INITIALIZED_STATE,
             EntryWidgetContract.ItemType.ERROR_STATE -> ViewType.ERROR_ITEM.ordinal
             EntryWidgetContract.ItemType.PROVIDED_BY -> ViewType.PROVIDED_BY_ITEM.ordinal
             else -> ViewType.CONTACT_ITEM.ordinal

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetErrorStateViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetErrorStateViewHolder.kt
@@ -39,6 +39,13 @@ internal class EntryWidgetErrorStateViewHolder(
                 binding.button.setOnClickListener(onClickListener)
                 binding.button.isVisible = true
             }
+            EntryWidgetContract.ItemType.SDK_NOT_INITIALIZED_STATE -> {
+                binding.title.setLocaleText(R.string.entry_widget_error_state_title)
+                binding.description.setLocaleText(R.string.entry_widget_error_state_description)
+                binding.button.setLocaleText(R.string.entry_widget_error_state_try_again_button_label)
+                binding.button.setOnClickListener(onClickListener)
+                binding.button.isVisible = false
+            }
             else -> {
                 // Do nothing
             }

--- a/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
@@ -57,7 +57,7 @@ class EntryWidgetControllerTest {
 
         controller.setView(view)
 
-        verify(view, atLeast(1)).showItems(listOf(EntryWidgetContract.ItemType.ERROR_STATE))
+        verify(view, atLeast(1)).showItems(listOf(EntryWidgetContract.ItemType.SDK_NOT_INITIALIZED_STATE))
     }
 
     @Test
@@ -73,6 +73,41 @@ class EntryWidgetControllerTest {
             result == listOf(
                 EntryWidgetContract.ItemType.CHAT,
                 EntryWidgetContract.ItemType.PROVIDED_BY
+            )
+        )
+    }
+
+    @Test
+    fun `mapState returns SECURE_MESSAGE and PROVIDED_BY if SECURE_MESSAGE media type is available and visitor is authenticates`() {
+        val queue = mock(Queue::class.java)
+        val queueState = mock(QueueState::class.java)
+        `when`(queue.state).thenReturn(queueState)
+        `when`(queueState.status).thenReturn(QueueState.Status.OPEN)
+        `when`(isAuthenticatedUseCase.invoke()).thenReturn(true)
+        `when`(queueState.medias).thenReturn(arrayOf(Engagement.MediaType.MESSAGING))
+
+        val result = controller.mapState(QueuesState.Queues(listOf(queue)))
+        assert(
+            result == listOf(
+                EntryWidgetContract.ItemType.SECURE_MESSAGE,
+                EntryWidgetContract.ItemType.PROVIDED_BY
+            )
+        )
+    }
+
+    @Test
+    fun `mapState returns EMPTY_STATE if SECURE_MESSAGE media type is available but visitor is not authenticates`() {
+        val queue = mock(Queue::class.java)
+        val queueState = mock(QueueState::class.java)
+        `when`(queue.state).thenReturn(queueState)
+        `when`(queueState.status).thenReturn(QueueState.Status.OPEN)
+        `when`(isAuthenticatedUseCase.invoke()).thenReturn(false)
+        `when`(queueState.medias).thenReturn(arrayOf(Engagement.MediaType.MESSAGING))
+
+        val result = controller.mapState(QueuesState.Queues(listOf(queue)))
+        assert(
+            result == listOf(
+                EntryWidgetContract.ItemType.EMPTY_STATE
             )
         )
     }

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorDefaultThemeGliaNotInitialized.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorDefaultThemeGliaNotInitialized.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3695bf4ecbf7fb56dd493a2fb85c1823df855f35556b2bff4d9929dd2cfc8d8
+size 43104

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3695bf4ecbf7fb56dd493a2fb85c1823df855f35556b2bff4d9929dd2cfc8d8
+size 43104

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8439f773833f08c4c3b2abb8cb9043c44cc44721836ad81dd3ab9624d31a546c
+size 54946

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bdaa9d5e75ebc3dc620d97ba66bab020b12267494933354e0b8894a185a2fef
+size 43927

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3695bf4ecbf7fb56dd493a2fb85c1823df855f35556b2bff4d9929dd2cfc8d8
+size 43104

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorDefaultThemeGliaNotInitialized.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorDefaultThemeGliaNotInitialized.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b4f84f08d413c5aa4a499e0a8065d046d53936e64703337885dfcb0178904fd
+size 39332

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b4f84f08d413c5aa4a499e0a8065d046d53936e64703337885dfcb0178904fd
+size 39332

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f76dfae0fc23a81e56e20f4d0f5b1afabb68a02c7b288d96e01348a041d1b1a
+size 51104

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b347afbc1cafe41139f5b959079ccc5171011623a8d214c7adf992d9d4178819
+size 37878

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b4f84f08d413c5aa4a499e0a8065d046d53936e64703337885dfcb0178904fd
+size 39332

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
@@ -163,6 +163,51 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         )
     }
 
+
+    // MARK: SDK not initialized state tests
+
+    private val sdkNotInitializedItems = listOf(
+        EntryWidgetContract.ItemType.SDK_NOT_INITIALIZED_STATE,
+        EntryWidgetContract.ItemType.PROVIDED_BY
+    )
+
+    @Test
+    fun sdkNotInitializedItemsDefaultTheme() {
+        snapshot(
+            setupView(items = sdkNotInitializedItems)
+        )
+    }
+
+    @Test
+    fun sdkNotInitializedItemsWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = sdkNotInitializedItems,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun sdkNotInitializedItemsWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = sdkNotInitializedItems,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
+    fun sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = sdkNotInitializedItems,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
     // MARK: Error state tests
 
     private val errorItems = listOf(


### PR DESCRIPTION
**What was solved?**
- [Entry Widget should show an empty state if only 'messaging' engagement is available but visitor is not authenticated](https://glia.atlassian.net/browse/MOB-3712)
- [Hide the 'Try Again' button if SDK is not initialized](https://glia.atlassian.net/browse/MOB-3728)
- Added snapshot tests for the case when Glia is not initialized and we should hide the 'Try again' button

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

https://github.com/user-attachments/assets/1b9e9b02-a0c6-49ac-897c-b09f91a0b73a


