### PR TITLE
Cancel ongoing queue ticket if visitor starts a new engagement during…

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -83,7 +83,13 @@ internal object Dependencies {
 
     @JvmStatic
     val engagementLauncher: EngagementLauncher by lazy {
-        EngagementLauncherImpl(activityLauncher, useCaseFactory.hasPendingSecureConversationsWithTimeoutUseCase, configurationManager)
+        EngagementLauncherImpl(
+            activityLauncher,
+            useCaseFactory.hasPendingSecureConversationsWithTimeoutUseCase,
+            useCaseFactory.isQueueingOrEngagementUseCase,
+            useCaseFactory.endEngagementUseCase,
+            configurationManager,
+            controllerFactory)
     }
 
     @JvmStatic

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/IsQueueingOrLiveEngagementUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/IsQueueingOrLiveEngagementUseCase.kt
@@ -6,6 +6,7 @@ internal interface IsQueueingOrLiveEngagementUseCase {
     val hasOngoingLiveEngagement: Boolean
     val isQueueingForMedia: Boolean
     val isQueueingForLiveChat: Boolean
+    val isQueueing: Boolean
     operator fun invoke(): Boolean
 }
 
@@ -13,5 +14,6 @@ internal class IsQueueingOrLiveEngagementUseCaseImpl(private val engagementRepos
     override val hasOngoingLiveEngagement: Boolean get() = engagementRepository.hasOngoingLiveEngagement
     override val isQueueingForMedia: Boolean get() = engagementRepository.isQueueingForMedia
     override val isQueueingForLiveChat: Boolean get() = engagementRepository.isQueueing && !isQueueingForMedia
+    override val isQueueing: Boolean get() = engagementRepository.isQueueing
     override fun invoke(): Boolean = engagementRepository.isQueueingOrLiveEngagement
 }


### PR DESCRIPTION
**Jira issue:**
[Visitors want to be able to select engagement of another type or start a new engagement during queueing](https://glia.atlassian.net/browse/MOB-3886)

**What was solved?**
- Visitors are now able to select engagement of another type
- Visitors are now able to start a new engagement during queueing

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

