### PR TITLE
Add SC business logic into Entry Widget public functions

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -86,7 +86,8 @@ internal object Dependencies {
         get() = EntryWidgetImpl(
             activityLauncher,
             gliaThemeManager,
-            controllerFactory.entryWidgetHideController
+            controllerFactory.entryWidgetHideController,
+            repositoryFactory.secureConversationsRepository
         )
 
     @JvmStatic


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3650

**What was solved?**
Add secure conversation business logic into the entry widget public functions

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
