### PR TITLE
Fix SDK crashes when trying to reopen local attachment

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -182,7 +182,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         controller?.onImageCaptured(it)
     }
 
-    private val getContentLauncher = chatActivity?.registerForActivityResult(ActivityResultContracts.GetContent()) {
+    private val getContentLauncher = chatActivity?.registerForActivityResult(ActivityResultContracts.OpenDocument()) {
         it?.apply { controller?.onContentChosen(this) }
     }
 
@@ -355,7 +355,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
             updateNewMessageOperatorStatusView(chatState.operatorProfileImgUrl)
             isInBottom = chatState.isChatInBottom
             binding.chatRecyclerView.setInBottom(isInBottom)
-            binding.newMessagesBadgeView.text = chatState.messagesNotSeen.toString()
+            binding.newMessagesBadgeView.text = "${chatState.messagesNotSeen}"
             if (chatState.isVisible) {
                 showChat()
             } else {
@@ -719,7 +719,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
     private fun setupAddAttachmentButton() {
         binding.addAttachmentButton.setOnClickListener {
             attachmentPopup.show(binding.chatMessageLayout, {
-                getContentLauncher?.launch(Constants.MIME_TYPE_IMAGES)
+                getContentLauncher?.launch(arrayOf(Constants.MIME_TYPE_IMAGES))
             }, {
                 controller?.onTakePhotoClicked()
             }, {

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
@@ -6,7 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.result.contract.ActivityResultContracts.GetContent
+import androidx.activity.result.contract.ActivityResultContracts.OpenDocument
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.TakePicture
 import com.glia.widgets.GliaWidgets
@@ -55,7 +55,7 @@ class MessageCenterActivity :
         Dependencies.controllerFactory.messageCenterController
     }
 
-    private val getContent = registerForActivityResult(GetContent()) { uri: Uri? ->
+    private val getContent = registerForActivityResult(OpenDocument()) { uri: Uri? ->
         uri?.also(controller::onContentChosen)
     }
 
@@ -118,7 +118,7 @@ class MessageCenterActivity :
     }
 
     override fun selectAttachmentFile(type: String) {
-        getContent.launch(type)
+        getContent.launch(arrayOf(type))
     }
 
     override fun takePhoto(uri: Uri) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3790

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
