### PR TITLE
Default XML attributes for the Entry Widget

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
@@ -14,6 +14,7 @@ import com.glia.widgets.R
 import com.glia.widgets.databinding.EntryWidgetFragmentBinding
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.entrywidget.adapter.EntryWidgetAdapter
+import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
 import com.glia.widgets.view.unifiedui.applyLayerTheme
 import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -35,7 +36,8 @@ internal class EntryWidgetFragment : BottomSheetDialogFragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = EntryWidgetFragmentBinding.inflate(inflater, container, false)
+        val layoutInflater = LayoutInflater.from(requireContext().wrapWithMaterialThemeOverlay())
+        val binding = EntryWidgetFragmentBinding.inflate(layoutInflater, container, false)
         val entryWidgetsTheme = Dependencies.gliaThemeManager.theme?.entryWidgetTheme
 
         setupView(requireContext(), binding, entryWidgetsTheme)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/EntryWidget.kt
@@ -27,7 +27,7 @@ internal fun DefaultMediaTypeItemsTheme(pallet: ColorPallet?): MediaTypeItemsThe
     pallet?.run {
         MediaTypeItemsTheme(
             mediaTypeItem = DefaultMediaItemTypeTheme(this),
-            dividerColor = baseNormalColorTheme
+            dividerColor = baseShadeColorTheme
         )
     }
 

--- a/widgetssdk/src/main/res/drawable/bg_entry_widget_divider.xml
+++ b/widgetssdk/src/main/res/drawable/bg_entry_widget_divider.xml
@@ -7,7 +7,7 @@
         <shape
             android:shape="rectangle">
             <size android:height="@dimen/glia_px" />
-            <solid android:color="@color/glia_stroke_gray" />
+            <solid android:color="?attr/gliaBaseShadeColor" />
         </shape>
 
     </item>

--- a/widgetssdk/src/main/res/drawable/ic_drag_handle.xml
+++ b/widgetssdk/src/main/res/drawable/ic_drag_handle.xml
@@ -5,7 +5,5 @@
     android:viewportHeight="4">
   <path
       android:pathData="M2.5,0L30.5,0A2,2 0,0 1,32.5 2L32.5,2A2,2 0,0 1,30.5 4L2.5,4A2,2 0,0 1,0.5 2L0.5,2A2,2 0,0 1,2.5 0z"
-      android:strokeAlpha="0.4"
-      android:fillColor="#79747E"
-      android:fillAlpha="0.4"/>
+      android:fillColor="?attr/gliaBaseShadeColor" />
 </vector>

--- a/widgetssdk/src/main/res/layout/entry_widget_fragment.xml
+++ b/widgetssdk/src/main/res/layout/entry_widget_fragment.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:background="@drawable/bg_bottom_sheet">
+    android:background="@drawable/bg_bottom_sheet"
+    android:backgroundTint="?attr/gliaBaseLightColor">
 
     <ImageView
         android:id="@+id/drag_handle"
@@ -16,7 +17,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/container"/>
+        app:layout_constraintBottom_toTopOf="@id/container" />
 
     <FrameLayout
         android:id="@+id/container"

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsDefaultTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e67fc3b0a2c672ae2c40dc0f8f4e837752f9218032289f79b70e1726b3d00a2
-size 130950
+oid sha256:131c12c79023f740e187f4ff8c30dce9105faa67f47faab9f95de12f8c717e3e
+size 130969

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f00e67cbdbabd37d5aba3dcf06854ec4c1f0df3060b19ac8b716ceb26de10cae
-size 161858
+oid sha256:11cde158a869f5b8b0f80b06f3fd024314cf0041bae4e0ca9875383ddc28cb30
+size 161847

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ed6e263bfd21ed57ee4b4df4e6ba7a6ec12d07dde69baebacb9a18f29b69f1e
-size 130540
+oid sha256:e4aeda81eb5fd357d68095cfbf538ed276379c18313b9eccecda1e30f5441253
+size 130569

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithUnifiedThemeWithoutEntryWidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e67fc3b0a2c672ae2c40dc0f8f4e837752f9218032289f79b70e1726b3d00a2
-size 130950
+oid sha256:131c12c79023f740e187f4ff8c30dce9105faa67f47faab9f95de12f8c717e3e
+size 130969

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyDefaultTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:336d163c3d6b55ad4defc89c260666be0b22c89dba7edebdff47080f003d13f9
-size 44814
+oid sha256:06161f46ba357a490eaea0510115da5b14e372b5a8ee65243aff0b4a0bb57a7c
+size 44820

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:631b854ff9741e5c806d277839810f2429f90ddfa9ce1a5d3a23b5182f75d536
-size 56110
+oid sha256:6a7e80837490680da1848dd0d2df38b0a7bad0891a2532e84cd5f6ca610a68e5
+size 56121

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f7bb73896de8bbb7dfdae7b2345947412e2245f70a53d3d78d689181eb23c32
-size 45432
+oid sha256:69f08a86e3ec50173f29fd6e7f2cac6515f9a2d6e8b31e8b5b5fb91568748640
+size 45439

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWithUnifiedThemeWithoutEntryWidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:336d163c3d6b55ad4defc89c260666be0b22c89dba7edebdff47080f003d13f9
-size 44814
+oid sha256:06161f46ba357a490eaea0510115da5b14e372b5a8ee65243aff0b4a0bb57a7c
+size 44820

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorDefaultTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2703e20ffbbfb60ee9d271deb240054733ad3011dd0d50ebfaea0b0cb4b1358f
-size 59814
+oid sha256:faf4e48a0001101de92b3cdb3b9042a3dc7cbf182023c5ae26243624c21cdd53
+size 59825

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5054eb7773efc59fb3bf1263e7702d6d6d4f0a9268131af09ed9b2a4b4b04de8
-size 68773
+oid sha256:1b1b3bda5c5a0a223cc7f992d9cf991f3538b76cd68b4ca9d996c99da896222b
+size 68776

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35650f02061d2d4bf9e6527c8e4e97fdda8337269476d085eae82437be04628a
-size 61604
+oid sha256:82c6315cc188d4251849da2303940236d685bf1538bae93b87c49e7cdac90def
+size 61605

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWithUnifiedThemeWithoutEntryWidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2703e20ffbbfb60ee9d271deb240054733ad3011dd0d50ebfaea0b0cb4b1358f
-size 59814
+oid sha256:faf4e48a0001101de92b3cdb3b9042a3dc7cbf182023c5ae26243624c21cdd53
+size 59825

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingDefaultTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:366d4dc766142ceaa2f94d953404a6410609038236395c365d04ac3d31ef034b
-size 26705
+oid sha256:cd82ad40d8cf79704b067ede6efcaf6fcce0f6521777d0a2ce7bec5129a7854b
+size 26728

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90a0edb85e982a3ffd0bee7a1678035547eaa41292f75124652d326e8ef239df
-size 53507
+oid sha256:23c989e05b4c10fe9048d32c3d97c98034e1b2b59de3e47b2cc63ad5b270673c
+size 53539

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1aa1e9e41290d663944e73ab8590672ee1a6e21d76298bc1152fbfba87416d7
-size 30219
+oid sha256:f30a8215115951f86fc0e0b9dbaf33462d5d1c5d13567c1c1c7153cdb46b9c58
+size 30231

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:366d4dc766142ceaa2f94d953404a6410609038236395c365d04ac3d31ef034b
-size 26705
+oid sha256:cd82ad40d8cf79704b067ede6efcaf6fcce0f6521777d0a2ce7bec5129a7854b
+size 26728

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsDefaultTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3695bf4ecbf7fb56dd493a2fb85c1823df855f35556b2bff4d9929dd2cfc8d8
-size 43104
+oid sha256:46d25db9ff51ae1556d1616986fb7398afb8d79fca1282923da67d98435a20cb
+size 43111

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8439f773833f08c4c3b2abb8cb9043c44cc44721836ad81dd3ab9624d31a546c
-size 54946
+oid sha256:b8b84202c3027d1abead2862861151b90f8be256958d6c8cef20e3908567dbc8
+size 54954

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bdaa9d5e75ebc3dc620d97ba66bab020b12267494933354e0b8894a185a2fef
-size 43927
+oid sha256:930f07f406d55c4698fe546bf30d1f87977c9fdd43485a382ee04d93af9bb092
+size 43942

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3695bf4ecbf7fb56dd493a2fb85c1823df855f35556b2bff4d9929dd2cfc8d8
-size 43104
+oid sha256:46d25db9ff51ae1556d1616986fb7398afb8d79fca1282923da67d98435a20cb
+size 43111

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsDefaultTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e211ff50cef1b702b63bfad94889b4692cd44198dc587519a4e7eba05b253538
+oid sha256:c42d0c6ea2d2c0487dfe501355882a6224ff2cd4b8d6d486305cd62d4d9cbe31
 size 127759

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68b51dffdeb10da6fce5d29f20b9969878be2188fa61ffe3c4829e0874d39543
-size 188391
+oid sha256:4b97555c784d320f81c4d23e28d8e847f9ae5ac904e1e7891b461780d700140b
+size 188403

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40852e0be7bf416ae03fc79be77d2a33745018d8c276a5c1a6757d50d418b8c2
-size 125375
+oid sha256:9ffb22e420e2334897b2d6f04e0e8c6fc034167527fb4a23a2d5398cf1bcdc48
+size 125404

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithUnifiedThemeWithoutEntryWidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e211ff50cef1b702b63bfad94889b4692cd44198dc587519a4e7eba05b253538
+oid sha256:c42d0c6ea2d2c0487dfe501355882a6224ff2cd4b8d6d486305cd62d4d9cbe31
 size 127759

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingDefaultTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fcf39bad75ca2d85fcd8acb69bb67d2e90bcaf1178b0949d2a72e01da4bfae15
-size 25673
+oid sha256:1f802b154b769afcc9a18476ba84ad2382050f406ac092caf3e7eeb283af7ca2
+size 25685

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedTheme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c49be404d586bb5870b9f4d86ceb820bb91453f356dc5e71296a29ab6c01199d
-size 54850
+oid sha256:93708070b0ce3dc80a50c5f7e3e05368b08a1ab0f9213b91c5c523b2670dfa09
+size 54844

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWithGlobalColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8c070cc1edfe1a3bad302fb39d935b015ac2cd099c69bbab63848e72b146741
-size 27081
+oid sha256:2a031f9091783a3b8293238af089f7719534cf1ef081e227b7facdfdc1a5921e
+size 27076

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fcf39bad75ca2d85fcd8acb69bb67d2e90bcaf1178b0949d2a72e01da4bfae15
-size 25673
+oid sha256:1f802b154b769afcc9a18476ba84ad2382050f406ac092caf3e7eeb283af7ca2
+size 25685


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3601

**What was solved?**
Apply default attributes from GliaTheme to the Entry Widget view in the XML layer.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
