### PR TITLE
Log additional events for an Entry Widget and Engagement Launcher

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -111,6 +111,7 @@ internal class EntryWidgetController @JvmOverloads constructor(
         unreadMessagesCount: Int,
         hasOngoingSC: Boolean
     ): List<EntryWidgetContract.ItemType> {
+        Logger.i(TAG, "Preparing items based on ongoing engagement")
         return when {
             engagementTypeUseCase.isCallVisualizer -> listOf(EntryWidgetContract.ItemType.CallVisualizerOngoing)
             hasOngoingSC -> listOf(EntryWidgetContract.ItemType.MessagingOngoing(unreadMessagesCount))

--- a/widgetssdk/src/main/java/com/glia/widgets/launcher/EngagementLauncher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/launcher/EngagementLauncher.kt
@@ -7,6 +7,8 @@ import com.glia.widgets.core.secureconversations.domain.HasOngoingSecureConversa
 import com.glia.widgets.di.ControllerFactory
 import com.glia.widgets.engagement.domain.EndEngagementUseCase
 import com.glia.widgets.engagement.domain.IsQueueingOrLiveEngagementUseCase
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
 
 /**
  * An interface for launching different types of engagements, such as chat,
@@ -57,6 +59,7 @@ internal class EngagementLauncherImpl(
 
     override fun startChat(context: Context, visitorContextAssetId: String?) {
         if (isQueueingOrLiveEngagementUseCase.isQueueing) {
+            Logger.i(TAG, "Canceling ongoing queue ticket to create a new one")
             endEngagementUseCase()
             controllerFactory.destroyChatController()
         }
@@ -73,6 +76,7 @@ internal class EngagementLauncherImpl(
 
     override fun startAudioCall(context: Context, visitorContextAssetId: String?) {
         if (isQueueingOrLiveEngagementUseCase.isQueueing) {
+            Logger.i(TAG, "Canceling ongoing queue ticket to create a new one")
             endEngagementUseCase()
             controllerFactory.destroyCallController()
         }
@@ -89,6 +93,7 @@ internal class EngagementLauncherImpl(
 
     override fun startVideoCall(context: Context, visitorContextAssetId: String?) {
         if (isQueueingOrLiveEngagementUseCase.isQueueing) {
+            Logger.i(TAG, "Canceling ongoing queue ticket to create a new one")
             endEngagementUseCase()
             controllerFactory.destroyCallController()
         }


### PR DESCRIPTION
**What was solved?**
1. [[Android] Developers want to log the 'Canceling ongoing queue ticket to create a new one' event](https://glia.atlassian.net/browse/MOB-3910)
2. [[Android] Developers want to log the 'Preparing items based on ongoing engagement' event for Entry Widget](https://glia.atlassian.net/browse/MOB-3911)

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [x] Did you add logging beneficial for troubleshooting of customer issues?
 - [x] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

