### PR TITLE
Prevent recursive dismiss() call

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
@@ -65,7 +65,7 @@ internal class EntryWidgetFragment : BottomSheetDialogFragment() {
             setEntryWidgetTheme(entryWidgetsTheme)
             binding.container.addView(this)
             onDismissListener = {
-                dismiss()
+                this@EntryWidgetFragment.dismiss()
             }
         }
 


### PR DESCRIPTION
**Jira issue:**
[[Android] SDK crashes on Entry Widget item tap](https://glia.atlassian.net/browse/MOB-3845)

**What was solved?**
Crash reason is [here](https://github.com/salemove/android-sdk-widgets/pull/1169/files#diff-4f29a0397380e2017630aae072bd897cc65374955c607c104dfddcff4bfb6cadR63-R69).
`dismiss()` was called recursively.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

