### PR TITLE
Update EntryWidgetsView to support MESSAGING_LIVE_SUPPORT flag

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
@@ -12,20 +12,24 @@ internal interface EntryWidgetContract {
         MESSAGING_LIVE_SUPPORT
     }
 
-    sealed class ItemType {
-        data object Chat : ItemType()
-        data object AudioCall : ItemType()
-        data object VideoCall : ItemType()
-        data class Messaging(val value: Int) : ItemType()
-        data object LoadingState : ItemType()
-        data object EmptyState : ItemType()
-        data object SdkNotInitializedState : ItemType()
-        data object ErrorState : ItemType()
-        data object ProvidedBy : ItemType()
+    sealed class ItemType(private val order: Int) : Comparable<ItemType> {
+        data object VideoCall : ItemType(0)
+        data object AudioCall : ItemType(1)
+        data object Chat : ItemType(2)
+        data class Messaging(val value: Int) : ItemType(3)
+        data object LoadingState : ItemType(10)
+        data object EmptyState : ItemType(10)
+        data object SdkNotInitializedState : ItemType(10)
+        data object ErrorState : ItemType(10)
+        data object ProvidedBy : ItemType(11)
+
+        override fun compareTo(other: ItemType): Int {
+            return this.order.compareTo(other.order)
+        }
     }
 
     interface Controller : BaseController {
-        fun setView(view: View)
+        fun setView(view: View, type: ViewType)
         fun onItemClicked(itemType: ItemType, activity: Activity)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
@@ -2,6 +2,8 @@ package com.glia.widgets.entrywidget
 
 import android.app.Activity
 import android.content.Context
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.InsetDrawable
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.glia.widgets.R
@@ -12,6 +14,7 @@ import com.glia.widgets.helper.getDrawableCompat
 import com.glia.widgets.helper.requireActivity
 import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
 import com.glia.widgets.view.unifiedui.applyLayerTheme
+import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
 import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemsTheme
@@ -60,7 +63,7 @@ internal class EntryWidgetView(
 
     override fun setController(controller: EntryWidgetContract.Controller) {
         this.controller = controller
-        controller.setView(this)
+        controller.setView(this, viewAdapter.viewType)
     }
 
     override fun showItems(items: List<EntryWidgetContract.ItemType>) {
@@ -88,11 +91,23 @@ internal class EntryWidgetView(
 
     private fun applyTheme(backgroundTheme: LayerTheme? = null, mediaTypeItemsTheme: MediaTypeItemsTheme? = null) {
         backgroundTheme?.let { applyLayerTheme(it) }
-        getDrawableCompat(R.drawable.bg_entry_widget_divider)?.let {
-            mediaTypeItemsTheme?.dividerColor?.let { dividerColor ->
-                it.setTint(dividerColor.primaryColor)
-            }
+        createDividerDrawable(mediaTypeItemsTheme?.dividerColor)?.let {
             addItemDecoration(EntryWidgetItemDecoration(it))
         }
+    }
+
+    private fun createDividerDrawable(dividerColor: ColorTheme?): Drawable? {
+        return getDrawableCompat(R.drawable.bg_entry_widget_divider)
+            ?.apply {
+                dividerColor?.primaryColor?.let { setTint(it) }
+            }
+            ?.let {
+                if (viewAdapter.viewType == EntryWidgetContract.ViewType.MESSAGING_LIVE_SUPPORT) {
+                    it
+                } else {
+                    val padding = resources.getDimension(R.dimen.glia_large).toInt()
+                    InsetDrawable(it, padding, 0, padding, 0)
+                }
+            }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
@@ -79,6 +79,7 @@ internal class EntryWidgetAdapter(
     val disposable: CompositeDisposable = CompositeDisposable()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val isInsideSecureConversation = this.viewType == EntryWidgetContract.ViewType.MESSAGING_LIVE_SUPPORT
         return when (viewType) {
             ViewType.ERROR_ITEM.ordinal -> EntryWidgetErrorStateViewHolder(
                 EntryWidgetErrorItemBinding.inflate(parent.layoutInflater, parent, false),
@@ -96,7 +97,8 @@ internal class EntryWidgetAdapter(
             )
             else -> EntryWidgetLiveItemViewHolder(
                 EntryWidgetLiveItemBinding.inflate(parent.layoutInflater, parent, false),
-                itemTheme = mediaTypeItemsTheme?.mediaTypeItem
+                itemTheme = mediaTypeItemsTheme?.mediaTypeItem,
+                isInsideSecureConversation
             )
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetLiveItemViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetLiveItemViewHolder.kt
@@ -15,7 +15,8 @@ import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemTheme
 
 internal class EntryWidgetLiveItemViewHolder(
     private val binding: EntryWidgetLiveItemBinding,
-    itemTheme: MediaTypeItemTheme?
+    itemTheme: MediaTypeItemTheme?,
+    isInsideSecureConversation: Boolean
 ) : EntryWidgetAdapter.ViewHolder(binding.root) {
 
     init {
@@ -29,6 +30,12 @@ internal class EntryWidgetLiveItemViewHolder(
                 binding.titleLoading.backgroundTintList = tintList
                 binding.descriptionLoading.backgroundTintList = tintList
             }
+        }
+
+
+        if (isInsideSecureConversation) {
+            val mediumPadding = binding.root.resources.getDimension(R.dimen.glia_medium).toInt()
+            binding.root.setPadding(0, mediumPadding, 0, mediumPadding)
         }
     }
 

--- a/widgetssdk/src/main/res/drawable/bg_entry_widget_divider.xml
+++ b/widgetssdk/src/main/res/drawable/bg_entry_widget_divider.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:left="@dimen/glia_large"
-        android:right="@dimen/glia_large">
+    <item>
 
         <shape
             android:shape="rectangle">

--- a/widgetssdk/src/main/res/layout/entry_widget_live_item.xml
+++ b/widgetssdk/src/main/res/layout/entry_widget_live_item.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingTop="@dimen/glia_large"
+    android:paddingBottom="@dimen/glia_large"
     android:foreground="?attr/selectableItemBackground">
 
     <ImageView
@@ -15,34 +18,34 @@
         app:layout_constraintEnd_toStartOf="@id/title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:tint="?attr/gliaBrandPrimaryColor" />
+        app:tint="?attr/gliaBrandPrimaryColor"
+        tools:src="@drawable/ic_audio" />
 
     <TextView
         android:id="@+id/title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/glia_large"
         android:layout_marginEnd="@dimen/glia_x_large"
         android:letterSpacing="-0.02"
         android:textColor="?attr/gliaBaseDarkColor"
         app:layout_constraintBottom_toTopOf="@id/description"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/icon"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/entry_widget_audio_button_label" />
 
     <TextView
         android:id="@+id/description"
         style="@style/Application.Glia.Subtitle2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/glia_x_large"
-        android:layout_marginBottom="@dimen/glia_large"
         android:letterSpacing="-0.01"
         android:textColor="?attr/gliaBaseNormalColor"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/title"
-        app:layout_constraintTop_toBottomOf="@id/title" />
+        app:layout_constraintTop_toBottomOf="@id/title"
+        tools:text="@string/entry_widget_audio_button_description" />
 
     <View
         android:id="@+id/icon_loading"

--- a/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
@@ -56,7 +56,7 @@ class EntryWidgetControllerTest {
             core,
             engagementLauncher
         )
-        controller.setView(view)
+        controller.setView(view, EntryWidgetContract.ViewType.BOTTOM_SHEET)
     }
 
     @After
@@ -71,7 +71,7 @@ class EntryWidgetControllerTest {
         `when`(observeUnreadMessagesCountUseCase.invoke()).thenReturn(Observable.just(unreadMessageCount))
         `when`(queueRepository.queuesState).thenReturn(Flowable.just(QueuesState.Loading))
 
-        controller.setView(view)
+        controller.setView(view, EntryWidgetContract.ViewType.BOTTOM_SHEET)
 
         verify(view, atLeast(1)).showItems(anyList())
     }
@@ -80,7 +80,7 @@ class EntryWidgetControllerTest {
     fun `showItems is called with ERROR_STATE if SDK is not initialized`() {
         `when`(core.isInitialized).thenReturn(false)
 
-        controller.setView(view)
+        controller.setView(view, EntryWidgetContract.ViewType.BOTTOM_SHEET)
 
         verify(view, atLeast(1)).showItems(listOf(EntryWidgetContract.ItemType.SdkNotInitializedState))
     }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3639

**What was solved?**
Made UI changes for EntryWidgetsView to correctly render as secure messaging top banner options:
- smaller padding between media items
- removed white label
- made divider match screen width

**Release notes:**

 - [x] Feature: **Part of SCv2 feature**
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

Currently, the new view type is not used anywhere but here is how it would look:
![Screenshot_20241112_185635](https://github.com/user-attachments/assets/09566404-21f0-4b5d-bc3f-103deca5c190)

Here are screenshots for the old view type (in this case it is BOTTOM_SHEET).
Posting it to show that it is unchanged
![Screenshot_20241112_184525](https://github.com/user-attachments/assets/2d0ed69f-bacc-480a-88f1-787dc6885764)

![Screenshot_20241112_184450](https://github.com/user-attachments/assets/45f24ac2-dc45-4b91-b257-b453ddcebeb7)

