### PR TITLE
Add ability to pass visitor context id through Engagement Launcher

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -91,14 +91,15 @@ class MainFragment : Fragment() {
                     entryWidget.show(requireActivity())
                 }
             }
+        val visitorContextAssetId = getContextAssetIdFromPrefs(sharedPreferences)
         view.findViewById<View>(R.id.chat_activity_button)
-            .setOnClickListener { engagementLauncher.startChat(requireActivity()) }
+            .setOnClickListener { engagementLauncher.startChat(requireActivity(), visitorContextAssetId) }
         view.findViewById<View>(R.id.audio_call_button)
-            .setOnClickListener { engagementLauncher.startAudioCall(requireActivity()) }
+            .setOnClickListener { engagementLauncher.startAudioCall(requireActivity(), visitorContextAssetId) }
         view.findViewById<View>(R.id.video_call_button)
-            .setOnClickListener { engagementLauncher.startVideoCall(requireActivity()) }
+            .setOnClickListener { engagementLauncher.startVideoCall(requireActivity(), visitorContextAssetId) }
         view.findViewById<View>(R.id.message_center_activity_button)
-            .setOnClickListener { engagementLauncher.startSecureMessaging(requireActivity()) }
+            .setOnClickListener { engagementLauncher.startSecureMessaging(requireActivity(), visitorContextAssetId) }
         view.findViewById<View>(R.id.end_engagement_button)
             .setOnClickListener { GliaWidgets.endEngagement() }
         view.findViewById<View>(R.id.visitor_info_button)
@@ -560,10 +561,10 @@ class MainFragment : Fragment() {
     }
 
     private fun showVisitorCode() {
-        val visitorContext = getContextAssetIdFromPrefs(sharedPreferences)
+        val visitorContextAssetId = getContextAssetIdFromPrefs(sharedPreferences)
         val cv = GliaWidgets.getCallVisualizer()
-        if (!visitorContext.isNullOrBlank()) {
-            cv.addVisitorContext(visitorContext)
+        if (!visitorContextAssetId.isNullOrBlank()) {
+            cv.addVisitorContext(visitorContextAssetId)
         }
         cv.showVisitorCodeDialog()
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/CallVisualizerManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/callvisualizer/CallVisualizerManager.kt
@@ -21,8 +21,8 @@ internal class CallVisualizerManager(
         callVisualizerController.showVisitorCodeDialog()
     }
 
-    override fun addVisitorContext(visitorContext: String) {
-        callVisualizerController.saveVisitorContextAssetId(visitorContext)
+    override fun addVisitorContext(visitorContextAssetId: String) {
+        callVisualizerController.saveVisitorContextAssetId(visitorContextAssetId)
     }
 
     @SuppressLint("CheckResult")

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -76,10 +76,12 @@ internal object Dependencies {
     @JvmStatic
     val configurationManager: ConfigurationManager by lazy { ConfigurationManagerImpl() }
 
-    val activityLauncher: ActivityLauncher by lazy { ActivityLauncherImpl(IntentHelperImpl()) }
+    val activityLauncher: ActivityLauncher by lazy {
+        ActivityLauncherImpl(IntentHelperImpl())
+    }
 
     @JvmStatic
-    val engagementLauncher: EngagementLauncher by lazy { EngagementLauncherImpl(activityLauncher) }
+    val engagementLauncher: EngagementLauncher by lazy { EngagementLauncherImpl(activityLauncher, configurationManager) }
 
     @JvmStatic
     val entryWidget: EntryWidget

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -149,7 +149,12 @@ public class RepositoryFactory {
 
     public EngagementRepository getEngagementRepository() {
         if (engagementRepository == null) {
-            engagementRepository = new EngagementRepositoryImpl(gliaCore, getOperatorRepository(), getQueueRepository());
+            engagementRepository = new EngagementRepositoryImpl(
+                gliaCore,
+                getOperatorRepository(),
+                getQueueRepository(),
+                configurationManager
+            );
         }
         return engagementRepository;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -37,6 +37,7 @@ import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.isAudioOrVideo
 import com.glia.widgets.helper.isQueueUnavailable
 import com.glia.widgets.helper.unSafeSubscribe
+import com.glia.widgets.launcher.ConfigurationManager
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -55,7 +56,8 @@ internal const val SKIP_ASKING_SCREEN_SHARING_PERMISSION_RESULT_CODE = 0x1995
 internal class EngagementRepositoryImpl(
     private val core: GliaCore,
     private val operatorRepository: GliaOperatorRepository,
-    private val queueRepository: QueueRepository
+    private val queueRepository: QueueRepository,
+    private val configurationManager: ConfigurationManager
 ) : EngagementRepository {
     private val engagementRequestCallback = Consumer<IncomingEngagementRequest>(::handleIncomingEngagementRequest)
     private val engagementOutcomeCallback = Consumer<Outcome>(::handleEngagementOutcome)
@@ -213,7 +215,12 @@ internal class EngagementRepositoryImpl(
         queueIngDisposable.add(
             queueRepository.relevantQueueIds.subscribe { ids ->
                 if (ids.isNotEmpty()) {
-                    core.queueForEngagement(ids, mediaType, null, null, MEDIA_PERMISSION_REQUEST_CODE) {
+                    core.queueForEngagement(
+                        ids,
+                        mediaType,
+                        configurationManager.visitorContextAssetId,
+                        null,
+                        MEDIA_PERMISSION_REQUEST_CODE) {
                         handleQueueingResponse(it)
                     }
                 } else {

--- a/widgetssdk/src/main/java/com/glia/widgets/launcher/ConfigurationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/launcher/ConfigurationManager.kt
@@ -14,17 +14,26 @@ internal interface ConfigurationManager {
 
     val queueIdsObservable: Flowable<List<String>>
 
+    val visitorContextAssetId: String?
+
     /**
      * Applies [GliaWidgetsConfig] from the [GliaWidgets.init] configuration step
      */
     fun applyConfiguration(config: GliaWidgetsConfig)
 
     /**
-     * Retrives queue IDs
+     * Sets queue IDs
      * [queueIds] A list of queue IDs to be used for the engagement launcher.
      * When empty or invalid, the default queues will be used.
      */
     fun setQueueIds(queueIds: List<String>)
+
+    /**
+     * Sets the visitor context for the engagement.
+     *
+     * @param visitorContextAssetId a visitor context id from Glia Hub.
+     */
+    fun setVisitorContextAssetId(visitorContextAssetId: String)
 }
 
 internal class ConfigurationManagerImpl : ConfigurationManager {
@@ -43,6 +52,10 @@ internal class ConfigurationManagerImpl : ConfigurationManager {
     private var _queueIdsObservable: BehaviorProcessor<List<String>> = BehaviorProcessor.create()
     override val queueIdsObservable: Flowable<List<String>> = _queueIdsObservable.onBackpressureLatest()
 
+    private var _visitorContextAssetId: String? = null
+    override val visitorContextAssetId: String?
+        get() = _visitorContextAssetId
+
     override fun applyConfiguration(config: GliaWidgetsConfig) {
         config.screenSharingMode?.also { _screenSharingMode = it }
         config.enableBubbleInsideApp?.also { _enableBubbleInsideApp = it }
@@ -51,5 +64,9 @@ internal class ConfigurationManagerImpl : ConfigurationManager {
 
     override fun setQueueIds(queueIds: List<String>) {
         _queueIdsObservable.onNext(queueIds)
+    }
+
+    override fun setVisitorContextAssetId(visitorContextAssetId: String) {
+        _visitorContextAssetId = visitorContextAssetId
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/launcher/EngagementLauncher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/launcher/EngagementLauncher.kt
@@ -12,46 +12,81 @@ interface EngagementLauncher {
      * Starts a chat engagement.
      *
      * @param activity The Activity used to launch the chat screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
      */
-    fun startChat(activity: Activity)
+    fun startChat(activity: Activity, visitorContextAssetId: String? = null)
 
     /**
      * Starts an audio engagement.
      *
      * @param activity The Activity used to launch the call screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
      */
-    fun startAudioCall(activity: Activity)
+    fun startAudioCall(activity: Activity, visitorContextAssetId: String? = null)
 
     /**
      * Starts a video engagement.
      *
      * @param activity The Activity used to launch the call screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
      */
-    fun startVideoCall(activity: Activity)
+    fun startVideoCall(activity: Activity, visitorContextAssetId: String? = null)
 
     /**
      * Starts a secure messaging.
      *
      * @param activity The Activity used to launch the secure messaging welcome or chat screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
      */
-    fun startSecureMessaging(activity: Activity)
+    fun startSecureMessaging(activity: Activity, visitorContextAssetId: String? = null)
 }
 
-internal class EngagementLauncherImpl(private val activityLauncher: ActivityLauncher) : EngagementLauncher {
+internal class EngagementLauncherImpl(
+    private val activityLauncher: ActivityLauncher,
+    private val configurationManager: ConfigurationManager
+) : EngagementLauncher {
 
-    override fun startChat(activity: Activity) {
+    /**
+     * Starts a chat engagement.
+     *
+     * @param activity The Activity used to launch the chat screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
+     */
+    override fun startChat(activity: Activity, visitorContextAssetId: String?) {
+        visitorContextAssetId?.let { configurationManager.setVisitorContextAssetId(it) }
         activityLauncher.launchChat(activity)
     }
 
-    override fun startAudioCall(activity: Activity) {
+    /**
+     * Starts an audio engagement.
+     *
+     * @param activity The Activity used to launch the call screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
+     */
+    override fun startAudioCall(activity: Activity, visitorContextAssetId: String?) {
+        visitorContextAssetId?.let { configurationManager.setVisitorContextAssetId(it) }
         activityLauncher.launchCall(activity, Engagement.MediaType.AUDIO, false)
     }
 
-    override fun startVideoCall(activity: Activity) {
+    /**
+     * Starts a video engagement.
+     *
+     * @param activity The Activity used to launch the call screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
+     */
+    override fun startVideoCall(activity: Activity, visitorContextAssetId: String?) {
+        visitorContextAssetId?.let { configurationManager.setVisitorContextAssetId(it) }
         activityLauncher.launchCall(activity, Engagement.MediaType.VIDEO, false)
     }
 
-    override fun startSecureMessaging(activity: Activity) {
+    /**
+     * Starts a secure messaging engagement.
+     *
+     * @param activity The Activity used to launch the secure messaging screen
+     * @param visitorContextAssetId Optional visitor context id from Glia Hub
+     */
+    override fun startSecureMessaging(activity: Activity, visitorContextAssetId: String?) {
+        visitorContextAssetId?.let { configurationManager.setVisitorContextAssetId(it) }
         activityLauncher.launchSecureMessagingWelcomeScreen(activity)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/launcher/EngagementLauncherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/launcher/EngagementLauncherTest.kt
@@ -1,0 +1,98 @@
+package com.glia.widgets.launcher
+
+import android.app.Activity
+import io.mockk.*
+import org.junit.Before
+import org.junit.Test
+
+class EngagementLauncherTest {
+
+    private lateinit var activity: Activity
+    private lateinit var activityLauncher: ActivityLauncher
+    private lateinit var engagementLauncher: EngagementLauncher
+    private lateinit var configurationManager: ConfigurationManager
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        activity = mockk(relaxed = true)
+        activityLauncher = mockk<ActivityLauncher> {
+            every { launchChat(any()) } returns  Unit
+            every { launchCall(any(), any(), any()) } returns  Unit
+            every { launchSecureMessagingWelcomeScreen(any()) } returns  Unit
+        }
+        configurationManager = mockk<ConfigurationManager> {
+            every { setVisitorContextAssetId(any()) } just Runs
+        }
+        engagementLauncher = EngagementLauncherImpl(activityLauncher, configurationManager)
+    }
+
+    @Test
+    fun `startChat with visitorContextAssetId calls setVisitorContextAssetId`() {
+        val visitorContextAssetId = "visitor_context"
+        engagementLauncher.startChat(activity, visitorContextAssetId)
+
+        verify { configurationManager.setVisitorContextAssetId(visitorContextAssetId) }
+    }
+
+    @Test
+    fun `startChat without visitorContextAssetId does not call setVisitorContextAssetId`() {
+        engagementLauncher.startChat(activity)
+
+        verify(exactly = 0) { configurationManager.setVisitorContextAssetId(any()) }
+    }
+
+    @Test
+    fun `startChat with visitorContextAssetId null does not call setVisitorContextAssetId`() {
+        val visitorContextAssetId = null
+        engagementLauncher.startChat(activity, visitorContextAssetId)
+
+        verify(exactly = 0) { configurationManager.setVisitorContextAssetId(any()) }
+    }
+
+    @Test
+    fun `startAudioCall with visitorContextAssetId calls setVisitorContextAssetId`() {
+        val visitorContextAssetId = "visitor_context"
+        engagementLauncher.startAudioCall(activity, visitorContextAssetId)
+
+        verify { configurationManager.setVisitorContextAssetId(visitorContextAssetId) }
+    }
+
+    @Test
+    fun `startAudioCall without visitorContextAssetId does not call setVisitorContextAssetId`() {
+        engagementLauncher.startAudioCall(activity)
+
+        verify(exactly = 0) { configurationManager.setVisitorContextAssetId(any()) }
+    }
+
+    @Test
+    fun `startAudioCall with visitorContextAssetId null does not call setVisitorContextAssetId`() {
+        val visitorContextAssetId = null
+        engagementLauncher.startAudioCall(activity, visitorContextAssetId)
+
+        verify(exactly = 0) { configurationManager.setVisitorContextAssetId(any()) }
+    }
+
+    @Test
+    fun `startSecureMessaging with visitorContextAssetId calls setVisitorContextAssetId`() {
+        val visitorContextAssetId = "visitor_context"
+        engagementLauncher.startSecureMessaging(activity, visitorContextAssetId)
+
+        verify { configurationManager.setVisitorContextAssetId(visitorContextAssetId) }
+    }
+
+    @Test
+    fun `startSecureMessaging without visitorContextAssetId does not call setVisitorContextAssetId`() {
+        engagementLauncher.startSecureMessaging(activity)
+
+        verify(exactly = 0) { configurationManager.setVisitorContextAssetId(any()) }
+    }
+
+    @Test
+    fun `startSecureMessaging with visitorContextAssetId null does not call setVisitorContextAssetId`() {
+        val visitorContextAssetId = null
+        engagementLauncher.startSecureMessaging(activity, visitorContextAssetId)
+
+        verify(exactly = 0) { configurationManager.setVisitorContextAssetId(any()) }
+    }
+}


### PR DESCRIPTION
[MOB-3752](https://glia.atlassian.net/browse/MOB-3752)

**What was solved?**
- Add ability to pass visitor context id through Engagement Launcher

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-3752]: https://glia.atlassian.net/browse/MOB-3752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ