### PR TITLE
Fix Click on visitor message works from 2nd attempt during tap to retry

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/adapter/holder/VisitorMessageViewHolder.kt
@@ -85,10 +85,14 @@ internal class VisitorMessageViewHolder(
 
         if (status.isError) {
             itemView.addClickActionAccessibilityLabel(localeProvider.getString(R.string.general_retry))
-            itemView.setOnClickListener { onRetryClickListener.onRetryClicked(id) }
+            binding.content.addClickActionAccessibilityLabel(localeProvider.getString(R.string.general_retry))
             binding.content.setOnClickListener { onRetryClickListener.onRetryClicked(id) }
+            binding.content.setTextIsSelectable(false)
+            itemView.setOnClickListener { onRetryClickListener.onRetryClicked(id) }
         } else {
             itemView.removeAccessibilityClickAction()
+            binding.content.removeAccessibilityClickAction()
+            binding.content.setTextIsSelectable(true)
             itemView.setOnClickListener(null)
             binding.content.setOnClickListener(null)
         }

--- a/widgetssdk/src/main/res/layout/chat_visitor_message_layout.xml
+++ b/widgetssdk/src/main/res/layout/chat_visitor_message_layout.xml
@@ -51,6 +51,7 @@
         android:textAppearance="?attr/textAppearanceCaption"
         android:textColor="?attr/gliaSystemNegativeColor"
         android:visibility="gone"
+        android:clickable="false"
         android:importantForAccessibility="no"
         app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3797

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
