### PR TITLE
Refresh Entry Widget on Glia init

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     // Needed for some automated and manual testing (e.g: acceptance tests)
     mavenLocal()
     //TODO switch to the release version before releasing core SDK
-    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1316" }
+    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1321" }
   }
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Mon Oct 07 09:29:14 UTC 2024
-dependency.coreSdk.version=1.9.0
+dependency.coreSdk.version=2.0.0_sc
 widgets.versionCode=86
 widgets.versionName=2.8.2

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -32,11 +32,10 @@ internal class EntryWidgetController(
         this.view = view
         this.type = type
 
-        if (core.isInitialized) {
-            subscribeToQueueState()
-        } else {
+        if (!core.isInitialized) {
             showSdkNotInitializedState()
         }
+        subscribeToQueueState()
     }
 
     private fun showSdkNotInitializedState() {

--- a/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
@@ -56,6 +56,9 @@ class EntryWidgetControllerTest {
             core,
             engagementLauncher
         )
+        val unreadMessageCount = 0
+        `when`(observeUnreadMessagesCountUseCase.invoke()).thenReturn(Observable.just(unreadMessageCount))
+        `when`(queueRepository.queuesState).thenReturn(Flowable.just(QueuesState.Loading))
         controller.setView(view, EntryWidgetContract.ViewType.BOTTOM_SHEET)
     }
 
@@ -67,9 +70,6 @@ class EntryWidgetControllerTest {
     @Test
     fun `showItems is called if sdk is initialized`() {
         `when`(core.isInitialized).thenReturn(true)
-        val unreadMessageCount = 0
-        `when`(observeUnreadMessagesCountUseCase.invoke()).thenReturn(Observable.just(unreadMessageCount))
-        `when`(queueRepository.queuesState).thenReturn(Flowable.just(QueuesState.Loading))
 
         controller.setView(view, EntryWidgetContract.ViewType.BOTTOM_SHEET)
 
@@ -200,8 +200,6 @@ class EntryWidgetControllerTest {
 
     @Test
     fun `onItemClicked does not call dismiss when ERROR_STATE item clicked`() {
-        val mockQueuesState : Flowable<QueuesState> = Flowable.just(QueuesState.Loading)
-        `when`(queueRepository.queuesState).thenReturn(mockQueuesState)
         controller.onItemClicked(EntryWidgetContract.ItemType.ErrorState, activity)
         verify(view, never()).dismiss()
         verify(queueRepository).fetchQueues()


### PR DESCRIPTION
**Jira issue:**
[MOB-3810](https://glia.atlassian.net/browse/MOB-3810)

**What was solved?**
Scenario:
- show embedded view before Glia is initialized (error state is shown)
- init Glia
**Actual result:** Entry Widget still shows an error state
**Expected result:** error state is replaced with loading state and data state afterwards

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**


[MOB-3810]: https://glia.atlassian.net/browse/MOB-3810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ