### PR TITLE
MOB 3942: Implement engagement 'on_end' functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     // Needed for some automated and manual testing (e.g: acceptance tests)
     mavenLocal()
     //TODO switch to the release version before releasing core SDK
-    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1346" }
+    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1349" }
   }
 }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -26,8 +26,6 @@ import com.glia.widgets.core.notification.domain.CallNotificationUseCase
 import com.glia.widgets.engagement.EngagementUpdateState
 import com.glia.widgets.engagement.ScreenSharingState
 import com.glia.widgets.engagement.State
-import com.glia.widgets.engagement.State.StartedCallVisualizer
-import com.glia.widgets.engagement.State.StartedOmniCore
 import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCase
 import com.glia.widgets.engagement.domain.EndEngagementUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -547,7 +545,7 @@ internal class CallController(
 
     private fun onEngagementStateChanged(state: State) {
         when (state) {
-            StartedCallVisualizer, StartedOmniCore -> newEngagementLoaded()
+            is State.EngagementStarted -> newEngagementLoaded()
             is State.Update -> handleEngagementStateUpdate(state.updateState)
             is State.QueueUnstaffed, is State.UnexpectedErrorHappened -> {
                 emitViewState(callState.changeVisibility(false))

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -60,8 +60,8 @@ internal class CallVisualizerController(
 
     private val _state: PublishProcessor<CallVisualizerContract.State> = PublishProcessor.create()
     override val state: Flowable<OneTimeEvent<CallVisualizerContract.State>> = _state.asOneTimeStateFlowable()
-    override val engagementStartFlow: Flowable<EngagementState> get() = engagementStateUseCase().filter { it is EngagementState.StartedCallVisualizer }
-    override val engagementEndFlow: Flowable<EngagementState> get() = engagementStateUseCase().filter { it is EngagementState.FinishedCallVisualizer }
+    override val engagementStartFlow: Flowable<EngagementState> get() = engagementStateUseCase().filter { it is EngagementState.EngagementStarted && it.isCallVisualizer }
+    override val engagementEndFlow: Flowable<EngagementState> get() = engagementStateUseCase().filter { it is EngagementState.EngagementEnded && it.isCallVisualizer }
 
     private var visitorContextAssetId: String? = null
 

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/VisitorCodeController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/VisitorCodeController.kt
@@ -69,7 +69,7 @@ internal class VisitorCodeController(
             return
         }
         engagementStateDisposable?.dispose()
-        engagementStateDisposable = engagementStateUseCase().filter { it is State.StartedCallVisualizer }.subscribe {
+        engagementStateDisposable = engagementStateUseCase().filter { it is State.EngagementStarted && it.isCallVisualizer }.subscribe {
             view.destroyTimer()
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -572,13 +572,16 @@ internal class ChatController(
 
     private fun onEngagementStateChanged(state: State) {
         when (state) {
-            State.FinishedCallVisualizer, State.FinishedOmniCore -> {
+            is State.EngagementEnded -> {
                 if (!isQueueingOrOngoingEngagement) {
                     dialogController.dismissDialogs()
                 }
+                if (state.onEnd == Engagement.ActionOnEnd.RETAIN) {
+                    onTransferredToSecureConversation()
+                }
             }
 
-            State.StartedOmniCore -> newEngagementLoaded()
+            is State.EngagementStarted -> if(!state.isCallVisualizer) newEngagementLoaded()
             is State.Update -> handleEngagementStateUpdate(state.updateState)
             is State.PreQueuing, is State.Queuing -> queueForEngagementStarted()
             is State.QueueUnstaffed, is State.UnexpectedErrorHappened, is State.QueueingCanceled -> emitViewState { chatState.chatUnavailableState() }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatState.kt
@@ -54,7 +54,10 @@ internal data class ChatState(
     fun setSecureMessagingState(): ChatState = copy(
         isSecureMessaging = true,
         chatInputMode = ChatInputMode.ENABLED,
-        isAttachmentButtonNeeded = true
+        isAttachmentButtonNeeded = true,
+        engagementRequested = false,
+        operatorProfileImgUrl = null,
+        formattedOperatorName = null
     )
 
     fun setLiveChatState(): ChatState = copy(

--- a/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/MediaProjectionService.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/screensharing/MediaProjectionService.kt
@@ -60,7 +60,7 @@ class MediaProjectionService : Service() {
             informThatReadyToShareScreenUseCase()
 
             engagementStateUseCase()
-                .filter { it is State.FinishedCallVisualizer || it is State.FinishedOmniCore }
+                .filter { it is State.EngagementEnded }
                 .subscribe { stopSelf() }
                 .also(compositeDisposable::add)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.engagement
 
+import com.glia.androidsdk.Engagement.ActionOnEnd
 import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.engagement.EngagementState
@@ -12,10 +13,8 @@ internal sealed interface State {
     data object QueueUnstaffed : State
     data object UnexpectedErrorHappened : State
     data object QueueingCanceled : State
-    data object StartedOmniCore : State
-    data object StartedCallVisualizer : State
-    data object FinishedOmniCore : State
-    data object FinishedCallVisualizer : State
+    data class EngagementStarted(val type: EngagementType) : StateWithType(type)
+    data class EngagementEnded(val type: EngagementType, val isEndedByVisitor: Boolean, val onEnd: ActionOnEnd) : StateWithType(type)
     data object TransferredToSecureConversation : State
     data class Update(val state: EngagementState, val updateState: EngagementUpdateState) : State
 
@@ -24,7 +23,7 @@ internal sealed interface State {
 
     val isLiveEngagement: Boolean
         get() = when (this) {
-            is Update, StartedOmniCore, StartedCallVisualizer -> true
+            is Update, is EngagementStarted -> true
             else -> false
         }
 
@@ -34,6 +33,10 @@ internal sealed interface State {
             is Queuing -> mediaType
             else -> null
         }
+
+    open class StateWithType(engagementType: EngagementType): State {
+        val isCallVisualizer = engagementType == EngagementType.CallVisualizer
+    }
 }
 
 internal sealed interface EngagementUpdateState {
@@ -45,7 +48,6 @@ internal sealed interface EngagementUpdateState {
 
 internal sealed interface SurveyState {
     data object Empty : SurveyState
-    data object EmptyFromOperatorRequest : SurveyState
     data class Value(val survey: Survey) : SurveyState
 }
 
@@ -56,4 +58,9 @@ internal sealed interface ScreenSharingState {
     data object RequestDeclined : ScreenSharingState
     data class FailedToAcceptRequest(val message: String) : ScreenSharingState
     data object Ended : ScreenSharingState
+}
+
+internal sealed interface EngagementType {
+    data object OmniCore: EngagementType
+    data object CallVisualizer: EngagementType
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionState.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionState.kt
@@ -1,11 +1,11 @@
 package com.glia.widgets.engagement.completion
 
+import com.glia.androidsdk.Engagement.ActionOnEnd
 import com.glia.androidsdk.engagement.Survey
 
 internal sealed interface EngagementCompletionState {
-    object QueueUnstaffed : EngagementCompletionState
-    object UnexpectedErrorHappened : EngagementCompletionState
-    object OperatorEndedEngagement : EngagementCompletionState
-    object QueuingOrEngagementEnded : EngagementCompletionState
+    data object QueueUnstaffed : EngagementCompletionState
+    data object UnexpectedErrorHappened : EngagementCompletionState
+    data class EngagementEnded(val isEndedByVisitor: Boolean, val actionOnEnd: ActionOnEnd) : EngagementCompletionState
     data class SurveyLoaded(val survey: Survey) : EngagementCompletionState
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
@@ -38,15 +38,13 @@ internal class ActivityWatcherForChatHeadController(
 
     private fun handleEngagementState(state: State) {
         when (state) {
-            is State.StartedOmniCore,
-            is State.StartedCallVisualizer,
+            is State.EngagementStarted,
             is State.Queuing,
             is State.PreQueuing -> onEngagementOrQueueingStarted()
 
             is State.Update -> updateBubble()
 
-            is State.FinishedCallVisualizer,
-            is State.FinishedOmniCore,
+            is State.EngagementEnded,
             is State.QueueUnstaffed,
             is State.UnexpectedErrorHappened,
             is State.QueueingCanceled -> onEngagementOrQueueingEnded()

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -51,14 +51,12 @@ internal class ApplicationChatHeadLayoutController(
         messagesNotSeenHandler.addListener(::onUnreadMessageCountChange)
         engagementStateUseCase().unSafeSubscribe {
             when (it) {
-                is EngagementState.FinishedCallVisualizer,
-                is EngagementState.FinishedOmniCore,
+                is EngagementState.EngagementEnded,
                 is EngagementState.QueueUnstaffed,
                 is EngagementState.UnexpectedErrorHappened,
                 is EngagementState.QueueingCanceled -> engagementEnded()
 
-                EngagementState.StartedCallVisualizer,
-                EngagementState.StartedOmniCore -> onNewEngagementLoaded()
+                is EngagementState.EngagementStarted -> onNewEngagementLoaded()
 
                 is EngagementState.Queuing,
                 is EngagementState.PreQueuing -> onQueuingStarted()

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
@@ -101,15 +101,13 @@ internal class ServiceChatHeadController(
 
     private fun handleEngagementState(state: com.glia.widgets.engagement.State) {
         when (state) {
-            is EngagementState.StartedOmniCore,
-            is EngagementState.StartedCallVisualizer -> {
+            is EngagementState.EngagementStarted -> {
                 newEngagementLoaded()
             }
 
             is EngagementState.Update -> toggleChatHead()
 
-            is EngagementState.FinishedCallVisualizer,
-            is EngagementState.FinishedOmniCore,
+            is EngagementState.EngagementEnded,
             is EngagementState.QueueUnstaffed,
             is EngagementState.UnexpectedErrorHappened,
             is EngagementState.QueueingCanceled -> {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/ActivityWatcherForLiveObservationController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/ActivityWatcherForLiveObservationController.kt
@@ -14,7 +14,7 @@ internal class ActivityWatcherForLiveObservationController(
 
     init {
         engagementStateUseCase()
-            .filter { it is State.StartedOmniCore || it is State.StartedCallVisualizer }
+            .filter { it is State.EngagementStarted }
             .switchMapSingle { liveObservationPopupUseCase() }
             .filter { it }
             .subscribe({ liveObservationWatcher.showSnackBar() }) {}

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
@@ -1,11 +1,13 @@
 package com.glia.widgets.callvisualizer.controller
 
+import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.IncomingEngagementRequest
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.dialog.domain.ConfirmationDialogLinksUseCase
 import com.glia.widgets.core.dialog.model.DialogState
 import com.glia.widgets.core.dialog.model.Link
 import com.glia.widgets.core.engagement.domain.ConfirmationDialogUseCase
+import com.glia.widgets.engagement.EngagementType
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementRequestUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -89,7 +91,7 @@ class CallVisualizerControllerTest {
 
     @Test
     fun `CV engagement start will trigger will dismiss visitor code dialog`() {
-        engagementStateProcessor.onNext(State.StartedCallVisualizer)
+        engagementStateProcessor.onNext(State.EngagementStarted(EngagementType.CallVisualizer))
         verify { dialogController.dismissVisitorCodeDialog() }
     }
 
@@ -99,7 +101,7 @@ class CallVisualizerControllerTest {
 
         verify { engagementStateUseCase() }
 
-        engagementStateProcessor.onNext(State.FinishedCallVisualizer)
+        engagementStateProcessor.onNext(State.EngagementEnded(EngagementType.CallVisualizer, false, Engagement.ActionOnEnd.RETAIN))
 
         engagementEnd.assertNotComplete().assertValueCount(1)
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/VisitorCodeControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/VisitorCodeControllerTest.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.callvisualizer.controller
 import com.glia.androidsdk.omnibrowse.VisitorCode
 import com.glia.widgets.callvisualizer.VisitorCodeContract
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeRepository
+import com.glia.widgets.engagement.EngagementType
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
 import com.glia.widgets.engagement.domain.IsQueueingOrLiveEngagementUseCase
@@ -85,7 +86,7 @@ internal class VisitorCodeControllerTest {
 
     @Test
     fun `auto close is triggered when engagement starts`() {
-        engagementState.onNext(State.StartedCallVisualizer)
+        engagementState.onNext(State.EngagementStarted(EngagementType.CallVisualizer))
 
         verify(view).destroyTimer()
         verifyNoInteractions(callVisualizerController)

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/HasOngoingSecureConversationUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/HasOngoingSecureConversationUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.glia.widgets.core.secureconversations.domain
 
 import com.glia.androidsdk.Engagement
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
+import com.glia.widgets.engagement.EngagementType
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
 import io.mockk.every
@@ -93,7 +94,7 @@ class HasOngoingSecureConversationUseCaseTest {
 
     @Test
     fun `invoke returns false when ongoing engagement`() {
-        mockInitialState(engagementState = State.StartedOmniCore, pendingSC = true)
+        mockInitialState(engagementState = State.EngagementStarted(EngagementType.OmniCore), pendingSC = true)
 
         val result = useCase().blockingLast()
         assertEquals(false, result)

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcherTest.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.os.Parcelable
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.engagement.Survey
 import com.glia.widgets.UiTheme
 import com.glia.widgets.chat.ChatActivity
@@ -85,7 +86,7 @@ class EngagementCompletionActivityWatcherTest {
         Logger.setIsDebug(false)
         every { Logger.d(any(), any()) } just Runs
 
-        val event = createMockEvent(EngagementCompletionState.QueuingOrEngagementEnded)
+        val event = createMockEvent(EngagementCompletionState.EngagementEnded(true, Engagement.ActionOnEnd.END_NOTIFICATION))
         every { event.consumed } returns true
 
         val activity = mockkActivity<Activity>()
@@ -111,8 +112,8 @@ class EngagementCompletionActivityWatcherTest {
     }
 
     @Test
-    fun `handleState will finish activities when state is QueuingOrEngagementEnded even if activity is null or finishing`() {
-        val event = createMockEvent(EngagementCompletionState.QueuingOrEngagementEnded)
+    fun `handleState will finish activities when state is EngagementEnded even if activity is null or finishing`() {
+        val event = createMockEvent(EngagementCompletionState.EngagementEnded(true, Engagement.ActionOnEnd.END_NOTIFICATION))
         val activity = mockkActivity<Activity>()
 
         every { activity.isFinishing } returns true
@@ -242,8 +243,8 @@ class EngagementCompletionActivityWatcherTest {
     }
 
     @Test
-    fun `handleState will show operator ended engagement dialog when event is OperatorEndedEngagement`() {
-        val event = createMockEvent(EngagementCompletionState.OperatorEndedEngagement)
+    fun `handleState will show operator ended engagement dialog when event is ActionOnEnd is END_NOTIFICATION`() {
+        val event = createMockEvent(EngagementCompletionState.EngagementEnded(false, Engagement.ActionOnEnd.END_NOTIFICATION))
 
         val activity = mockkActivity<ChatActivity>()
 

--- a/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
@@ -2,6 +2,7 @@ package com.glia.widgets.entrywidget
 
 import android.COMMON_EXTENSIONS_CLASS_PATH
 import android.app.Activity
+import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.engagement.EngagementState
 import com.glia.androidsdk.queuing.Queue
@@ -11,6 +12,7 @@ import com.glia.widgets.core.queue.QueuesState
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
 import com.glia.widgets.core.secureconversations.domain.HasOngoingSecureConversationUseCase
 import com.glia.widgets.di.GliaCore
+import com.glia.widgets.engagement.EngagementType
 import com.glia.widgets.engagement.EngagementUpdateState
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -662,10 +664,10 @@ class EntryWidgetControllerTest {
         testPrepareItemsBasedOnQueuesCalledForEngagementState(State.QueueUnstaffed)
         testPrepareItemsBasedOnQueuesCalledForEngagementState(State.UnexpectedErrorHappened)
         testPrepareItemsBasedOnQueuesCalledForEngagementState(State.QueueingCanceled)
-        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.StartedOmniCore)
-        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.StartedCallVisualizer)
-        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.FinishedOmniCore)
-        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.FinishedCallVisualizer)
+        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.EngagementStarted(EngagementType.OmniCore))
+        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.EngagementStarted(EngagementType.CallVisualizer))
+        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.EngagementEnded(EngagementType.OmniCore, false, Engagement.ActionOnEnd.UNKNOWN))
+        testPrepareItemsBasedOnQueuesCalledForEngagementState(State.EngagementEnded(EngagementType.CallVisualizer, false, Engagement.ActionOnEnd.UNKNOWN))
         testPrepareItemsBasedOnQueuesCalledForEngagementState(State.TransferredToSecureConversation)
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
@@ -7,6 +7,7 @@ import com.glia.androidsdk.Engagement
 import com.glia.widgets.chat.ChatView
 import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
+import com.glia.widgets.engagement.EngagementType
 import com.glia.widgets.engagement.ScreenSharingState
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -112,8 +113,8 @@ internal class ActivityWatcherForChatHeadTest {
 
     @Test
     fun `bubble will be removed when engagement or queueing ended`() {
-        engagementStateFlowable.onNext(State.FinishedCallVisualizer)
-        engagementStateFlowable.onNext(State.FinishedOmniCore)
+        engagementStateFlowable.onNext(State.EngagementEnded(EngagementType.CallVisualizer, false, Engagement.ActionOnEnd.UNKNOWN))
+        engagementStateFlowable.onNext(State.EngagementEnded(EngagementType.OmniCore, false, Engagement.ActionOnEnd.UNKNOWN))
         engagementStateFlowable.onNext(State.QueueUnstaffed)
         engagementStateFlowable.onNext(State.UnexpectedErrorHappened)
         engagementStateFlowable.onNext(State.QueueingCanceled)
@@ -126,7 +127,7 @@ internal class ActivityWatcherForChatHeadTest {
     fun `bubble will be updated when OmniCoreEngagement is started`() {
         mockShouldShowChatHead()
 
-        engagementStateFlowable.onNext(State.StartedOmniCore)
+        engagementStateFlowable.onNext(State.EngagementStarted(EngagementType.OmniCore))
         verifyBubbleIsShowed(times = 2)
     }
 
@@ -134,7 +135,7 @@ internal class ActivityWatcherForChatHeadTest {
     fun `bubble will be updated when OmniBrowseEngagement is started`() {
         mockShouldShowChatHead()
 
-        engagementStateFlowable.onNext(State.StartedCallVisualizer)
+        engagementStateFlowable.onNext(State.EngagementStarted(EngagementType.CallVisualizer))
         verifyBubbleIsShowed(times = 2)
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3942

**What was solved?**

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
