### PR TITLE
Add business logic into EngagementLauncher.startSecureMessaging

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -79,7 +79,9 @@ internal object Dependencies {
     val activityLauncher: ActivityLauncher by lazy { ActivityLauncherImpl(IntentHelperImpl()) }
 
     @JvmStatic
-    val engagementLauncher: EngagementLauncher by lazy { EngagementLauncherImpl(activityLauncher) }
+    val engagementLauncher: EngagementLauncher by lazy {
+        EngagementLauncherImpl(activityLauncher, useCaseFactory.hasPendingSecureConversationsWithTimeoutUseCase)
+    }
 
     @JvmStatic
     val entryWidget: EntryWidget


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3758

**What was solved?**

**Release notes:**

 - [x] Feature(part of SC V2 feature)
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
