### PR TITLE
Make SC APIs work seamlessly when sdk is not initialized

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversationsRepository.kt
@@ -8,18 +8,17 @@ import com.glia.androidsdk.secureconversations.SecureConversations
 import com.glia.widgets.chat.data.GliaChatRepository
 import com.glia.widgets.chat.domain.GliaSendMessageUseCase
 import com.glia.widgets.core.queue.QueueRepository
-import com.glia.widgets.entrywidget.EntryWidget
+import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.unSafeSubscribe
-import com.glia.widgets.launcher.EngagementLauncher
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 import io.reactivex.rxjava3.subjects.Subject
-import java.util.concurrent.TimeUnit
 
-internal class SecureConversationsRepository(private val secureConversations: SecureConversations, private val queueRepository: QueueRepository) {
+internal class SecureConversationsRepository(private val core: GliaCore, private val queueRepository: QueueRepository) {
+    private val secureConversations: SecureConversations by lazy { core.secureConversations }
+
     private val _messageSendingObservable: Subject<Boolean> = BehaviorSubject.createDefault(false)
-
     val messageSendingObservable: Observable<Boolean> = _messageSendingObservable
 
     fun fetchChatTranscript(listener: GliaChatRepository.HistoryLoadedListener) {
@@ -77,12 +76,4 @@ internal class SecureConversationsRepository(private val secureConversations: Se
             }
         }
     }
-
-    /**
-     * Since we're using this function in [EntryWidget] and [EngagementLauncher] where we need the immediate UI response to the user interaction,
-     * it is important to to avoid delays for the user.
-     */
-    fun getHasPendingSecureConversationsWithTimeout(): Single<Boolean> = getHasPendingSecureConversations()
-        .timeout(1, TimeUnit.SECONDS)
-        .onErrorReturnItem(false)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCase.kt
@@ -1,7 +1,9 @@
 package com.glia.widgets.core.secureconversations.domain
 
 import androidx.annotation.VisibleForTesting
+import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.Logger
 import io.reactivex.rxjava3.core.Single
 import java.util.concurrent.TimeUnit
@@ -20,9 +22,16 @@ internal const val TIMEOUT_SEC = 3L
 
 internal const val NO_UNREAD_MESSAGES = 0
 
-internal class GetUnreadMessagesCountWithTimeoutUseCase(private val repository: SecureConversationsRepository) {
+internal class GetUnreadMessagesCountWithTimeoutUseCase(
+    private val repository: SecureConversationsRepository,
+    private val isAuthenticatedUseCase: IsAuthenticatedUseCase,
+    private val core: GliaCore
+) {
 
     /**
+     * This function provides a default value instead of an error.
+     * If error handling is needed, use the repository function directly.
+     *
      * @return [NO_UNREAD_MESSAGES] if the current socket doesn't signal a success value within the specified [TIMEOUT_SEC] window.
      *
      * This is combined with the chat transcript result to avoid "Jumping UI" when adding new messages'
@@ -30,7 +39,13 @@ internal class GetUnreadMessagesCountWithTimeoutUseCase(private val repository: 
      * there is no warranty that it will return anything so timeout is added to make sure that it will return [NO_UNREAD_MESSAGES]
      * after the timeout if there is no answer from socket yet.
      */
-    operator fun invoke(): Single<Int> = Single.create {
+    operator fun invoke(): Single<Int> = when {
+        core.isInitialized.not() -> Single.just(NO_UNREAD_MESSAGES)
+        isAuthenticatedUseCase().not() -> Single.just(NO_UNREAD_MESSAGES)
+        else -> getUnreadMessagesCountWithTimeout()
+    }
+
+    private fun getUnreadMessagesCountWithTimeout() = Single.create {
         repository.getUnreadMessagesCount { count, exception ->
             if (it.isDisposed) return@getUnreadMessagesCount
             if (exception != null) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/HasPendingSecureConversationsWithTimeoutUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/HasPendingSecureConversationsWithTimeoutUseCase.kt
@@ -1,0 +1,33 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.di.GliaCore
+import com.glia.widgets.entrywidget.EntryWidget
+import com.glia.widgets.launcher.EngagementLauncher
+import io.reactivex.rxjava3.core.Single
+import java.util.concurrent.TimeUnit
+
+internal class HasPendingSecureConversationsWithTimeoutUseCase(
+    private val secureConversationsRepository: SecureConversationsRepository,
+    private val isAuthenticatedUseCase: IsAuthenticatedUseCase,
+    private val core: GliaCore
+) {
+    /**
+     * This function provides a default value instead of an error.
+     * If error handling is needed, use the repository function directly.
+     *
+     * @return `false` if the SDk is not initialized, visitor is not authenticated or
+     * if the current socket doesn't signal a success value within the specified 1 sec window.
+     *
+     * Since we're using this function in [EntryWidget] and [EngagementLauncher] where we need the immediate UI response to the user interaction,
+     *  * it is important to to avoid delays for the user.
+     */
+    operator fun invoke(): Single<Boolean> = when {
+        core.isInitialized.not() -> Single.just(false)
+        isAuthenticatedUseCase().not() -> Single.just(false)
+        else -> secureConversationsRepository.getHasPendingSecureConversations()
+            .timeout(1, TimeUnit.SECONDS)
+            .onErrorReturnItem(false)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -87,7 +87,7 @@ internal object Dependencies {
             activityLauncher,
             gliaThemeManager,
             controllerFactory.entryWidgetHideController,
-            repositoryFactory.secureConversationsRepository
+            useCaseFactory.hasPendingSecureConversationsWithTimeoutUseCase
         )
 
     @JvmStatic

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -114,7 +114,7 @@ public class RepositoryFactory {
 
     public SecureConversationsRepository getSecureConversationsRepository() {
         if (secureConversationsRepository == null) {
-            secureConversationsRepository = new SecureConversationsRepository(gliaCore.getSecureConversations(), getQueueRepository());
+            secureConversationsRepository = new SecureConversationsRepository(gliaCore, getQueueRepository());
         }
         return secureConversationsRepository;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -106,6 +106,7 @@ import com.glia.widgets.core.secureconversations.domain.AddSecureFileAttachments
 import com.glia.widgets.core.secureconversations.domain.AddSecureFileToAttachmentAndUploadUseCase;
 import com.glia.widgets.core.secureconversations.domain.GetSecureFileAttachmentsUseCase;
 import com.glia.widgets.core.secureconversations.domain.GetUnreadMessagesCountWithTimeoutUseCase;
+import com.glia.widgets.core.secureconversations.domain.HasPendingSecureConversationsWithTimeoutUseCase;
 import com.glia.widgets.core.secureconversations.domain.IsMessagingAvailableUseCase;
 import com.glia.widgets.core.secureconversations.domain.IsSecureEngagementUseCase;
 import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase;
@@ -605,7 +606,11 @@ public class UseCaseFactory {
 
     @NonNull
     public GetUnreadMessagesCountWithTimeoutUseCase createSubscribeToUnreadMessagesCountUseCase() {
-        return new GetUnreadMessagesCountWithTimeoutUseCase(repositoryFactory.getSecureConversationsRepository());
+        return new GetUnreadMessagesCountWithTimeoutUseCase(
+            repositoryFactory.getSecureConversationsRepository(),
+            createIsAuthenticatedUseCase(),
+            gliaCore
+        );
     }
 
     @NonNull
@@ -1083,6 +1088,15 @@ public class UseCaseFactory {
         return new FlipCameraButtonStateUseCaseImpl(
             repositoryFactory.getEngagementRepository(),
             getFlipVisitorCameraUseCase()
+        );
+    }
+
+    @NonNull
+    public HasPendingSecureConversationsWithTimeoutUseCase getHasPendingSecureConversationsWithTimeoutUseCase() {
+        return new HasPendingSecureConversationsWithTimeoutUseCase(
+            repositoryFactory.getSecureConversationsRepository(),
+            createIsAuthenticatedUseCase(),
+            gliaCore
         );
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
@@ -3,7 +3,7 @@ package com.glia.widgets.entrywidget
 import android.app.Activity
 import android.content.Context
 import android.view.View
-import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.core.secureconversations.domain.HasPendingSecureConversationsWithTimeoutUseCase
 import com.glia.widgets.entrywidget.adapter.EntryWidgetAdapter
 import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.launcher.ActivityLauncher
@@ -37,11 +37,11 @@ internal class EntryWidgetImpl(
     private val activityLauncher: ActivityLauncher,
     private val themeManager: UnifiedThemeManager,
     private val entryWidgetHideController: EntryWidgetHideController,
-    private val secureConversationsRepository: SecureConversationsRepository
+    private val hasPendingSecureConversationsWithTimeoutUseCase: HasPendingSecureConversationsWithTimeoutUseCase
 ) : EntryWidget {
 
     override fun show(activity: Activity) {
-        secureConversationsRepository.getHasPendingSecureConversationsWithTimeout().unSafeSubscribe {
+        hasPendingSecureConversationsWithTimeoutUseCase().unSafeSubscribe {
             handleShowWithPendingSecureConversations(it, activity)
         }
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/GetUnreadMessagesCountWithTimeoutUseCaseTest.kt
@@ -2,7 +2,9 @@ package com.glia.widgets.core.secureconversations.domain
 
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.di.GliaCore
 import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import org.junit.Before
 import org.junit.Test
@@ -20,16 +22,37 @@ import kotlin.properties.Delegates
 class GetUnreadMessagesCountWithTimeoutUseCaseTest {
     private var repository: SecureConversationsRepository by Delegates.notNull()
     private var useCase: GetUnreadMessagesCountWithTimeoutUseCase by Delegates.notNull()
+    private var isAuthenticatedUseCase: IsAuthenticatedUseCase by Delegates.notNull()
+    private var core: GliaCore by Delegates.notNull()
 
     @Before
     fun setUp() {
         RxJavaPlugins.reset()
         repository = mock()
-        useCase = GetUnreadMessagesCountWithTimeoutUseCase(repository)
+        isAuthenticatedUseCase = mock()
+        core = mock()
+        useCase = GetUnreadMessagesCountWithTimeoutUseCase(repository, isAuthenticatedUseCase, core)
+    }
+
+    @Test
+    fun `invoke returns NO_UNREAD_MESSAGES when GliaCore is not initialized`() {
+        whenever(core.isInitialized).thenReturn(false)
+
+        useCase().test().assertComplete().assertValue(NO_UNREAD_MESSAGES)
+    }
+
+    @Test
+    fun `invoke returns NO_UNREAD_MESSAGES when user is not authenticated`() {
+        whenever(core.isInitialized).thenReturn(true)
+        whenever(isAuthenticatedUseCase()).thenReturn(false)
+
+        useCase().test().assertComplete().assertValue(NO_UNREAD_MESSAGES)
     }
 
     @Test
     fun `invoke returns NO_UNREAD_MESSAGES when there is no answer during timeout`() {
+        mockInitializedAndAuthenticated()
+
         val answer: Answer<*> = AnswersWithDelay(
             TIMEOUT_SEC * 2_000L
         ) {
@@ -43,6 +66,8 @@ class GetUnreadMessagesCountWithTimeoutUseCaseTest {
 
     @Test
     fun `invoke completes with NO_UNREAD_MESSAGES when error is returned`() {
+        mockInitializedAndAuthenticated()
+
         doAnswer {
             val callback: RequestCallback<Int?> = it.getArgument(0)
             callback.onResult(null, GliaException("", GliaException.Cause.INTERNAL_ERROR))
@@ -53,6 +78,8 @@ class GetUnreadMessagesCountWithTimeoutUseCaseTest {
 
     @Test
     fun `invoke completes with NO_UNREAD_MESSAGES when count is null`() {
+        mockInitializedAndAuthenticated()
+
         doAnswer {
             val callback: RequestCallback<Int?> = it.getArgument(0)
             callback.onResult(null, null)
@@ -63,6 +90,8 @@ class GetUnreadMessagesCountWithTimeoutUseCaseTest {
 
     @Test
     fun `invoke completes with NO_UNREAD_MESSAGES when count is 0`() {
+        mockInitializedAndAuthenticated()
+
         doAnswer {
             val callback: RequestCallback<Int?> = it.getArgument(0)
             callback.onResult(0, null)
@@ -73,11 +102,18 @@ class GetUnreadMessagesCountWithTimeoutUseCaseTest {
 
     @Test
     fun `invoke completes with correct messages count when success is called`() {
+        mockInitializedAndAuthenticated()
+
         doAnswer {
             val callback: RequestCallback<Int?> = it.getArgument(0)
             callback.onResult(10, null)
         }.whenever(repository).getUnreadMessagesCount(any())
 
         useCase().test().assertComplete().assertValue(10)
+    }
+
+    private fun mockInitializedAndAuthenticated() {
+        whenever(core.isInitialized).thenReturn(true)
+        whenever(isAuthenticatedUseCase()).thenReturn(true)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/HasPendingSecureConversationsWithTimeoutUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/HasPendingSecureConversationsWithTimeoutUseCaseTest.kt
@@ -1,0 +1,91 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
+import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.di.GliaCore
+import io.mockk.every
+import io.mockk.mockk
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.plugins.RxJavaPlugins
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class HasPendingSecureConversationsWithTimeoutUseCaseTest {
+    private lateinit var repository: SecureConversationsRepository
+    private lateinit var useCase: HasPendingSecureConversationsWithTimeoutUseCase
+    private lateinit var isAuthenticatedUseCase: IsAuthenticatedUseCase
+    private lateinit var core: GliaCore
+
+    @Before
+    fun setUp() {
+        RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
+        repository = mockk()
+        isAuthenticatedUseCase = mockk()
+        core = mockk()
+        useCase = HasPendingSecureConversationsWithTimeoutUseCase(repository, isAuthenticatedUseCase, core)
+    }
+
+    @Test
+    fun `invoke returns false when GliaCore is not initialized`() {
+        every { core.isInitialized } returns false
+
+        val result = useCase().blockingGet()
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `invoke returns false when user is not authenticated`() {
+        every { core.isInitialized } returns true
+        every { isAuthenticatedUseCase() } returns false
+
+        val result = useCase().blockingGet()
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `invoke returns false when there is no answer during timeout`() {
+        mockInitializedAndAuthenticated()
+
+        every { repository.getHasPendingSecureConversations() } returns Single.never()
+
+        val result = useCase().blockingGet()
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `invoke returns false when error is returned`() {
+        mockInitializedAndAuthenticated()
+
+        every { repository.getHasPendingSecureConversations() } returns Single.error(Exception("Error"))
+
+        val result = useCase().blockingGet()
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `invoke returns true when there are pending secure conversations`() {
+        mockInitializedAndAuthenticated()
+
+        every { repository.getHasPendingSecureConversations() } returns Single.just(true)
+
+        val result = useCase().blockingGet()
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `invoke returns false when there are no pending secure conversations`() {
+        mockInitializedAndAuthenticated()
+
+        every { repository.getHasPendingSecureConversations() } returns Single.just(false)
+
+        val result = useCase().blockingGet()
+        assertEquals(false, result)
+    }
+
+    private fun mockInitializedAndAuthenticated() {
+        every { core.isInitialized } returns true
+        every { isAuthenticatedUseCase() } returns true
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3761

**What was solved?**
Added initialization and authentication checks for the SC `getUnreadMessagesCound()` and `hasSecureConversations()` inside their use cases to prevent crashes in the Entry Widget.

**Release notes:**

 - [x] Feature(Part of SC V2 feature)
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
