### PR TITLE
Implement Entry Widget for ongoing engagement cases

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/HasOngoingSecureConversationUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/HasOngoingSecureConversationUseCase.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.core.secureconversations.domain
 
+import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -9,6 +10,7 @@ import io.reactivex.rxjava3.core.Flowable
 
 internal class HasOngoingSecureConversationUseCase(
     private val secureConversationsRepository: SecureConversationsRepository,
+    private val isAuthenticatedUseCase: IsAuthenticatedUseCase,
     private val engagementStateUseCase: EngagementStateUseCase
 ) {
     /**
@@ -20,7 +22,8 @@ internal class HasOngoingSecureConversationUseCase(
             secureConversationsRepository.unreadMessagesCountObservable,
             engagementStateUseCase()
         ) { pendingSecureConversations, unreadMessagesCount, state ->
-            pendingSecureConversations || unreadMessagesCount > 0 || state is State.TransferredToSecureConversation
+            isAuthenticatedUseCase() &&
+                (pendingSecureConversations || unreadMessagesCount > 0 || state is State.TransferredToSecureConversation)
         }
 
     operator fun invoke(): Flowable<Boolean> = hasOngoingInteraction.distinctUntilChanged().observeOn(AndroidSchedulers.mainThread())

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -243,7 +243,8 @@ public class ControllerFactory {
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.getCurrentOperatorUseCase(),
                 useCaseFactory.getVisitorMediaUseCase(),
-                useCaseFactory.getScreenSharingUseCase()
+                useCaseFactory.getScreenSharingUseCase(),
+                useCaseFactory.getEngagementTypeUseCase()
             );
         }
         return serviceChatHeadController;
@@ -259,7 +260,8 @@ public class ControllerFactory {
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.getCurrentOperatorUseCase(),
                 useCaseFactory.getVisitorMediaUseCase(),
-                useCaseFactory.getScreenSharingUseCase()
+                useCaseFactory.getScreenSharingUseCase(),
+                useCaseFactory.getEngagementTypeUseCase()
             );
         }
         return applicationChatHeadController;
@@ -390,8 +392,11 @@ public class ControllerFactory {
             useCaseFactory.createIsAuthenticatedUseCase(),
             repositoryFactory.getSecureConversationsRepository(),
             useCaseFactory.getHasPendingSecureConversationsWithTimeoutUseCase(),
+            useCaseFactory.getEngagementStateUseCase(),
+            useCaseFactory.getEngagementTypeUseCase(),
             core,
-            Dependencies.getEngagementLauncher()
+            Dependencies.getEngagementLauncher(),
+            Dependencies.getActivityLauncher()
         );
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -76,6 +76,7 @@ internal object Dependencies {
     @JvmStatic
     val configurationManager: ConfigurationManager by lazy { ConfigurationManagerImpl() }
 
+    @JvmStatic
     val activityLauncher: ActivityLauncher by lazy {
         ActivityLauncherImpl(IntentHelperImpl(), repositoryFactory.engagementRepository)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -875,6 +875,7 @@ public class UseCaseFactory {
         return new EngagementTypeUseCaseImpl(
             getIsQueueingOrEngagementUseCase(),
             getIsCurrentEngagementCallVisualizer(),
+            getScreenSharingUseCase(),
             getOperatorMediaUseCase(),
             getVisitorMediaUseCase(),
             getIsOperatorPresentUseCase()
@@ -1057,6 +1058,7 @@ public class UseCaseFactory {
     public HasOngoingSecureConversationUseCase getHasPendingSecureConversationsWithTimeoutUseCase() {
         return new HasOngoingSecureConversationUseCase(
             repositoryFactory.getSecureConversationsRepository(),
+            createIsAuthenticatedUseCase(),
             getEngagementStateUseCase()
         );
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EngagementTypeUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EngagementTypeUseCase.kt
@@ -1,21 +1,48 @@
 package com.glia.widgets.engagement.domain
 
+import com.glia.androidsdk.Engagement.MediaType
+import com.glia.widgets.helper.hasAudio
+import com.glia.widgets.helper.hasVideo
+import io.reactivex.rxjava3.core.Flowable
+
 internal interface EngagementTypeUseCase {
+    val isAudioEngagement: Boolean
+    val isVideoEngagement: Boolean
     val isMediaEngagement: Boolean
     val isChatEngagement: Boolean
+    val isCallVisualizer: Boolean
     val isCallVisualizerScreenSharing: Boolean
+
+    operator fun invoke(): Flowable<MediaType>
 }
 
 internal class EngagementTypeUseCaseImpl(
     private val isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase,
     private val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase,
+    private val screenSharingUseCase: ScreenSharingUseCase,
     private val operatorMediaUseCase: OperatorMediaUseCase,
     private val visitorMediaUseCase: VisitorMediaUseCase,
-    private val isOperatorPresentUseCase: IsOperatorPresentUseCase
+    private val isOperatorPresentUseCase: IsOperatorPresentUseCase,
 ) : EngagementTypeUseCase {
     private val hasOngoingEngagement get() = isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement
+    private val hasAudio: Boolean get() = visitorMediaUseCase.hasAudio || operatorMediaUseCase.hasAudio
+    private val hasVideo: Boolean get() = visitorMediaUseCase.hasVideo || operatorMediaUseCase.hasVideo
+    override val isAudioEngagement: Boolean get() = hasOngoingEngagement && isOperatorPresentUseCase() && hasAudio
+    override val isVideoEngagement: Boolean get() = hasOngoingEngagement && isOperatorPresentUseCase() && hasVideo
     private val hasAnyMedia: Boolean get() = visitorMediaUseCase.hasMedia || operatorMediaUseCase.hasMedia
     override val isMediaEngagement: Boolean get() = hasOngoingEngagement && isOperatorPresentUseCase() && hasAnyMedia
     override val isChatEngagement: Boolean get() = hasOngoingEngagement && !isCurrentEngagementCallVisualizerUseCase() && isOperatorPresentUseCase() && !hasAnyMedia
-    override val isCallVisualizerScreenSharing: Boolean get() = isCurrentEngagementCallVisualizerUseCase() && !hasAnyMedia
+    override val isCallVisualizer: Boolean get() = isCurrentEngagementCallVisualizerUseCase()
+    override val isCallVisualizerScreenSharing: Boolean get() = isCurrentEngagementCallVisualizerUseCase() && screenSharingUseCase.isSharing
+    private val operatorMediaObservable by lazy { operatorMediaUseCase() }
+
+    override fun invoke(): Flowable<MediaType> {
+        return operatorMediaObservable.map { operatorMediaState ->
+            when {
+                operatorMediaState.hasVideo -> MediaType.VIDEO
+                operatorMediaState.hasAudio -> MediaType.AUDIO
+                else -> MediaType.UNKNOWN
+            }
+        }
+    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/OperatorMediaUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/OperatorMediaUseCase.kt
@@ -1,21 +1,33 @@
 package com.glia.widgets.engagement.domain
 
+import com.glia.androidsdk.comms.Audio
 import com.glia.androidsdk.comms.MediaState
+import com.glia.androidsdk.comms.Video
 import com.glia.widgets.engagement.EngagementRepository
 import com.glia.widgets.helper.Data
+import com.glia.widgets.helper.hasAudio
 import com.glia.widgets.helper.hasMedia
+import com.glia.widgets.helper.hasVideo
 import io.reactivex.rxjava3.core.Flowable
 
 internal interface OperatorMediaUseCase {
+    val hasAudio: Boolean
+    val hasVideo: Boolean
     val hasMedia: Boolean
     operator fun invoke(): Flowable<MediaState>
 }
 
 internal class OperatorMediaUseCaseImpl(private val engagementRepository: EngagementRepository) : OperatorMediaUseCase {
-    private val operatorMediaState: Flowable<MediaState> = engagementRepository.operatorMediaState
-        .filter(Data<MediaState>::hasValue)
-        .map { it as Data.Value }
-        .map(Data.Value<MediaState>::result)
+    private val emptyMediaState: MediaState = object : MediaState {
+        override fun getVideo(): Video? = null
+        override fun getAudio(): Audio? = null
+    }
+
+    private val operatorMediaState: Flowable<MediaState> = engagementRepository
+        .operatorMediaState
+        .map { if (it is Data.Value) it.result else emptyMediaState }
+    override val hasAudio: Boolean get() = engagementRepository.operatorCurrentMediaState?.hasAudio ?: false
+    override val hasVideo: Boolean get() = engagementRepository.operatorCurrentMediaState?.hasVideo ?: false
 
     override val hasMedia: Boolean get() = engagementRepository.operatorCurrentMediaState?.hasMedia ?: false
     override fun invoke(): Flowable<MediaState> = operatorMediaState

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/VisitorMediaUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/VisitorMediaUseCase.kt
@@ -1,24 +1,36 @@
 package com.glia.widgets.engagement.domain
 
+import com.glia.androidsdk.comms.Audio
 import com.glia.androidsdk.comms.MediaState
+import com.glia.androidsdk.comms.Video
 import com.glia.widgets.engagement.EngagementRepository
 import com.glia.widgets.helper.Data
+import com.glia.widgets.helper.hasAudio
 import com.glia.widgets.helper.hasMedia
+import com.glia.widgets.helper.hasVideo
 import io.reactivex.rxjava3.core.Flowable
 
 internal interface VisitorMediaUseCase {
+    val hasAudio: Boolean
+    val hasVideo: Boolean
     val hasMedia: Boolean
     val onHoldState: Flowable<Boolean>
     operator fun invoke(): Flowable<MediaState>
 }
 
 internal class VisitorMediaUseCaseImpl(private val engagementRepository: EngagementRepository) : VisitorMediaUseCase {
-    private val visitorMediaState: Flowable<MediaState> = engagementRepository.visitorMediaState
-        .filter(Data<MediaState>::hasValue)
-        .map { it as Data.Value }
-        .map(Data.Value<MediaState>::result)
+    private val emptyMediaState: MediaState = object : MediaState {
+        override fun getVideo(): Video? = null
+        override fun getAudio(): Audio? = null
+    }
+
+    private val visitorMediaState: Flowable<MediaState> = engagementRepository
+        .visitorMediaState
+        .map { if (it is Data.Value) it.result else emptyMediaState }
 
     override val onHoldState: Flowable<Boolean> = engagementRepository.onHoldState
+    override val hasAudio: Boolean get() = engagementRepository.visitorCurrentMediaState?.hasAudio ?: false
+    override val hasVideo: Boolean get() = engagementRepository.visitorCurrentMediaState?.hasVideo ?: false
 
     override val hasMedia: Boolean get() = engagementRepository.visitorCurrentMediaState?.hasMedia ?: false
 

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetContract.kt
@@ -17,9 +17,14 @@ internal interface EntryWidgetContract {
 
     sealed class ItemType(private val order: Int = HIGHEST_ORDER) : Comparable<ItemType> {
         data object VideoCall : ItemType(order = 0)
-        data object AudioCall : ItemType(order = 1)
-        data object Chat : ItemType(order = 2)
-        data class Messaging(val value: Int) : ItemType(order = 3)
+        data object VideoCallOngoing : ItemType(order = 1)
+        data object AudioCall : ItemType(order = 2)
+        data object AudioCallOngoing : ItemType(order = 3)
+        data object Chat : ItemType(order = 4)
+        data object ChatOngoing : ItemType(order = 5)
+        data class Messaging(val value: Int) : ItemType(order = 6)
+        data class MessagingOngoing(val value: Int) : ItemType(order = 7)
+        data object CallVisualizerOngoing : ItemType(order = 8)
         data object LoadingState : ItemType()
         data object EmptyState : ItemType()
         data object SdkNotInitializedState : ItemType()

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.glia.widgets.databinding.EntryWidgetCallVisualizerItemBinding
 import com.glia.widgets.databinding.EntryWidgetErrorItemBinding
 import com.glia.widgets.databinding.EntryWidgetLiveItemBinding
 import com.glia.widgets.databinding.EntryWidgetMessagingItemBinding
@@ -84,6 +85,7 @@ internal class EntryWidgetAdapter(
     enum class ViewType {
         LIVE_MEDIA_TYPE_ITEMS,
         MESSAGING_MEDIA_TYPE_ITEM,
+        CALL_VISUALIZER_ITEM,
         ERROR_ITEM,
         PROVIDED_BY_ITEM
     }
@@ -105,6 +107,10 @@ internal class EntryWidgetAdapter(
                 EntryWidgetMessagingItemBinding.inflate(parent.layoutInflater, parent, false),
                 itemTheme = mediaTypeItemsTheme?.mediaTypeItem
             )
+            ViewType.CALL_VISUALIZER_ITEM.ordinal -> EntryWidgetCallVisualizerItemViewHolder(
+                EntryWidgetCallVisualizerItemBinding.inflate(parent.layoutInflater, parent, false),
+                itemTheme = mediaTypeItemsTheme?.mediaTypeItem
+            )
             else -> EntryWidgetLiveItemViewHolder(
                 EntryWidgetLiveItemBinding.inflate(parent.layoutInflater, parent, false),
                 itemTheme = mediaTypeItemsTheme?.mediaTypeItem,
@@ -116,6 +122,12 @@ internal class EntryWidgetAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         getItem(position)?.let { item ->
             if (item is EntryWidgetContract.ItemType.Messaging && holder is EntryWidgetMessagingItemViewHolder) {
+                holder.bind(item, item.value) {
+                    onItemClickListener?.invoke(item)
+                }
+            } else if (item is EntryWidgetContract.ItemType.MessagingOngoing &&
+                holder is EntryWidgetMessagingItemViewHolder
+            ) {
                 holder.bind(item, item.value) {
                     onItemClickListener?.invoke(item)
                 }
@@ -133,7 +145,9 @@ internal class EntryWidgetAdapter(
             EntryWidgetContract.ItemType.SdkNotInitializedState,
             EntryWidgetContract.ItemType.ErrorState -> ViewType.ERROR_ITEM.ordinal
             EntryWidgetContract.ItemType.PoweredBy -> ViewType.PROVIDED_BY_ITEM.ordinal
-            is EntryWidgetContract.ItemType.Messaging -> ViewType.MESSAGING_MEDIA_TYPE_ITEM.ordinal
+            is EntryWidgetContract.ItemType.Messaging,
+            is EntryWidgetContract.ItemType.MessagingOngoing -> ViewType.MESSAGING_MEDIA_TYPE_ITEM.ordinal
+            is EntryWidgetContract.ItemType.CallVisualizerOngoing -> ViewType.CALL_VISUALIZER_ITEM.ordinal
             else -> ViewType.LIVE_MEDIA_TYPE_ITEMS.ordinal
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetCallVisualizerItemViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetCallVisualizerItemViewHolder.kt
@@ -1,0 +1,46 @@
+package com.glia.widgets.entrywidget.adapter
+
+import android.view.View
+import androidx.core.view.isVisible
+import com.glia.widgets.R
+import com.glia.widgets.databinding.EntryWidgetCallVisualizerItemBinding
+import com.glia.widgets.entrywidget.EntryWidgetContract
+import com.glia.widgets.helper.setLocaleHint
+import com.glia.widgets.helper.setLocaleText
+import com.glia.widgets.view.unifiedui.applyImageColorTheme
+import com.glia.widgets.view.unifiedui.applyLayerTheme
+import com.glia.widgets.view.unifiedui.applyTextTheme
+import com.glia.widgets.view.unifiedui.theme.entrywidget.MediaTypeItemTheme
+
+internal class EntryWidgetCallVisualizerItemViewHolder(
+    private val binding: EntryWidgetCallVisualizerItemBinding,
+    itemTheme: MediaTypeItemTheme?,
+) : EntryWidgetAdapter.ViewHolder(binding.root) {
+
+    init {
+        itemTheme?.let {
+            binding.root.applyLayerTheme(it.background)
+            binding.title.applyTextTheme(it.title)
+            binding.description.applyTextTheme(it.message)
+            binding.icon.applyImageColorTheme(it.iconColor)
+            it.loadingTintColor?.primaryColorStateList?.let { tintList ->
+                binding.iconLoading.backgroundTintList = tintList
+                binding.titleLoading.backgroundTintList = tintList
+                binding.descriptionLoading.backgroundTintList = tintList
+            }
+        }
+    }
+
+    override fun bind(
+        itemType: EntryWidgetContract.ItemType,
+        onClickListener: View.OnClickListener
+    ) {
+        binding.root.setOnClickListener(onClickListener)
+        binding.root.contentDescription = null
+        binding.icon.setImageResource(R.drawable.ic_screensharing)
+        binding.title.setLocaleText(R.string.entry_widget_call_visualizer_button_label)
+        binding.loadingGroup.isVisible = itemType == EntryWidgetContract.ItemType.LoadingState
+        binding.description.setLocaleText(R.string.entry_widget_call_visualizer_description)
+        binding.description.setLocaleHint(R.string.entry_widget_ongoing_engagement_button_accessibility_hint)
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetItemDivider.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetItemDivider.kt
@@ -58,6 +58,7 @@ internal class EntryWidgetItemDivider(
 
     private fun isContactItem(viewType: Int?): Boolean {
         return viewType == EntryWidgetAdapter.ViewType.LIVE_MEDIA_TYPE_ITEMS.ordinal ||
-            viewType == EntryWidgetAdapter.ViewType.MESSAGING_MEDIA_TYPE_ITEM.ordinal
+            viewType == EntryWidgetAdapter.ViewType.MESSAGING_MEDIA_TYPE_ITEM.ordinal ||
+            viewType == EntryWidgetAdapter.ViewType.CALL_VISUALIZER_ITEM.ordinal
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetLiveItemViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetLiveItemViewHolder.kt
@@ -39,7 +39,7 @@ internal class EntryWidgetLiveItemViewHolder(
         }
     }
 
-    override fun bind(itemType: EntryWidgetContract.ItemType, onClickListener: View.OnClickListener) {
+    override fun bind(itemType: EntryWidgetContract.ItemType, onClickListener: View.OnClickListener) { //
         binding.root.setOnClickListener(onClickListener)
         binding.root.contentDescription = null
         when (itemType) {
@@ -50,6 +50,13 @@ internal class EntryWidgetLiveItemViewHolder(
                 binding.description.setLocaleHint(R.string.entry_widget_video_button_accessibility_hint)
             }
 
+            EntryWidgetContract.ItemType.VideoCallOngoing -> {
+                binding.icon.setImageResource(R.drawable.ic_video)
+                binding.title.setLocaleText(R.string.entry_widget_video_button_label)
+                binding.description.setLocaleText(R.string.entry_widget_ongoing_engagement_description)
+                binding.description.setLocaleHint(R.string.entry_widget_ongoing_engagement_button_accessibility_hint)
+            }
+
             EntryWidgetContract.ItemType.AudioCall -> {
                 binding.icon.setImageResource(R.drawable.ic_audio)
                 binding.title.setLocaleText(R.string.entry_widget_audio_button_label)
@@ -57,11 +64,25 @@ internal class EntryWidgetLiveItemViewHolder(
                 binding.description.setLocaleHint(R.string.entry_widget_audio_button_accessibility_hint)
             }
 
+            EntryWidgetContract.ItemType.AudioCallOngoing -> {
+                binding.icon.setImageResource(R.drawable.ic_audio)
+                binding.title.setLocaleText(R.string.entry_widget_audio_button_label)
+                binding.description.setLocaleText(R.string.entry_widget_ongoing_engagement_description)
+                binding.description.setLocaleHint(R.string.entry_widget_ongoing_engagement_button_accessibility_hint)
+            }
+
             EntryWidgetContract.ItemType.Chat -> {
                 binding.icon.setImageResource(R.drawable.ic_chat)
                 binding.title.setLocaleText(R.string.entry_widget_live_chat_button_label)
                 binding.description.setLocaleText(R.string.entry_widget_live_chat_button_description)
                 binding.description.setLocaleHint(R.string.entry_widget_live_chat_button_accessibility_hint)
+            }
+
+            EntryWidgetContract.ItemType.ChatOngoing -> {
+                binding.icon.setImageResource(R.drawable.ic_chat)
+                binding.title.setLocaleText(R.string.entry_widget_live_chat_button_label)
+                binding.description.setLocaleText(R.string.entry_widget_ongoing_engagement_description)
+                binding.description.setLocaleHint(R.string.entry_widget_ongoing_engagement_button_accessibility_hint)
             }
 
             else -> {

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetMessagingItemViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/adapter/EntryWidgetMessagingItemViewHolder.kt
@@ -53,8 +53,17 @@ internal class EntryWidgetMessagingItemViewHolder(
         binding.root.contentDescription = null
         binding.icon.setImageResource(R.drawable.ic_secure_message)
         binding.title.setLocaleText(R.string.entry_widget_secure_messaging_button_label)
-        binding.description.setLocaleText(R.string.entry_widget_secure_messaging_button_description)
-        binding.description.setLocaleHint(R.string.entry_widget_secure_messaging_button_accessibility_hint)
         binding.loadingGroup.isVisible = itemType == EntryWidgetContract.ItemType.LoadingState
+
+        when (itemType) {
+            is EntryWidgetContract.ItemType.Messaging -> {
+                binding.description.setLocaleText(R.string.entry_widget_secure_messaging_button_description)
+                binding.description.setLocaleHint(R.string.entry_widget_secure_messaging_button_accessibility_hint)
+            }
+            else -> {
+                binding.description.setLocaleText(R.string.entry_widget_ongoing_engagement_description)
+                binding.description.setLocaleHint(R.string.entry_widget_ongoing_engagement_button_accessibility_hint)
+            }
+        }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -8,6 +8,7 @@ import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.De
 import com.glia.widgets.engagement.ScreenSharingState
 import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
+import com.glia.widgets.engagement.domain.EngagementTypeUseCase
 import com.glia.widgets.engagement.domain.ScreenSharingUseCase
 import com.glia.widgets.engagement.domain.VisitorMediaUseCase
 import com.glia.widgets.helper.imageUrl
@@ -24,7 +25,8 @@ internal class ApplicationChatHeadLayoutController(
     private val engagementStateUseCase: EngagementStateUseCase,
     private val currentOperatorUseCase: CurrentOperatorUseCase,
     private val visitorMediaUseCase: VisitorMediaUseCase,
-    private val screenSharingUseCase: ScreenSharingUseCase
+    private val screenSharingUseCase: ScreenSharingUseCase,
+    private val engagementTypeUseCase: EngagementTypeUseCase
 ) : ChatHeadLayoutContract.Controller {
     private var chatHeadLayout: ChatHeadLayoutContract.View? = null
     private var state = State.ENDED
@@ -165,7 +167,8 @@ internal class ApplicationChatHeadLayoutController(
     }
 
     private fun decideOnEngagementBubbleDesign(view: ChatHeadLayoutContract.View) {
-        if (isCallVisualizerScreenSharingUseCase()) {
+        if (isCallVisualizerScreenSharingUseCase() && !engagementTypeUseCase.isMediaEngagement) {
+            // Show screen sharing icon only if there is no 1 or 2 way video
             view.showScreenSharing()
             return
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
@@ -8,6 +8,7 @@ import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.core.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
 import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
+import com.glia.widgets.engagement.domain.EngagementTypeUseCase
 import com.glia.widgets.engagement.domain.ScreenSharingUseCase
 import com.glia.widgets.engagement.domain.VisitorMediaUseCase
 import com.glia.widgets.helper.Logger.d
@@ -28,7 +29,8 @@ internal class ServiceChatHeadController(
     engagementStateUseCase: EngagementStateUseCase,
     currentOperatorUseCase: CurrentOperatorUseCase,
     visitorMediaUseCase: VisitorMediaUseCase,
-    screenSharingUseCase: ScreenSharingUseCase
+    screenSharingUseCase: ScreenSharingUseCase,
+    private val engagementTypeUseCase: EngagementTypeUseCase
 ) : ChatHeadContract.Controller {
     private var chatHeadView: ChatHeadContract.View? = null
     private var state = State.ENDED
@@ -181,7 +183,8 @@ internal class ServiceChatHeadController(
     private fun decideOnBubbleDesign() {
         val view = chatHeadView ?: return
 
-        if (isCallVisualizerScreenSharingUseCase()) {
+        if (isCallVisualizerScreenSharingUseCase() && !engagementTypeUseCase.isMediaEngagement) {
+            // Show screen sharing icon only if there is no 1 or 2 way video
             view.showScreenSharing()
             return
         }

--- a/widgetssdk/src/main/res/layout/entry_widget_call_visualizer_item.xml
+++ b/widgetssdk/src/main/res/layout/entry_widget_call_visualizer_item.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?attr/selectableItemBackground"
+    android:paddingTop="@dimen/glia_large"
+    android:paddingBottom="@dimen/glia_large">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="@dimen/glia_large_x_large"
+        android:layout_height="@dimen/glia_large_x_large"
+        android:layout_marginStart="@dimen/glia_large"
+        android:layout_marginEnd="@dimen/glia_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?attr/gliaBrandPrimaryColor"
+        tools:src="@drawable/ic_audio" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/glia_x_large"
+        android:letterSpacing="0.03125"
+        android:textColor="?attr/gliaBaseDarkColor"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toTopOf="@id/description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/entry_widget_audio_button_label" />
+
+    <TextView
+        android:id="@+id/description"
+        style="@style/Application.Glia.Subtitle2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:letterSpacing="0.017857"
+        android:textColor="?attr/gliaBaseNormalColor"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        tools:text="@string/entry_widget_audio_button_description" />
+
+    <View
+        android:id="@+id/icon_loading"
+        android:layout_width="@dimen/glia_large_x_large"
+        android:layout_height="@dimen/glia_large_x_large"
+        android:background="@drawable/bg_circle"
+        android:backgroundTint="?attr/gliaBaseShadeColor"
+        app:layout_constraintBottom_toBottomOf="@id/icon"
+        app:layout_constraintEnd_toEndOf="@id/icon"
+        app:layout_constraintStart_toStartOf="@id/icon"
+        app:layout_constraintTop_toTopOf="@id/icon" />
+
+    <View
+        android:id="@+id/title_loading"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="@dimen/glia_medium"
+        android:background="@drawable/bg_entry_widget_loading"
+        android:backgroundTint="?attr/gliaBaseShadeColor"
+        app:layout_constraintBottom_toTopOf="@id/description_loading"
+        app:layout_constraintEnd_toEndOf="@+id/title"
+        app:layout_constraintStart_toStartOf="@+id/title"
+        app:layout_constraintTop_toTopOf="@+id/title"
+        app:layout_constraintVertical_weight="7" />
+
+    <View
+        android:id="@+id/description_loading"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/bg_entry_widget_loading"
+        android:backgroundTint="?attr/gliaBaseShadeColor"
+        app:layout_constraintBottom_toBottomOf="@+id/description"
+        app:layout_constraintEnd_toEndOf="@+id/description"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toStartOf="@+id/description"
+        app:layout_constraintTop_toBottomOf="@+id/title_loading"
+        app:layout_constraintVertical_weight="6"
+        app:layout_constraintWidth_percent="0.43" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/loading_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:constraint_referenced_ids="icon_loading, title_loading, description_loading" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -240,5 +240,9 @@
     <string name="entry_widget_error_state_description">We couldn\'t load the contacts at this time. This may be due to a temporary syncing issue or network problem.</string>
     <string name="entry_widget_error_state_try_again_button_label">Try again</string>
     <string name="entry_widget_loading_accessibility_label">Loading indicator. Waiting for available options.</string>
+    <string name="entry_widget_ongoing_engagement_description">Ongoing • Tap to return</string>
+    <string name="entry_widget_ongoing_engagement_button_accessibility_hint">Returns to ongoing engagement</string>
+    <string name="entry_widget_call_visualizer_button_label">Call Visualizer</string>
+    <string name="entry_widget_call_visualizer_description">You are already in contact with the support team</string>
 
 </resources>

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementDomainTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementDomainTest.kt
@@ -214,9 +214,10 @@ class EngagementDomainTest {
     }
 
     @Test
-    fun `EngagementTypeUseCase isCallVisualizerScreenSharing returns true when current engagement is call visualizer and has no media`() {
+    fun `EngagementTypeUseCase isCallVisualizerScreenSharing returns true when current engagement is call visualizer`() {
         val isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase = mockk(relaxUnitFun = true)
         val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase = mockk(relaxUnitFun = true)
+        val screenSharingUseCase: ScreenSharingUseCase = mockk(relaxUnitFun = true)
         val operatorMediaUseCase: OperatorMediaUseCase = mockk(relaxUnitFun = true)
         val visitorMediaUseCase: VisitorMediaUseCase = mockk(relaxUnitFun = true)
         val isOperatorPresentUseCase: IsOperatorPresentUseCase = mockk(relaxUnitFun = true)
@@ -224,10 +225,12 @@ class EngagementDomainTest {
         every { isCurrentEngagementCallVisualizerUseCase() } returns true
         every { visitorMediaUseCase.hasMedia } returns false
         every { operatorMediaUseCase.hasMedia } returns false
+        every { screenSharingUseCase.isSharing } returns true
 
         val useCase: EngagementTypeUseCase = EngagementTypeUseCaseImpl(
             isQueueingOrLiveEngagementUseCase = isQueueingOrLiveEngagementUseCase,
             isCurrentEngagementCallVisualizerUseCase = isCurrentEngagementCallVisualizerUseCase,
+            screenSharingUseCase = screenSharingUseCase,
             operatorMediaUseCase = operatorMediaUseCase,
             visitorMediaUseCase = visitorMediaUseCase,
             isOperatorPresentUseCase = isOperatorPresentUseCase
@@ -237,32 +240,36 @@ class EngagementDomainTest {
     }
 
     @Test
-    fun `EngagementTypeUseCase isCallVisualizerScreenSharing returns false when engagement has media`() {
+    fun `EngagementTypeUseCase isCallVisualizerScreenSharing returns true even when engagement has media`() {
         val isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase = mockk(relaxUnitFun = true)
         val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase = mockk(relaxUnitFun = true)
+        val screenSharingUseCase: ScreenSharingUseCase = mockk(relaxUnitFun = true)
         val operatorMediaUseCase: OperatorMediaUseCase = mockk(relaxUnitFun = true)
         val visitorMediaUseCase: VisitorMediaUseCase = mockk(relaxUnitFun = true)
         val isOperatorPresentUseCase: IsOperatorPresentUseCase = mockk(relaxUnitFun = true)
 
         every { isCurrentEngagementCallVisualizerUseCase() } returns true
         every { visitorMediaUseCase.hasMedia } returns true
-        every { operatorMediaUseCase.hasMedia } returns false
+        every { operatorMediaUseCase.hasMedia } returns true
+        every { screenSharingUseCase.isSharing } returns true
 
         val useCase: EngagementTypeUseCase = EngagementTypeUseCaseImpl(
             isQueueingOrLiveEngagementUseCase = isQueueingOrLiveEngagementUseCase,
             isCurrentEngagementCallVisualizerUseCase = isCurrentEngagementCallVisualizerUseCase,
+            screenSharingUseCase = screenSharingUseCase,
             operatorMediaUseCase = operatorMediaUseCase,
             visitorMediaUseCase = visitorMediaUseCase,
             isOperatorPresentUseCase = isOperatorPresentUseCase
         )
 
-        assertFalse(useCase.isCallVisualizerScreenSharing)
+        assertTrue(useCase.isCallVisualizerScreenSharing)
     }
 
     @Test
     fun `EngagementTypeUseCase isChatEngagement returns true when engagement has no media, is not a cv and operator is present`() {
         val isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase = mockk(relaxUnitFun = true)
         val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase = mockk(relaxUnitFun = true)
+        val screenSharingUseCase: ScreenSharingUseCase = mockk(relaxUnitFun = true)
         val operatorMediaUseCase: OperatorMediaUseCase = mockk(relaxUnitFun = true)
         val visitorMediaUseCase: VisitorMediaUseCase = mockk(relaxUnitFun = true)
         val isOperatorPresentUseCase: IsOperatorPresentUseCase = mockk(relaxUnitFun = true)
@@ -276,6 +283,7 @@ class EngagementDomainTest {
         val useCase: EngagementTypeUseCase = EngagementTypeUseCaseImpl(
             isQueueingOrLiveEngagementUseCase = isQueueingOrLiveEngagementUseCase,
             isCurrentEngagementCallVisualizerUseCase = isCurrentEngagementCallVisualizerUseCase,
+            screenSharingUseCase = screenSharingUseCase,
             operatorMediaUseCase = operatorMediaUseCase,
             visitorMediaUseCase = visitorMediaUseCase,
             isOperatorPresentUseCase = isOperatorPresentUseCase
@@ -288,6 +296,7 @@ class EngagementDomainTest {
     fun `EngagementTypeUseCase isMediaEngagement returns true when engagement has  media and operator is present`() {
         val isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase = mockk(relaxUnitFun = true)
         val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase = mockk(relaxUnitFun = true)
+        val screenSharingUseCase: ScreenSharingUseCase = mockk(relaxUnitFun = true)
         val operatorMediaUseCase: OperatorMediaUseCase = mockk(relaxUnitFun = true)
         val visitorMediaUseCase: VisitorMediaUseCase = mockk(relaxUnitFun = true)
         val isOperatorPresentUseCase: IsOperatorPresentUseCase = mockk(relaxUnitFun = true)
@@ -300,6 +309,7 @@ class EngagementDomainTest {
         val useCase: EngagementTypeUseCase = EngagementTypeUseCaseImpl(
             isQueueingOrLiveEngagementUseCase = isQueueingOrLiveEngagementUseCase,
             isCurrentEngagementCallVisualizerUseCase = isCurrentEngagementCallVisualizerUseCase,
+            screenSharingUseCase = screenSharingUseCase,
             operatorMediaUseCase = operatorMediaUseCase,
             visitorMediaUseCase = visitorMediaUseCase,
             isOperatorPresentUseCase = isOperatorPresentUseCase
@@ -385,7 +395,7 @@ class EngagementDomainTest {
     }
 
     @Test
-    fun `OperatorMediaUseCase invoke will emit data only when data is present`() {
+    fun `OperatorMediaUseCase invoke will emit empty media state even when data is absent`() {
         val video = mockk<Video>(relaxUnitFun = true)
 
         val mediaState = mockk<MediaState>(relaxUnitFun = true) {
@@ -406,13 +416,12 @@ class EngagementDomainTest {
 
         verify { engagementRepository.operatorMediaState }
 
-        mediaStateFlow.test().assertNoValues()
+        assertFalse(operatorMediaUseCase.hasMedia)
 
         mediaStateSubject.onNext(Data.Empty)
         mediaStateSubject.onNext(Data.Empty)
         mediaStateSubject.onNext(Data.Empty)
 
-        mediaStateFlow.test().assertNoValues()
         assertFalse(operatorMediaUseCase.hasMedia)
 
         mediaStateSubject.onNext(Data.Value(mediaState))
@@ -426,7 +435,7 @@ class EngagementDomainTest {
     }
 
     @Test
-    fun `VisitorMediaUseCase invoke will emit data only when data is present`() {
+    fun `VisitorMediaUseCase invoke will emit empty media state even when data is absent`() {
         val video = mockk<Video>(relaxUnitFun = true)
 
         val mediaState = mockk<MediaState>(relaxUnitFun = true) {
@@ -448,13 +457,12 @@ class EngagementDomainTest {
 
         verify { engagementRepository.visitorMediaState }
 
-        mediaStateFlow.test().assertNoValues()
+        assertFalse(visitorMediaUseCase.hasMedia)
 
         mediaStateSubject.onNext(Data.Empty)
         mediaStateSubject.onNext(Data.Empty)
         mediaStateSubject.onNext(Data.Empty)
 
-        mediaStateFlow.test().assertNoValues()
         assertFalse(visitorMediaUseCase.hasMedia)
 
         mediaStateSubject.onNext(Data.Value(mediaState))

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementTypeUseCaseImplTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementTypeUseCaseImplTest.kt
@@ -1,0 +1,93 @@
+package com.glia.widgets.engagement.domain
+
+import com.glia.androidsdk.Engagement.MediaType
+import com.glia.androidsdk.comms.Audio
+import com.glia.androidsdk.comms.MediaState
+import com.glia.androidsdk.comms.Video
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.reactivex.rxjava3.core.Flowable
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class EngagementTypeUseCaseImplTest {
+
+    @MockK
+    private lateinit var isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase
+    @MockK
+    private lateinit var isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase
+    @MockK
+    private lateinit var screenSharingUseCase: ScreenSharingUseCase
+    @MockK
+    private lateinit var operatorMediaUseCase: OperatorMediaUseCase
+    @MockK
+    private lateinit var visitorMediaUseCase: VisitorMediaUseCase
+    @MockK
+    private lateinit var isOperatorPresentUseCase: IsOperatorPresentUseCase
+
+    private lateinit var useCase: EngagementTypeUseCaseImpl
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        useCase = EngagementTypeUseCaseImpl(
+            isQueueingOrLiveEngagementUseCase,
+            isCurrentEngagementCallVisualizerUseCase,
+            screenSharingUseCase,
+            operatorMediaUseCase,
+            visitorMediaUseCase,
+            isOperatorPresentUseCase
+        )
+    }
+
+    @Test
+    fun `invoke returns VIDEO when operator has only video`() {
+        val operatorMediaState = mockk<MediaState>()
+        val video = mockk<Video>()
+        every { operatorMediaState.video } returns video
+        every { operatorMediaState.audio } returns null
+        every { operatorMediaUseCase() } returns Flowable.just(operatorMediaState)
+
+        val result = useCase().blockingFirst()
+        assertEquals(MediaType.VIDEO, result)
+    }
+
+    @Test
+    fun `invoke returns AUDIO when operator has only audio`() {
+        val operatorMediaState = mockk<MediaState>()
+        val audio = mockk<Audio>()
+        every { operatorMediaState.video } returns null
+        every { operatorMediaState.audio } returns audio
+        every { operatorMediaUseCase() } returns Flowable.just(operatorMediaState)
+
+        val result = useCase().blockingFirst()
+        assertEquals(MediaType.AUDIO, result)
+    }
+
+    @Test
+    fun `invoke returns VIDEO when operator has audio and video`() {
+        val operatorMediaState = mockk<MediaState>()
+        val video = mockk<Video>()
+        val audio = mockk<Audio>()
+        every { operatorMediaState.video } returns video
+        every { operatorMediaState.audio } returns audio
+        every { operatorMediaUseCase() } returns Flowable.just(operatorMediaState)
+
+        val result = useCase().blockingFirst()
+        assertEquals(MediaType.VIDEO, result)
+    }
+
+    @Test
+    fun `invoke returns UNKNOWN when operator has no media`() {
+        val operatorMediaState = mockk<MediaState>()
+        every { operatorMediaState.video } returns null
+        every { operatorMediaState.audio } returns null
+        every { operatorMediaUseCase() } returns Flowable.just(operatorMediaState)
+
+        val result = useCase().blockingFirst()
+        assertEquals(MediaType.UNKNOWN, result)
+    }
+}

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a9266449e2b865a1857cb0e1f86d7581c4ed2fd6d907c0c849e31f12fe7862d
+size 34557

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aee535dc02380c6cf87eba3a5ebaaf56b3f99e2b79b25040f020dcfd669e00b2
+size 101682

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f259778d527abe6ff32b2ad4badae4bc76f332f162bc9b5d617486922e1c0927
+size 35555

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_audioCallOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a9266449e2b865a1857cb0e1f86d7581c4ed2fd6d907c0c849e31f12fe7862d
+size 34557

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17e9dc569ce245bd8d5174fcc6a384feb00f323a9da4e9aff9d6dd8d2cef04af
+size 34255

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ec161fa4700ddadb5d07b53f5199526447407e5f5d2c5e77e1e01995f28e242
+size 102257

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1a9cadb527a717bb2cf87460bde10cdcd74733289ff2c05bd39541a0771e38d
+size 35406

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_chatOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17e9dc569ce245bd8d5174fcc6a384feb00f323a9da4e9aff9d6dd8d2cef04af
+size 34255

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da7db1ef95f5fb501051f61fa9afdc8eae85b782413eba7de20c9f6d9b8389c7
+size 41540

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ed88cb7eb746b75e10d279784a4ace1e92416c20f6906eee6d0376a72d8829
+size 110321

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:749444506d2b4e05685d018f543ef7d69124dcfe01dc9f6705fbbb916a1a497f
+size 42165

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da7db1ef95f5fb501051f61fa9afdc8eae85b782413eba7de20c9f6d9b8389c7
+size 41540

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0de0a349228235f30ba71add5b3eddffadad2155403275e2b017f24237f8892
+size 44069

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a88d8279d920c3ea05f824e4ac957b1c5441a97bc7e4b153b595fcdb3fbcb28
+size 115732

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65aee3dcf87bd235be314eee0b440b25e68f24346b18abcc12f2aa4af327433f
+size 44987

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_messagingOngoingWithUnreadWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0de0a349228235f30ba71add5b3eddffadad2155403275e2b017f24237f8892
+size 44069

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f777f213854245b7a6f24bcfb47a79ac39e9ad316c1c2059a0ad44433180543e
+size 34245

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13e6ecd8da50415be3cd6c166dcf85ce91d3cecd04815cfb663773a25b9d9349
+size 100743

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c9bea5acfb8db9e869471ff9b507ca3ab5702c0ec450a19778a2e842d48fb39
+size 35408

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetBottomSheetTest_videoCallOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f777f213854245b7a6f24bcfb47a79ac39e9ad316c1c2059a0ad44433180543e
+size 34245

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69aefaed13e24c1adb46272f899a8ca300c79622941fbea3ff5c89583ddcbf7a
+size 32673

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa912566b310df368e7e7e06569b2962cbce09688494b30293aa775a94de8690
+size 96533

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0771b09ef21bb1577376f6263dfa2efa4647db8ee9883972f96659cf00cb63a
+size 31956

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_audioCallOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69aefaed13e24c1adb46272f899a8ca300c79622941fbea3ff5c89583ddcbf7a
+size 32673

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffe26afbafd69aa5458151196b6d3f17a3855835df63d23df4499797db685a56
+size 32467

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4464de8505a60502d980d1396e362adeb52f647a6908dc0d9b04552c12721133
+size 96693

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e51e1cd5025fb3d0bb52da4cb8ad2ecf47699ca28ebbaaa19b904ae5205f6a5a
+size 31658

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_chatOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffe26afbafd69aa5458151196b6d3f17a3855835df63d23df4499797db685a56
+size 32467

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fdac6b5d0953b61d5765bfa26c4a6771455ba9c5b074760a5ebbbe48d042332
+size 39869

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3c238ce01591b809474f4e8f0e1f756d0a6dac54654ef0d84b3e617873a8cd5
+size 104837

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c185793ef2778866551cc44f5862911c7adf281a7045c69e5421ec85ebbaae4d
+size 38868

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fdac6b5d0953b61d5765bfa26c4a6771455ba9c5b074760a5ebbbe48d042332
+size 39869

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60ab623e67913558e95a73d540982768d7c9a3518a2b7fda9e7c4651ccc3a2c1
+size 42352

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20ea4bee0d999694a44dab3df84f22ed0ba482e63654600fed7fb3effa100fab
+size 110910

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0730e98411f44975ec440e609108a20f9bc4fac0de1a9a302cc673eba17e2320
+size 41730

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_messagingOngoingWithUnreadWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60ab623e67913558e95a73d540982768d7c9a3518a2b7fda9e7c4651ccc3a2c1
+size 42352

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9c2a8af0798ce62fb1458e43c88d28f5b391f2afc239b551fdf1883e8a58ed9
+size 32332

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingWithUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingWithUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f27db323f77b9027d5b2bbfa10d30a8af3bc033a2ce55e70c9bb5c212527771
+size 95271

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingWithUnifiedThemeWithGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingWithUnifiedThemeWithGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72018c96425120fc48d1d05fe65f089a4d48c9d2ed0f20a442b9af1e7819edad
+size 31577

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingWithUnifiedThemeWithoutEntryWidget.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.entrywidget_EntryWidgetEmbeddedViewTest_videoCallOngoingWithUnifiedThemeWithoutEntryWidget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9c2a8af0798ce62fb1458e43c88d28f5b391f2afc239b551fdf1883e8a58ed9
+size 32332

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetEmbeddedViewTest.kt
@@ -25,7 +25,7 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         Dependencies.controllerFactory = controllerFactoryMock
     }
 
-    // MARK: Contacts Tests without unread count badge
+    // MARK: Tests for available engagement items without unread count badge
 
     private val mediaTypesWithoutUnreadMessaging = listOf(
         EntryWidgetContract.ItemType.VideoCall,
@@ -72,7 +72,7 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         )
     }
 
-    // MARK: Contacts Tests with unread count badge
+    // MARK: Tests for available engagement items with unread count badge
 
     private val mediaTypesWithUnreadMessaging = listOf(
         EntryWidgetContract.ItemType.VideoCall,
@@ -508,6 +508,221 @@ internal open class EntryWidgetEmbeddedViewTest : SnapshotTest(
         snapshot(
             setupView(
                 items = errorItemsWhiteLabel,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    // MARK: Tests for VideoCallOngoing engagement item
+
+    private val videoCallOngoing = listOf(
+        EntryWidgetContract.ItemType.VideoCallOngoing,
+    )
+
+    @Test
+    fun videoCallOngoingDefaultTheme() {
+        snapshot(
+            setupView(items = videoCallOngoing)
+        )
+    }
+
+    @Test
+    fun videoCallOngoingWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = videoCallOngoing,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun videoCallOngoingWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = videoCallOngoing,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
+    fun videoCallOngoingWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = videoCallOngoing,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    // MARK: Tests for AudioCallOngoing engagement item
+
+    private val audioCallOngoing = listOf(
+        EntryWidgetContract.ItemType.AudioCallOngoing,
+    )
+
+    @Test
+    fun audioCallOngoingDefaultTheme() {
+        snapshot(
+            setupView(items = audioCallOngoing)
+        )
+    }
+
+    @Test
+    fun audioCallOngoingWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = audioCallOngoing,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun audioCallOngoingWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = audioCallOngoing,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
+    fun audioCallOngoingWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = audioCallOngoing,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    // MARK: Tests for ChatOngoing engagement item
+
+    private val chatOngoing = listOf(
+        EntryWidgetContract.ItemType.ChatOngoing,
+    )
+
+    @Test
+    fun chatOngoingDefaultTheme() {
+        snapshot(
+            setupView(items = chatOngoing)
+        )
+    }
+
+    @Test
+    fun chatOngoingWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = chatOngoing,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun chatOngoingWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = chatOngoing,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
+    fun chatOngoingWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = chatOngoing,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    // MARK: Tests for MessagingOngoing engagement item without unread count badge
+
+    private val messagingOngoing = listOf(
+        EntryWidgetContract.ItemType.MessagingOngoing(0),
+    )
+
+    @Test
+    fun messagingOngoingDefaultTheme() {
+        snapshot(
+            setupView(items = messagingOngoing)
+        )
+    }
+
+    @Test
+    fun messagingOngoingWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = messagingOngoing,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun messagingOngoingWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = messagingOngoing,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
+    fun messagingOngoingWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = messagingOngoing,
+                unifiedTheme = unifiedThemeWithoutEntryWidget()
+            )
+        )
+    }
+
+    // MARK: Tests for MessagingOngoing engagement item with unread count badge
+
+    private val messagingOngoingWithUnread = listOf(
+        EntryWidgetContract.ItemType.MessagingOngoing(5),
+    )
+
+    @Test
+    fun messagingOngoingWithUnreadDefaultTheme() {
+        snapshot(
+            setupView(items = messagingOngoingWithUnread)
+        )
+    }
+
+    @Test
+    fun messagingOngoingWithUnreadWithUnifiedTheme() {
+        snapshot(
+            setupView(
+                items = messagingOngoingWithUnread,
+                unifiedTheme = unifiedTheme()
+            )
+        )
+    }
+
+    @Test
+    fun messagingOngoingWithUnreadWithUnifiedThemeWithGlobalColors() {
+        snapshot(
+            setupView(
+                items = messagingOngoingWithUnread,
+                unifiedTheme = unifiedThemeWithGlobalColors()
+            )
+        )
+    }
+
+    @Test
+    fun messagingOngoingWithUnreadWithUnifiedThemeWithoutEntryWidget() {
+        snapshot(
+            setupView(
+                items = messagingOngoingWithUnread,
                 unifiedTheme = unifiedThemeWithoutEntryWidget()
             )
         )


### PR DESCRIPTION
**Jira issue:**
[[Android] Handle Entry Widget item tap during ongoing engagement](https://glia.atlassian.net/browse/MOB-3811)

**Changes overview**
- Added an `isAuthenticatedUseCase()` check to `HasOngoingSecureConversationUseCase`
- Added `isAudioEngagement`, `isVideoEngagement`, `isCallVisualizer` and observable `Flowable<MediaType>` to `EngagementTypeUseCase`
- Changed the `OperatorMediaUseCase` and `VisitorMediaUseCase` so that they return a value even if operator or visitor doesn't have video or audio. Otherwise, these use cases kept returning an outdated value after engagement has been ended. Also, they were not returning a value at all, making `EntryWidgetController` subscribers stuck.
- Added 'ongoing' items to Entry Widget
- Changed the logic in EntryWidgetController to return 'Ongoing' items if there is an active engagement

ℹ️ I will add snapshot tests in a separate PR

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

https://github.com/user-attachments/assets/a59bce10-bf7c-4309-b6bf-c86f6ecd7e92

https://github.com/user-attachments/assets/23096d9f-32d9-471b-8ac3-802d06d5096f
