### PR TITLE
Rename 'Live Chat' to 'Chat'

### DIFF
--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -217,7 +217,7 @@
     <string name="gva_gallery_card_message_accessibility">%1$s \n Card: %2$d of %3$d.</string><!--does not synchronized yet-->
 
     <!--    Entry Widget -->
-    <string name="entry_widget_live_chat_button_label">Live Chat</string>
+    <string name="entry_widget_live_chat_button_label">Chat</string>
     <string name="entry_widget_live_chat_button_description">For the texter in all of us</string>
     <string name="entry_widget_live_chat_button_accessibility_hint">Starts a chat</string>
     <string name="entry_widget_audio_button_label">Audio</string>


### PR DESCRIPTION
**What was solved?**
- Rename 'Live Chat' to 'Chat' according to the [conversation](https://salemove.slack.com/archives/C07DM3JD8R1/p1731500928908379) in Slack

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img width="256" alt="Screenshot 2024-11-13 at 15 11 14" src="https://github.com/user-attachments/assets/447054ef-21f6-419f-bed0-7d0520e8b10b">
