### PR TITLE
Add secure messaging unavailable label

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.kt
@@ -1,7 +1,7 @@
 package com.glia.widgets.chat.model
 
 internal data class ChatState(
-    val integratorChatStarted: Boolean = false,
+    val isChatUnavailable: Boolean = false,
     val isVisible: Boolean = false,
     val isChatInBottom: Boolean = true,
     val messagesNotSeen: Int = 0,
@@ -12,7 +12,9 @@ internal data class ChatState(
     val lastTypedText: String = "",
     val engagementRequested: Boolean = false,
     val operatorStatusItem: OperatorStatusItem? = null,
-    val showSendButton: Boolean = false,
+    val isSendButtonVisible: Boolean = false,
+    val isSendButtonEnabled: Boolean = false,
+    val isSecureMessagingUnavailableLabelVisible: Boolean = false,
     val isAttachmentButtonEnabled: Boolean = false,
     val isAttachmentButtonNeeded: Boolean = false,
     val isOperatorTyping: Boolean = false,
@@ -33,11 +35,12 @@ internal data class ChatState(
     val isAttachmentButtonVisible: Boolean get() = isAttachmentButtonNeeded && isAttachmentAllowed
 
     fun initChat(): ChatState = copy(
-        integratorChatStarted = true,
+        isChatUnavailable = true,
         isVisible = true,
-        showSendButton = false,
-        isAttachmentButtonEnabled = true,
-        isAttachmentAllowed = true
+        isSendButtonVisible = false,
+        isSendButtonEnabled = true,
+        isAttachmentAllowed = true,
+        isAttachmentButtonEnabled = true
     )
 
     fun queueingStarted(): ChatState = copy(
@@ -47,13 +50,24 @@ internal data class ChatState(
         engagementRequested = true
     )
 
+    fun setSecureMessaging(isSecureMessaging: Boolean) =
+        if (isSecureMessaging) {
+            setSecureMessagingState()
+        } else {
+            setLiveChatState()
+        }
+
     fun setSecureMessagingState(): ChatState = copy(
         isSecureMessaging = true,
         chatInputMode = ChatInputMode.ENABLED,
         isAttachmentButtonNeeded = true
     )
 
-    fun setLiveChatState(): ChatState = copy(isSecureMessaging = false)
+    fun setLiveChatState(): ChatState = copy(
+        isSecureMessaging = false,
+        chatInputMode = ChatInputMode.ENABLED_NO_ENGAGEMENT,
+        isSecureMessagingUnavailableLabelVisible = false,
+    )
 
     fun allowSendAttachmentStateChanged(isAttachmentAllowed: Boolean): ChatState = copy(isAttachmentAllowed = isAttachmentAllowed)
 
@@ -69,7 +83,7 @@ internal data class ChatState(
         engagementRequested = false,
         operatorStatusItem = OperatorStatusItem.Transferring,
         chatInputMode = ChatInputMode.DISABLED,
-        showSendButton = false,
+        isSendButtonVisible = false,
         isAttachmentButtonNeeded = false
     )
 
@@ -83,7 +97,7 @@ internal data class ChatState(
         isAttachmentButtonNeeded = true
     )
 
-    fun historyLoaded(): ChatState = copy(
+    fun liveChatHistoryLoaded(): ChatState = copy(
         chatInputMode = ChatInputMode.ENABLED_NO_ENGAGEMENT,
         isAttachmentButtonNeeded = false
     )
@@ -98,17 +112,35 @@ internal data class ChatState(
 
     fun messagesNotSeenChanged(messagesNotSeen: Int): ChatState = copy(messagesNotSeen = messagesNotSeen)
 
-    fun setShowSendButton(isShow: Boolean): ChatState = copy(showSendButton = isShow)
+    fun setShowSendButton(isShow: Boolean): ChatState = copy(isSendButtonVisible = isShow)
+
+    fun setSecureMessagingUnavailable(): ChatState = copy(
+        isSecureMessagingUnavailableLabelVisible = true,
+        isAttachmentButtonNeeded = true,
+        isAttachmentButtonEnabled = false,
+        isSendButtonVisible = true,
+        isSendButtonEnabled = false,
+        chatInputMode = ChatInputMode.DISABLED
+    )
+
+    fun setSecureMessagingAvailable(): ChatState = copy(
+        isSecureMessagingUnavailableLabelVisible = false,
+        isAttachmentButtonNeeded = true,
+        isAttachmentButtonEnabled = true,
+        isSendButtonVisible = true,
+        isSendButtonEnabled = true,
+        chatInputMode = ChatInputMode.ENABLED
+    )
 
     fun setIsOperatorTyping(isOperatorTyping: Boolean): ChatState = copy(isOperatorTyping = isOperatorTyping)
 
     fun setIsAttachmentButtonEnabled(isAttachmentButtonEnabled: Boolean): ChatState = copy(isAttachmentButtonEnabled = isAttachmentButtonEnabled)
 
-    fun stop(): ChatState = copy(
+    fun chatUnavailableState(): ChatState = copy(
         formattedOperatorName = null,
         operatorProfileImgUrl = null,
         isVisible = false,
-        integratorChatStarted = false,
+        isChatUnavailable = false,
         isAttachmentButtonNeeded = false,
         isMediaUpgradeVide = null
     )

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/UnifiedUiExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/UnifiedUiExtensions.kt
@@ -129,6 +129,10 @@ internal fun TextView.applyTextColorTheme(color: ColorTheme?) {
         paint.shader = null
         setTextColor(color.primaryColor)
     }
+
+    // Line below apply text color to any drawable that are part of this TextVIew
+    // e.g.: app:drawableStartCompat="@drawable/ic_attention"
+    color.primaryColorStateList.let(::setCompoundDrawableTintList)
 }
 
 internal fun TextView.applyTextTheme(

--- a/widgetssdk/src/main/res/layout/chat_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_view.xml
@@ -112,7 +112,7 @@
         android:id="@+id/sc_bottom_banner_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/chat_divider"
+        app:layout_constraintBottom_toTopOf="@+id/chat_sc_error_barrier"
         android:paddingTop="8dp"
         android:paddingBottom="8dp"
         android:paddingStart="16dp"
@@ -120,6 +120,32 @@
         android:background="?attr/gliaSystemAgentBubbleColor"
         android:textAppearance="?attr/textAppearanceCaption"
         tools:text="@string/secure_messaging_chat_banner_bottom" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/chat_sc_error_barrier"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:barrierDirection="top"
+        app:constraint_referenced_ids="sc_error_label, chat_divider"/>
+
+    <TextView
+        android:id="@+id/sc_error_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        app:layout_constraintBottom_toTopOf="@+id/chat_divider"
+        android:background="?attr/gliaSystemNegativeColor"
+        android:textColor="?attr/gliaBaseLightColor"
+        android:textAppearance="?attr/textAppearanceCaption"
+        app:drawableStartCompat="@drawable/ic_attention"
+        app:drawableTint="?attr/gliaBaseLightColor"
+        android:drawablePadding="8dp"
+        android:visibility="gone"
+        tools:visibility="visible"
+        tools:text="@string/message_center_error_unavailable_message" />
 
     <View
         android:id="@+id/chat_divider"
@@ -159,6 +185,7 @@
             android:textColor="?attr/gliaBaseDarkColor"
             android:textColorHint="?attr/gliaBaseNormalColor"
             android:textCursorDrawable="@null"
+            tools:text="@string/chat_input_placeholder"
             tools:ignore="RtlSymmetry"
             tools:textColor="@color/glia_black_color" />
 

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -168,6 +168,7 @@
     <string name="general_send">@string/message_center_send_message_btn</string>
     <string name="message_center_welcome_file_picker_accessibility_label">File picker</string>
     <string name="secure_messaging_chat_banner_bottom">@string/message_center_bottom_banner</string>
+    <string name="secure_messaging_chat_unavailable_message">@string/message_center_error_unavailable_message</string>
 
     <!-- General -->
     <string name="general_refresh">@string/glia_visitor_code_refresh_button</string>

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="glia_message_center_title">Secure Messaging</string>
     <string name="message_center_confirmation_screen_message">Your message has been sent. We will get back to you within 1 business day.</string>
     <string name="message_center_bottom_banner">Secure messaging has an expected response time of 1 business day.</string>
+    <string name="message_center_error_unavailable_message">Sending messages is currently not available.</string>
     <string name="call_visualizer_screen_sharing_title">Screen Sharing</string>
     <string name="call_visualizer_label">Your Screen is Being Shared</string>
     <string name="glia_chat_file_download_success_message">The file has been downloaded.</string>

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingUnavailable.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingUnavailable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23f53f60273320595171ad452a0ad8090fc2cc81a879b10d14ebb4cae4654000
+size 24801

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingUnavailableWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingUnavailableWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9efbb7f5073ca18cf52ec3c7121cbf1a90c44e442b47ba149efe9f28a854d517
+size 23897

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingUnavailableWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.chat_ChatViewSnapshotTest_secureMessagingUnavailableWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:556bdc1cb01f13676f674962bcf64c6d143044d5a6fdb86db884b469125d4a9d
+size 37673

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/ChatViewSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/ChatViewSnapshotTest.kt
@@ -157,10 +157,11 @@ internal class ChatViewSnapshotTest : SnapshotTest(), SnapshotChatView, Snapshot
 
     // MARK: Secure messaging
 
-    private fun secureMessagingView(unifiedTheme: UnifiedTheme? = null) = setupView(
+    private fun secureMessagingView(unifiedTheme: UnifiedTheme? = null, isUnavailable: Boolean = false) = setupView(
         chatState = ChatState()
-            .changeVisibility(true)
-            .setSecureMessagingState(),
+            .initChat()
+            .setSecureMessagingState()
+            .let { if (isUnavailable) it.setSecureMessagingUnavailable() else it },
         message = mediumLengthTexts()[2],
         unifiedTheme = unifiedTheme
     )
@@ -195,6 +196,33 @@ internal class ChatViewSnapshotTest : SnapshotTest(), SnapshotChatView, Snapshot
         snapshot(
             secureMessagingView(
                 unifiedTheme = unifiedThemeWithoutChat()
+            ).root
+        )
+    }
+
+    @Test
+    fun secureMessagingUnavailable() {
+        snapshot(
+            secureMessagingView(isUnavailable = true).root
+        )
+    }
+
+    @Test
+    fun secureMessagingUnavailableWithGlobalColors() {
+        snapshot(
+            secureMessagingView(
+                unifiedTheme = unifiedThemeWithGlobalColors(),
+                isUnavailable = true
+            ).root
+        )
+    }
+
+    @Test
+    fun secureMessagingUnavailableWithUnifiedTheme() {
+        snapshot(
+            secureMessagingView(
+                unifiedTheme = unifiedTheme(),
+                isUnavailable = true
             ).root
         )
     }

--- a/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
+++ b/widgetssdk/src/testSnapshot/res/raw/test_unified_config.json
@@ -1463,6 +1463,29 @@
       "bottomBannerDividerColor": {
         "type": "fill",
         "value": ["b9000d"]
+      },
+      "unavailableStatusBackground": {
+        "color": {
+          "type": "gradient",
+          "value": ["#70faff", "#db71e7"]
+        },
+        "border": {
+          "type": "fill",
+          "value": ["#3b36a2"]
+        },
+        "borderWidth": 4,
+        "cornerRadius": 30
+      },
+      "unavailableStatusText": {
+        "alignment": "center",
+        "font": {
+          "size": 10,
+          "style": "bold"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#b9000d"]
+        }
       }
     }
   },


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3635

**What was solved?**

Previously, we showed an Alert Dialog that said that secure messaging was unavailable, but now it should be a label above the chat EditText view.

- There have been slight differences in chat view snapshots because of the height of the visitor message edit text view. But that is related to constrained layout rules changes when implementing secure conversations unavailable label. Was not able to fix it...
- Will implement the 'disabled' color state to the message EditText view and attachment/send buttons in separate PR

**Release notes:**

 - [x] Feature: **part of the SCv2 project**
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
![Screenshot_20241031_124608](https://github.com/user-attachments/assets/9f6fb515-1c4b-4ec4-beed-1f00e8f848dc)

