### PR TITLE
Improve the mark messages as read logic

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadWithDelayUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/MarkMessagesReadWithDelayUseCase.kt
@@ -13,6 +13,10 @@ private const val TAG = "MarkMessagesReadUseCase"
 @VisibleForTesting
 const val DELAY_SEC = 6L
 
+/**
+ * This use case is responsible for marking the messages as read with a delay.
+ * The messages should be marked as read if the chat screen is open and the leave dialog is not visible.
+ */
 internal class MarkMessagesReadWithDelayUseCase(
     private val secureConversationsRepository: SecureConversationsRepository,
     private val chatScreenRepository: ChatScreenRepository

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/ShouldMarkMessagesReadUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/ShouldMarkMessagesReadUseCase.kt
@@ -1,0 +1,22 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.widgets.engagement.EngagementRepository
+
+/**
+ * This use case is responsible for determining if the messages should be marked as read.
+ * The messages should be marked as read if there is no ongoing live engagement or if the current
+ * engagement action on end is retain.
+ *
+ * If result is true, [MarkMessagesReadWithDelayUseCase] should be used to mark the messages as read.
+ * Additional logic is implemented in [MarkMessagesReadWithDelayUseCase] to delay the marking of
+ * messages as read if the chat screen is open or the leave dialog is visible.
+ */
+internal class ShouldMarkMessagesReadUseCase(
+    private val engagementRepository: EngagementRepository
+) {
+
+    operator fun invoke(): Boolean {
+        return !engagementRepository.hasOngoingLiveEngagement
+            || engagementRepository.isRetainAfterEnd
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ManagerFactory.kt
@@ -9,6 +9,7 @@ internal class ManagerFactory(private val useCaseFactory: UseCaseFactory) {
                 onMessageUseCase = createGliaOnMessageUseCase(),
                 loadHistoryUseCase = createGliaLoadHistoryUseCase(),
                 addNewMessagesDividerUseCase = createAddNewMessagesDividerUseCase(),
+                shouldMarkMessagesReadUseCase = createShouldMarkMessagesReadUseCase(),
                 markMessagesReadWithDelayUseCase = createMarkMessagesReadUseCase(),
                 appendHistoryChatMessageUseCase = createAppendHistoryChatMessageUseCase(),
                 appendNewChatMessageUseCase = createAppendNewChatMessageUseCase(),

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -113,6 +113,7 @@ import com.glia.widgets.core.secureconversations.domain.SendMessageButtonStateUs
 import com.glia.widgets.core.secureconversations.domain.SendSecureMessageUseCase;
 import com.glia.widgets.core.secureconversations.domain.SetLeaveSecureConversationDialogVisibleUseCase;
 import com.glia.widgets.core.secureconversations.domain.SetLeaveSecureConversationDialogVisibleUseCaseImpl;
+import com.glia.widgets.core.secureconversations.domain.ShouldMarkMessagesReadUseCase;
 import com.glia.widgets.core.secureconversations.domain.ShowMessageLimitErrorUseCase;
 import com.glia.widgets.core.survey.domain.GliaSurveyAnswerUseCase;
 import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCase;
@@ -577,6 +578,13 @@ public class UseCaseFactory {
     @NonNull
     public SecureConversationTopBannerVisibilityUseCase createSecureConversationTopBannerVisibilityUseCase() {
         return new SecureConversationTopBannerVisibilityUseCase(repositoryFactory.getQueueRepository(), createManageSecureMessagingStatusUseCase());
+    }
+
+    @NonNull
+    public ShouldMarkMessagesReadUseCase createShouldMarkMessagesReadUseCase() {
+        return new ShouldMarkMessagesReadUseCase(
+            repositoryFactory.getEngagementRepository()
+        );
     }
 
     @NonNull

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
@@ -2,6 +2,7 @@ package com.glia.widgets.engagement
 
 import android.app.Activity
 import android.content.Intent
+import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.EngagementRequest.Outcome
 import com.glia.androidsdk.IncomingEngagementRequest
@@ -42,6 +43,7 @@ internal interface EngagementRepository {
     val isOperatorPresent: Boolean
     val isSharingScreen: Boolean
     val isSecureMessagingRequested: Boolean
+    val isRetainAfterEnd: Boolean
     val cameras: List<CameraDevice>?
     val currentVisitorCamera: VisitorCamera
 

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -171,6 +171,9 @@ internal class EngagementRepositoryImpl(
     override val isSecureMessagingRequested: Boolean
         get() = _isSecureMessagingRequested
 
+    override val isRetainAfterEnd: Boolean
+        get() = currentEngagement?.state?.actionOnEnd == Engagement.ActionOnEnd.RETAIN
+
     override val cameras: List<CameraDevice>?
         get() = currentEngagement?.media?.cameraDevices
 

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -34,6 +34,7 @@ import com.glia.widgets.core.engagement.domain.model.ChatHistoryResponse
 import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
 import com.glia.widgets.core.secureconversations.domain.HasOngoingSecureConversationUseCase
 import com.glia.widgets.core.secureconversations.domain.MarkMessagesReadWithDelayUseCase
+import com.glia.widgets.core.secureconversations.domain.ShouldMarkMessagesReadUseCase
 import com.glia.widgets.engagement.domain.IsQueueingOrLiveEngagementUseCase
 import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import io.reactivex.rxjava3.core.Completable
@@ -71,6 +72,7 @@ class ChatManagerTest {
     private lateinit var onMessageUseCase: GliaOnMessageUseCase
     private lateinit var loadHistoryUseCase: GliaLoadHistoryUseCase
     private lateinit var addNewMessagesDividerUseCase: AddNewMessagesDividerUseCase
+    private lateinit var shouldMarkMessagesReadUseCase: ShouldMarkMessagesReadUseCase
     private lateinit var markMessagesReadWithDelayUseCase: MarkMessagesReadWithDelayUseCase
     private lateinit var appendHistoryChatMessageUseCase: AppendHistoryChatMessageUseCase
     private lateinit var appendNewChatMessageUseCase: AppendNewChatMessageUseCase
@@ -95,6 +97,7 @@ class ChatManagerTest {
         onMessageUseCase = mock()
         loadHistoryUseCase = mock()
         addNewMessagesDividerUseCase = mock()
+        shouldMarkMessagesReadUseCase = mock()
         markMessagesReadWithDelayUseCase = mock()
         appendHistoryChatMessageUseCase = mock()
         appendNewChatMessageUseCase = mock()
@@ -114,6 +117,7 @@ class ChatManagerTest {
             onMessageUseCase,
             loadHistoryUseCase,
             addNewMessagesDividerUseCase,
+            shouldMarkMessagesReadUseCase,
             markMessagesReadWithDelayUseCase,
             appendHistoryChatMessageUseCase,
             appendNewChatMessageUseCase,

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/ShouldMarkMessagesReadUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/ShouldMarkMessagesReadUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.glia.widgets.core.secureconversations.domain
+
+import com.glia.widgets.engagement.EngagementRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ShouldMarkMessagesReadUseCaseTest {
+    private lateinit var engagementRepository: EngagementRepository
+    private lateinit var useCase: ShouldMarkMessagesReadUseCase
+
+    @Before
+    fun setUp() {
+        engagementRepository = mockk()
+        useCase = ShouldMarkMessagesReadUseCase(engagementRepository)
+    }
+
+    @Test
+    fun `invoke returns true when there is no ongoing live engagement`() {
+        every { engagementRepository.hasOngoingLiveEngagement } returns false
+        val result = useCase()
+        assertTrue(result)
+    }
+
+    @Test
+    fun `invoke returns true when the current engagement action on end is retain`() {
+        every { engagementRepository.isRetainAfterEnd } returns true
+        every { engagementRepository.hasOngoingLiveEngagement } returns true
+        val result = useCase()
+        assertTrue(result)
+    }
+
+    @Test
+    fun `invoke returns false when the current engagement action on end is not retain`() {
+        every { engagementRepository.isRetainAfterEnd } returns false
+        every { engagementRepository.hasOngoingLiveEngagement } returns true
+        val result = useCase()
+        assertFalse(result)
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
@@ -1475,4 +1475,28 @@ class EngagementRepositoryTest {
         verify { queueRepository.relevantQueueIds }
         verify(exactly = 1) { core.queueForEngagement(listOf(queueId), MediaType.TEXT, null, any(), any(), capture(queueForEngagementCallbackSlot)) }
     }
+
+    @Test
+    fun `isRetainAfterEnd is true when actionOnEnd is RETAIN`() {
+        mockEngagementAndStart()
+
+        every { engagementState.actionOnEnd } returns Engagement.ActionOnEnd.RETAIN
+
+        assertTrue(repository.isRetainAfterEnd)
+    }
+
+    @Test
+    fun `isRetainAfterEnd is false when actionOnEnd is not RETAIN`() {
+        mockEngagementAndStart()
+
+        every { engagementState.actionOnEnd } returnsMany listOf(
+            Engagement.ActionOnEnd.SHOW_SURVEY,
+            Engagement.ActionOnEnd.END_NOTIFICATION,
+            Engagement.ActionOnEnd.UNKNOWN
+        )
+
+        assertFalse(repository.isRetainAfterEnd)
+        assertFalse(repository.isRetainAfterEnd)
+        assertFalse(repository.isRetainAfterEnd)
+    }
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3954

**What was solved?**
New messages should be marked as read when:

- We have new messages when the history loaded after a visitor opened the chat (transcript) screen or a visitor gets a new SC or Live Engagement message from an Operator; and
- There are no ongoing engagements or an ongoing engagement on_end equals retain; and
- The visitor has stayed on the chat (transcript) screen for at least 6 seconds after the new message; and
- The leave current SC dialog has not shown for at least 6 seconds after the new message.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
