### PR TITLE
Do not cancel queue ticket if visitor selects engagement of the same type during queueing

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -424,7 +424,8 @@ internal class ChatManager(
     fun mapInQueue(state: State): State = state.apply {
         OperatorStatusItem.InQueue.also {
             operatorStatusItem = it
-            chatItems += it
+            val isQueueingItemAlreadyDisplayed = chatItems.size > 0 && chatItems[chatItems.lastIndex] == it
+            if (!isQueueingItemAlreadyDisplayed) chatItems += it
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
@@ -36,6 +36,8 @@ internal interface EngagementRepository {
     val isTransferredSecureConversation: Boolean
     val isQueueing: Boolean
     val isQueueingForMedia: Boolean
+    val isQueueingForVideo: Boolean
+    val isQueueingForAudio: Boolean
     val isCallVisualizerEngagement: Boolean
     val isOperatorPresent: Boolean
     val isSharingScreen: Boolean

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -151,6 +151,12 @@ internal class EngagementRepositoryImpl(
     override val isQueueingForMedia: Boolean
         get() = currentState?.queueingMediaType?.isAudioOrVideo() == true
 
+    override val isQueueingForAudio: Boolean
+        get() = (currentState?.queueingMediaType == MediaType.AUDIO)
+
+    override val isQueueingForVideo: Boolean
+        get() = (currentState?.queueingMediaType == MediaType.VIDEO)
+
     override val isCallVisualizerEngagement: Boolean
         get() = currentEngagement is OmnibrowseEngagement
 

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/IsQueueingOrLiveEngagementUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/IsQueueingOrLiveEngagementUseCase.kt
@@ -5,6 +5,8 @@ import com.glia.widgets.engagement.EngagementRepository
 internal interface IsQueueingOrLiveEngagementUseCase {
     val hasOngoingLiveEngagement: Boolean
     val isQueueingForMedia: Boolean
+    val isQueueingForAudio: Boolean
+    val isQueueingForVideo: Boolean
     val isQueueingForLiveChat: Boolean
     val isQueueing: Boolean
     operator fun invoke(): Boolean
@@ -13,6 +15,8 @@ internal interface IsQueueingOrLiveEngagementUseCase {
 internal class IsQueueingOrLiveEngagementUseCaseImpl(private val engagementRepository: EngagementRepository) : IsQueueingOrLiveEngagementUseCase {
     override val hasOngoingLiveEngagement: Boolean get() = engagementRepository.hasOngoingLiveEngagement
     override val isQueueingForMedia: Boolean get() = engagementRepository.isQueueingForMedia
+    override val isQueueingForAudio: Boolean get() = engagementRepository.isQueueingForAudio
+    override val isQueueingForVideo: Boolean get() = engagementRepository.isQueueingForVideo
     override val isQueueingForLiveChat: Boolean get() = engagementRepository.isQueueing && !isQueueingForMedia
     override val isQueueing: Boolean get() = engagementRepository.isQueueing
     override fun invoke(): Boolean = engagementRepository.isQueueingOrLiveEngagement

--- a/widgetssdk/src/main/java/com/glia/widgets/launcher/EngagementLauncher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/launcher/EngagementLauncher.kt
@@ -58,7 +58,7 @@ internal class EngagementLauncherImpl(
 ) : EngagementLauncher {
 
     override fun startChat(context: Context, visitorContextAssetId: String?) {
-        if (isQueueingOrLiveEngagementUseCase.isQueueing) {
+        if (isQueueingOrLiveEngagementUseCase.isQueueingForMedia) {
             Logger.i(TAG, "Canceling ongoing queue ticket to create a new one")
             endEngagementUseCase()
             controllerFactory.destroyChatController()
@@ -75,7 +75,7 @@ internal class EngagementLauncherImpl(
     }
 
     override fun startAudioCall(context: Context, visitorContextAssetId: String?) {
-        if (isQueueingOrLiveEngagementUseCase.isQueueing) {
+        if (isQueueingOrLiveEngagementUseCase.isQueueingForLiveChat || isQueueingOrLiveEngagementUseCase.isQueueingForVideo) {
             Logger.i(TAG, "Canceling ongoing queue ticket to create a new one")
             endEngagementUseCase()
             controllerFactory.destroyCallController()
@@ -92,7 +92,7 @@ internal class EngagementLauncherImpl(
     }
 
     override fun startVideoCall(context: Context, visitorContextAssetId: String?) {
-        if (isQueueingOrLiveEngagementUseCase.isQueueing) {
+        if (isQueueingOrLiveEngagementUseCase.isQueueingForLiveChat || isQueueingOrLiveEngagementUseCase.isQueueingForAudio) {
             Logger.i(TAG, "Canceling ongoing queue ticket to create a new one")
             endEngagementUseCase()
             controllerFactory.destroyCallController()


### PR DESCRIPTION
**Jira issue:**
[[Android] Do not cancel queue ticket if visitor selects engagement of the same type during queueing](https://glia.atlassian.net/browse/MOB-3930)

**Release notes:**
1. Do not cancel queue ticket if visitor selects engagement of the same type during queueing
2. Prevent showing multiple "queueing' items with animation if Chat screen is launched through `EngagementLauncher` during queueing

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

