### PR TITLE
Add snapshot tests for Entry Widget for the cases when 'whiteLabel == true'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     // Needed for some automated and manual testing (e.g: acceptance tests)
     mavenLocal()
     //TODO switch to the release version before releasing core SDK
-    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1328" }
+    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1329" }
   }
 }
 

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a2366ca62a2bc6315c66fcdb0fe9d03a3d40d3b08ff63db62dd88e0c6873c65
+size 132918

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07fddba8b50ebdeb64e13766b6e92581242fb2ebefbc72e31400ded9124e17a2
+size 152556

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:607ef94e2e0f369f8b39c042efe9d5b1e7dd29a49af44f743934091e4e4a16d4
+size 131798

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a2366ca62a2bc6315c66fcdb0fe9d03a3d40d3b08ff63db62dd88e0c6873c65
+size 132918

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acea25f892771a06549a560e2fab85f8cc162347202b8680c41ffae426413c23
+size 36799

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3fcf4c03784d9a1761dff8fa7c9e0c0f6b7855a3c32ef290ba93884c7f4d35d
+size 51260

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b2ab745363f3121551a87501cd30f66c717763ccae8c3df18ff143f0111a9b1
+size 37082

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_emptyWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acea25f892771a06549a560e2fab85f8cc162347202b8680c41ffae426413c23
+size 36799

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afa058744f19451734dba9ad0e715a4904c4f52f8ca5b0678e987618e6350509
+size 52012

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62161ec4d347916bb1d6747b63a8d5558ded9fe91d6eb8559ae0ea538cffd858
+size 62363

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ff3a9602b88a63de85c35a12cdf54050b28be3e09207bbfd2d6abf0e37bd2ba
+size 53635

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_errorWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afa058744f19451734dba9ad0e715a4904c4f52f8ca5b0678e987618e6350509
+size 52012

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f47d77fe7875b86a162270a76178d1be5bf46af782c5899a3f58d56a9756786b
+size 18468

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f21ad66acda6e4b9b6ede4bd9b8c64376976074fff8791bdce8fa06450ce1455
+size 48364

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWhiteLabelWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWhiteLabelWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09faa4172b2c46a03fe3ddfdee0dc3478e4c84ba4dd0afb7cb2e4e060fd55118
+size 21566

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWhiteLabelWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_loadingWithUnifiedThemeWhiteLabelWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f47d77fe7875b86a162270a76178d1be5bf46af782c5899a3f58d56a9756786b
+size 18468

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44731fb8b8b94368a8c0db3d0f8d696d62fa9eb5a4b28cf5532b1660576398e4
+size 35430

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be79bee21eabd0db2a584a899713c891838750f63b9d45f6cd646f13e0cc6f3a
+size 49163

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5552ea147298ba550ecda472a63c089191cf04e9f461701531091677f398b92
+size 35758

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44731fb8b8b94368a8c0db3d0f8d696d62fa9eb5a4b28cf5532b1660576398e4
+size 35430

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fe6c091e5c40eae5b53d1ed109baab3108f8d14db5afe230c982ddc1ab326bb
+size 131102

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfe614210abf0ed6823b75dc263c5894862699942dacd054337b77d88db51691
+size 179438

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3055bc607c202c991ef831e6bfec9231f915eeabcfe2b3d75e6fb59f5d5b198f
+size 128185

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_contactsWithBadgeWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fe6c091e5c40eae5b53d1ed109baab3108f8d14db5afe230c982ddc1ab326bb
+size 131102

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e2fb19a8c4db41e06d16d68eeed3838a6f60c9be41c0dad1b5c0df27922925a
+size 33074

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf53261b338a3185c4bc851acf48bec60224e0ae4271d6579e07910693c8a827
+size 45868

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d785add935cf79ebc4ac7f7c07a36ada58587be00409bd91a66c64036bf89d9e
+size 31390

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_emptyWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e2fb19a8c4db41e06d16d68eeed3838a6f60c9be41c0dad1b5c0df27922925a
+size 33074

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a1b39d9a440f525bc55c08c7879732661dc7920f2258cb7bcab45c47d83202a
+size 50484

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:115299322de6f5814625080e82abfbf651de97a31570be58ddf2c68bb544a5df
+size 59812

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc5c6974bcb9a010bc0505f30f6cd46b0cf6c840f885d11dd7bf2d6ea32e57ff
+size 50164

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_errorWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a1b39d9a440f525bc55c08c7879732661dc7920f2258cb7bcab45c47d83202a
+size 50484

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12f7141c70110b39c5975773e42b9db8a53d7a74efb4161d617a52a5fa390d8a
+size 17329

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25cd7a211aba759abc89d4bcb00406ddcec07b167c543c0d70d834fd069782ae
+size 45685

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWhiteLabelWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWhiteLabelWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73f75cd2d489dd580a37f36ed6c1d365524f063f04b0723967db6bc910fbaee3
+size 18534

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWhiteLabelWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_loadingWithUnifiedThemeWhiteLabelWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12f7141c70110b39c5975773e42b9db8a53d7a74efb4161d617a52a5fa390d8a
+size 17329

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eed14a15f6170f857c94e51a1d55bed12c65c256fc92fa83a9a8d453341d23dd
+size 31751

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:842e403c4b0e0162a9407d2f558dda6c1fa07ffbaeb72bd3cc86dad90a73b2ed
+size 43460

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ceee6e6fb80da5e58f3c487934fea1cb5a02143ef16388086a02666f878502c
+size 30132

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eed14a15f6170f857c94e51a1d55bed12c65c256fc92fa83a9a8d453341d23dd
+size 31751

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
@@ -83,11 +83,27 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         EntryWidgetContract.ItemType.PoweredBy
     )
 
+    private val mediaTypesWithUnreadMessagingWhiteLabel = listOf(
+        EntryWidgetContract.ItemType.VideoCall,
+        EntryWidgetContract.ItemType.AudioCall,
+        EntryWidgetContract.ItemType.Chat,
+        EntryWidgetContract.ItemType.Messaging(5)
+    )
+
     @Test
     fun contactsWithBadgeDefaultTheme() {
         snapshot(
             setupView(
                 items = mediaTypesWithUnreadMessaging,
+            )
+        )
+    }
+
+    @Test
+    fun contactsWithBadgeWhiteLabelDefaultTheme() {
+        snapshot(
+            setupView(
+                items = mediaTypesWithUnreadMessagingWhiteLabel,
             )
         )
     }
@@ -103,10 +119,29 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun contactsWithBadgeWhiteLabelWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = mediaTypesWithUnreadMessagingWhiteLabel,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
     fun contactsWithBadgeWithUnifiedThemeWithGlobalColors() {
         snapshot(
             setupView(
                 items = mediaTypesWithUnreadMessaging,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+    @Test
+    fun contactsWithBadgeWhiteLabelWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = mediaTypesWithUnreadMessagingWhiteLabel,
                 unifiedTheme = unifiedThemeWithGlobalColors()
             )
         )
@@ -122,6 +157,16 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         )
     }
 
+    @Test
+    fun contactsWithBadgeWhiteLabelWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = mediaTypesWithUnreadMessagingWhiteLabel,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
     // MARK: Loading state tests
 
     private val loadingItems = listOf(
@@ -132,6 +177,13 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         EntryWidgetContract.ItemType.PoweredBy
     )
 
+    private val loadingItemsWhiteLabel = listOf(
+        EntryWidgetContract.ItemType.LoadingState,
+        EntryWidgetContract.ItemType.LoadingState,
+        EntryWidgetContract.ItemType.LoadingState,
+        EntryWidgetContract.ItemType.LoadingState
+    )
+
     @Test
     fun loadingDefaultTheme() {
         snapshot(
@@ -140,10 +192,27 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun loadingWhiteLabelDefaultTheme() {
+        snapshot(
+            setupView(items = loadingItemsWhiteLabel)
+        )
+    }
+
+    @Test
     fun loadingWithUnifiedTheme() {
         snapshot(
             setupView(
                 items = loadingItems,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun loadingWhiteLabelWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = loadingItemsWhiteLabel,
                 unifiedTheme = unifiedTheme()
             )
         )
@@ -160,10 +229,30 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun loadingWithUnifiedThemeWhiteLabelWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = loadingItemsWhiteLabel,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
     fun loadingWithUnifiedThemeWithoutEntryWidget() {
         snapshot(
             setupView(
                 items = loadingItems,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    @Test
+    fun loadingWithUnifiedThemeWhiteLabelWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = loadingItemsWhiteLabel,
                 unifiedTheme = unifiedThemeWithoutEntryWidget()
             )
         )
@@ -176,6 +265,10 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         EntryWidgetContract.ItemType.PoweredBy
     )
 
+    private val emptyItemsWhiteLabel = listOf(
+        EntryWidgetContract.ItemType.EmptyState
+    )
+
     @Test
     fun emptyDefaultTheme() {
         snapshot(
@@ -184,10 +277,27 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun emptyWhiteLabelDefaultTheme() {
+        snapshot(
+            setupView(items = emptyItemsWhiteLabel)
+        )
+    }
+
+    @Test
     fun emptyWithUnifiedTheme() {
         snapshot(
             setupView(
                 items = emptyItems,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun emptyWhiteLabelWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = emptyItemsWhiteLabel,
                 unifiedTheme = unifiedTheme()
             )
         )
@@ -204,10 +314,30 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun emptyWhiteLabelWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = emptyItemsWhiteLabel,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
     fun emptyWithUnifiedThemeWithoutEntryWidget() {
         snapshot(
             setupView(
                 items = emptyItems,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    @Test
+    fun emptyWhiteLabelWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = emptyItemsWhiteLabel,
                 unifiedTheme = unifiedThemeWithoutEntryWidget()
             )
         )
@@ -221,6 +351,10 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         EntryWidgetContract.ItemType.PoweredBy
     )
 
+    private val sdkNotInitializedItemsWhiteLabel = listOf(
+        EntryWidgetContract.ItemType.SdkNotInitializedState
+    )
+
     @Test
     fun sdkNotInitializedItemsDefaultTheme() {
         snapshot(
@@ -229,10 +363,27 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun sdkNotInitializedItemsWhiteLabelDefaultTheme() {
+        snapshot(
+            setupView(items = sdkNotInitializedItemsWhiteLabel)
+        )
+    }
+
+    @Test
     fun sdkNotInitializedItemsWithUnifiedTheme() {
         snapshot(
             setupView(
                 items = sdkNotInitializedItems,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun sdkNotInitializedItemsWhiteLabelWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = sdkNotInitializedItemsWhiteLabel,
                 unifiedTheme = unifiedTheme()
             )
         )
@@ -249,10 +400,30 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = sdkNotInitializedItemsWhiteLabel,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
     fun sdkNotInitializedItemsWithUnifiedThemeWithoutEntryWidget() {
         snapshot(
             setupView(
                 items = sdkNotInitializedItems,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    @Test
+    fun sdkNotInitializedItemsWhiteLabelWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = sdkNotInitializedItemsWhiteLabel,
                 unifiedTheme = unifiedThemeWithoutEntryWidget()
             )
         )
@@ -265,6 +436,10 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         EntryWidgetContract.ItemType.PoweredBy
     )
 
+    private val errorItemsWhiteLabel = listOf(
+        EntryWidgetContract.ItemType.ErrorState
+    )
+
     @Test
     fun errorDefaultTheme() {
         snapshot(
@@ -273,10 +448,27 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun errorWhiteLabelDefaultTheme() {
+        snapshot(
+            setupView(items = errorItemsWhiteLabel)
+        )
+    }
+
+    @Test
     fun errorWithUnifiedTheme() {
         snapshot(
             setupView(
                 items = errorItems,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun errorWhiteLabelWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = errorItemsWhiteLabel,
                 unifiedTheme = unifiedTheme()
             )
         )
@@ -293,10 +485,30 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
     }
 
     @Test
+    fun errorWhiteLabelWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = errorItemsWhiteLabel,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
     fun errorWithUnifiedThemeWithoutEntryWidget() {
         snapshot(
             setupView(
                 items = errorItems,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    @Test
+    fun errorWhiteLabelWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = errorItemsWhiteLabel,
                 unifiedTheme = unifiedThemeWithoutEntryWidget()
             )
         )


### PR DESCRIPTION
**Jira issue:**
[MOB-3854](https://glia.atlassian.net/browse/MOB-3854)

**What was solved?**
- Added snapshot tests for the case when 'Powered by Glia' is hidden for all combinations

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-3854]: https://glia.atlassian.net/browse/MOB-3854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ