### PR TITLE
Fix send and attachment buttons overlap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     // Needed for some automated and manual testing (e.g: acceptance tests)
     mavenLocal()
     //TODO switch to the release version before releasing core SDK
-    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1329" }
+    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1330" }
   }
 }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/AttachmentPopup.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/AttachmentPopup.kt
@@ -12,18 +12,19 @@ import com.glia.widgets.databinding.ChatAttachmentPopupBinding
 import com.glia.widgets.helper.getColorCompat
 import com.glia.widgets.helper.setLocaleText
 import com.glia.widgets.helper.setTintCompat
+import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
 import com.glia.widgets.view.unifiedui.applyImageColorTheme
 import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.chat.AttachmentsPopupTheme
 
 internal class AttachmentPopup(
-    anchor: View,
+    context: Context,
     private val theme: AttachmentsPopupTheme?,
     private val popupWindowFunc: (LinearLayout) -> PopupWindow = ::popupWindow
 ) {
 
-    private val margin by lazy { anchor.context.resources.getDimensionPixelSize(R.dimen.glia_chat_attachment_menu_margin) }
-    private val binding: ChatAttachmentPopupBinding by lazy { bindLayout(anchor.context) }
+    private val margin by lazy { context.resources.getDimensionPixelSize(R.dimen.glia_chat_attachment_menu_margin) }
+    private val binding: ChatAttachmentPopupBinding by lazy { bindLayout(context.wrapWithMaterialThemeOverlay()) }
     private val popupWindow: PopupWindow by lazy { createPopupMenu() }
 
     private fun createPopupMenu(): PopupWindow {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -172,7 +172,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         get() = binding.root as ConstraintLayout
     private val attachmentPopup by lazy {
         AttachmentPopup(
-            binding.chatMessageLayout, Dependencies.gliaThemeManager.theme?.chatTheme?.attachmentsPopup
+            context, Dependencies.gliaThemeManager.theme?.chatTheme?.attachmentsPopup
         )
     }
 
@@ -711,7 +711,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
 
     private fun setupAddAttachmentButton() {
         binding.addAttachmentButton.setOnClickListener {
-            attachmentPopup.show(binding.chatMessageLayout, {
+            attachmentPopup.show(binding.addAttachmentButton, {
                 getContentLauncher?.launch(arrayOf(Constants.MIME_TYPE_IMAGES))
             }, {
                 controller?.onTakePhotoClicked()
@@ -845,7 +845,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         binding.sendButton.applyButtonTheme(inputTheme.sendButton)
         binding.addAttachmentButton.applyButtonTheme(inputTheme.mediaButton)
         binding.chatDivider.applyColorTheme(inputTheme.divider)
-        binding.chatMessageLayout.applyLayerTheme(inputTheme.background)
+        binding.messageInputBackground.applyLayerTheme(inputTheme.background)
         binding.chatEditText.applyTextTheme(textTheme = inputTheme.text, withAlignment = false)
         inputTheme.placeholder?.textColor?.primaryColor?.also(binding.chatEditText::setHintTextColor)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageView.kt
@@ -75,7 +75,7 @@ internal class MessageView(
     }
 
     private val attachmentPopup by lazy {
-        AttachmentPopup(addAttachmentButton, unifiedTheme?.pickMediaTheme)
+        AttachmentPopup(context, unifiedTheme?.pickMediaTheme)
     }
 
     val messageTitleTop: Int get() = messageTitle.top

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/SnackBarDelegate.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/SnackBarDelegate.kt
@@ -88,7 +88,7 @@ internal class CommonSnackBarDelegate(activity: Activity, titleStringKey: Int, l
 @VisibleForTesting
 internal class ChatActivitySnackBarDelegate(activity: ChatActivity, titleStringKey: Int, localeProvider: LocaleProvider, unifiedTheme: UnifiedTheme?) :
     SnackBarDelegate(activity.findViewById(R.id.chat_view), titleStringKey, localeProvider, unifiedTheme?.snackBarTheme) {
-    override val anchorViewId: Int = R.id.chat_message_layout
+    override val anchorViewId: Int = R.id.message_input_background
 }
 
 @VisibleForTesting

--- a/widgetssdk/src/main/res/layout/chat_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_view.xml
@@ -210,56 +210,64 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:scrollbars="vertical"
-        app:layout_constraintBottom_toTopOf="@+id/chat_message_layout"
+        app:layout_constraintBottom_toTopOf="@+id/chat_edit_text"
         app:layout_constraintHeight_max="216dp"
         tools:itemCount="6"
         tools:listitem="@layout/chat_attachment_uploaded_item" />
 
-    <LinearLayout
-        android:id="@+id/chat_message_layout"
-        android:layout_width="match_parent"
+    <View
+        android:id="@+id/message_input_background"
+        android:layout_height="0dp"
+        android:layout_width="0dp"
+        app:layout_constraintTop_toTopOf="@+id/chat_edit_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <EditText
+        android:id="@+id/chat_edit_text"
+        style="@style/Application.Glia.Chat.Edittext"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/add_attachment_button"
+        android:importantForAutofill="no"
+        android:maxLength="10000"
+        android:maxLines="4"
+        android:minHeight="@dimen/glia_chat_edit_text_min_height"
+        android:paddingStart="@dimen/glia_large"
+        android:textColor="?attr/gliaBaseDarkColor"
+        android:textColorHint="?attr/gliaBaseNormalColor"
+        android:textCursorDrawable="@null"
+        tools:text="@string/chat_input_placeholder"/>
 
-        <EditText
-            android:id="@+id/chat_edit_text"
-            style="@style/Application.Glia.Chat.Edittext"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:importantForAutofill="no"
-            android:maxLength="10000"
-            android:maxLines="4"
-            android:minHeight="@dimen/glia_chat_edit_text_min_height"
-            android:paddingStart="@dimen/glia_large"
-            android:textColor="?attr/gliaBaseDarkColor"
-            android:textColorHint="?attr/gliaBaseNormalColor"
-            android:textCursorDrawable="@null"
-            tools:text="@string/chat_input_placeholder"
-            tools:ignore="RtlSymmetry" />
+    <ImageButton
+        android:id="@+id/add_attachment_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="@+id/message_input_background"
+        app:layout_constraintBottom_toBottomOf="@+id/message_input_background"
+        app:layout_constraintStart_toEndOf="@+id/chat_edit_text"
+        app:layout_constraintEnd_toStartOf="@+id/send_button"
+        android:background="?attr/selectableItemBackground"
+        android:padding="@dimen/glia_large"
+        android:src="@drawable/ic_add_attachment" />
 
-        <ImageButton
-            android:id="@+id/add_attachment_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:background="?attr/selectableItemBackground"
-            android:padding="@dimen/glia_large"
-            android:src="@drawable/ic_add_attachment" />
-
-        <ImageButton
-            android:id="@+id/send_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:background="?attr/selectableItemBackground"
-            android:padding="@dimen/glia_large"
-            android:src="?attr/gliaIconSendMessage"
-            app:tint="?attr/gliaBrandPrimaryColor"
-            tools:src="@drawable/ic_baseline_send"
-            tools:tint="?attr/gliaBrandPrimaryColor" />
-    </LinearLayout>
+    <ImageButton
+        android:id="@+id/send_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/glia_large"
+        app:layout_constraintBottom_toBottomOf="@+id/message_input_background"
+        app:layout_constraintTop_toTopOf="@+id/message_input_background"
+        app:layout_constraintStart_toEndOf="@+id/add_attachment_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:background="?attr/selectableItemBackground"
+        android:src="?attr/gliaIconSendMessage"
+        app:tint="?attr/gliaBrandPrimaryColor"
+        tools:src="@drawable/ic_baseline_send"
+        tools:tint="@color/glia_primary_color" />
 
     <View
         android:id="@+id/blocking_curtain"

--- a/widgetssdk/src/test/java/com/glia/widgets/view/snackbar/SnackBarDelegateTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/snackbar/SnackBarDelegateTest.kt
@@ -80,7 +80,7 @@ class SnackBarDelegateTest {
     fun `anchorViewId returns corresponding ids when chat or call activity is passed`() {
         CommonSnackBarDelegate(commonActivity, titleStringKey, mock(), mock()).apply { assertNull(anchorViewId) }
         CallActivitySnackBarDelegate(callActivity, titleStringKey, mock(), mock()).apply { assertEquals(R.id.buttons_layout_bg, anchorViewId) }
-        ChatActivitySnackBarDelegate(chatActivity, titleStringKey, mock(), mock()).apply { assertEquals(R.id.chat_message_layout, anchorViewId) }
+        ChatActivitySnackBarDelegate(chatActivity, titleStringKey, mock(), mock()).apply { assertEquals(R.id.message_input_background, anchorViewId) }
     }
 
     @Test

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/AttachmentPopupSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/chat/AttachmentPopupSnapshotTest.kt
@@ -54,16 +54,15 @@ internal class AttachmentPopupSnapshotTest : SnapshotTest(), SnapshotTheme, Snap
         viewCallback: (View) -> Unit
     ) : AttachmentPopup {
 
-        val anchor = LinearLayout(context)
         return AttachmentPopup(
-            anchor,
+            context,
             unifiedTheme
         ) {
             it.layoutParams = LinearLayout.LayoutParams(650, LinearLayout.LayoutParams.WRAP_CONTENT)
             viewCallback(it)
             mock()
         }.apply {
-            show(anchor, mock(), mock(), mock())
+            show(View(context), mock(), mock(), mock())
         }
     }
 }


### PR DESCRIPTION

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3844

**What was solved?**
Fix the send and attachment buttons overlaping.
A side effect of making the layout flat is that now those buttons have slight animation.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
[Screen_recording_20241202_131317.webm](https://github.com/user-attachments/assets/a974c86b-c4fe-48be-a4a8-7ccdbb81550c)

