### PR TITLE
Update Core SDK staging repo url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     // Needed for some automated and manual testing (e.g: acceptance tests)
     mavenLocal()
     //TODO switch to the release version before releasing core SDK
-    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1321" }
+    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1323" }
   }
 }
 


### PR DESCRIPTION


**Jira issue:**
- no ticket -

**What was solved?**
The old staging version of Core SDK got automatically deleted for some reason.

Discussion in slack:
https://salemove.slack.com/archives/C01F9K88SQZ/p1732545132319779?thread_ts=1732527166.629109&cid=C01F9K88SQZ

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
