### PR TITLE
Show the Entry Widget items in correct order

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -67,9 +67,9 @@ internal class EntryWidgetController(
             .distinct()
             .let { allMedias ->
                 return buildList {
-                    if (allMedias.contains(Engagement.MediaType.TEXT)) add(EntryWidgetContract.ItemType.CHAT)
-                    if (allMedias.contains(Engagement.MediaType.AUDIO)) add(EntryWidgetContract.ItemType.AUDIO_CALL)
                     if (allMedias.contains(Engagement.MediaType.VIDEO)) add(EntryWidgetContract.ItemType.VIDEO_CALL)
+                    if (allMedias.contains(Engagement.MediaType.AUDIO)) add(EntryWidgetContract.ItemType.AUDIO_CALL)
+                    if (allMedias.contains(Engagement.MediaType.TEXT)) add(EntryWidgetContract.ItemType.CHAT)
                     if (allMedias.contains(Engagement.MediaType.MESSAGING) && isAuthenticatedUseCase()) add(EntryWidgetContract.ItemType.SECURE_MESSAGE)
 
                     if (allMedias.isEmpty() || allMedias.hasOnlyMessagingAndIsNotAuthenticated()) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3784

**What was solved?**
Show the Entry Widget items in order according to the design

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img src="https://github.com/user-attachments/assets/3251bbff-180c-46c3-8204-3dd9acc0e588" width="300" />
