### PR TITLE
Feature/mob 3969 adjust engagement launcher logic as per diagram

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     // Needed for some automated and manual testing (e.g: acceptance tests)
     mavenLocal()
     //TODO switch to the release version before releasing core SDK
-    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1349" }
+    maven { url = "https://s01.oss.sonatype.org/content/repositories/comglia-1351" }
   }
 }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizerActivityWatcher.kt
@@ -46,7 +46,6 @@ internal class CallVisualizerActivityWatcher(
             activity is WebBrowserActivity && state is ControllerState.DisplayConfirmationDialog -> Logger.d(TAG, "skipping.. WebBrowser is open")
             activity is WebBrowserActivity && state is ControllerState.OpenWebBrowserScreen -> event.consume { controller.onWebBrowserOpened() }
             state is ControllerState.ShowTimeoutSnackBar -> event.consume { showTimedOutSnackBar(activity) }
-            state is ControllerState.ShowAlreadyInCvSnackBar -> event.consume { showAlreadyInCvSnackBar(activity) }
             //Ensure this state remains unconsumed until the opening of the WebBrowserActivity.
             state is ControllerState.OpenWebBrowserScreen -> openWebBrowser(activity, state.title, state.url)
             state is ControllerState.DisplayVisitorCodeDialog -> displayVisitorCodeDialog(activity)
@@ -96,8 +95,6 @@ internal class CallVisualizerActivityWatcher(
     }
 
     private fun showTimedOutSnackBar(activity: Activity) = showSnackBar(activity, R.string.engagement_incoming_request_timed_out_message)
-
-    private fun showAlreadyInCvSnackBar(activity: Activity) = showSnackBar(activity, R.string.entry_widget_call_visualizer_description)
 
     private fun showSnackBar(activity: Activity, @StringRes messageRes: Int) = SnackBarDelegateFactory(
         activity,

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -27,7 +27,6 @@ internal interface CallVisualizerContract {
         data class DisplayConfirmationDialog(val links: ConfirmationDialogLinks) : State
         data object DismissDialog : State
         data object ShowTimeoutSnackBar : State
-        data object ShowAlreadyInCvSnackBar : State
         data object CloseHolderActivity : State
         data class OpenWebBrowserScreen(val title: LocaleString, val url: String) : State
     }
@@ -44,7 +43,6 @@ internal interface CallVisualizerContract {
         fun onLinkClicked(link: Link)
         fun dismissVisitorCodeDialog()
         fun onWebBrowserOpened()
-        fun showAlreadyInCvSnackBar()
     }
 }
 
@@ -142,10 +140,6 @@ internal class CallVisualizerController(
 
     override fun onWebBrowserOpened() {
         dialogController.showCVEngagementConfirmationDialog()
-    }
-
-    override fun showAlreadyInCvSnackBar() {
-        _state.onNext(CallVisualizerContract.State.ShowAlreadyInCvSnackBar)
     }
 
     private fun closeHolderActivity() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -40,8 +40,10 @@ import com.glia.widgets.view.head.controller.ActivityWatcherForChatHeadContract;
 import com.glia.widgets.view.head.controller.ActivityWatcherForChatHeadController;
 import com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController;
 import com.glia.widgets.view.head.controller.ServiceChatHeadController;
-import com.glia.widgets.view.snackbar.ActivityWatcherForLiveObservationContract;
-import com.glia.widgets.view.snackbar.ActivityWatcherForLiveObservationController;
+import com.glia.widgets.view.snackbar.liveobservation.ActivityWatcherForLiveObservationContract;
+import com.glia.widgets.view.snackbar.liveobservation.ActivityWatcherForLiveObservationController;
+import com.glia.widgets.view.snackbar.SnackbarContract;
+import com.glia.widgets.view.snackbar.SnackbarController;
 
 /**
  * @hide
@@ -68,6 +70,7 @@ public class ControllerFactory {
     private ActivityWatcherForChatHeadController activityWatcherForChatHeadController;
     private ActivityWatcherForLiveObservationController activityWatcherForLiveObservationController;
     private EntryWidgetHideController entryWidgetHideController;
+    private SnackbarController snackbarController;
 
     public ControllerFactory(
         RepositoryFactory repositoryFactory,
@@ -408,5 +411,12 @@ public class ControllerFactory {
             entryWidgetHideController = new EntryWidgetHideController();
         }
         return entryWidgetHideController;
+    }
+
+    public SnackbarContract.Controller getSnackbarController() {
+        if (snackbarController == null) {
+            snackbarController = new SnackbarController();
+        }
+        return snackbarController;
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -40,7 +40,8 @@ import com.glia.widgets.operator.OperatorRequestActivityWatcher
 import com.glia.widgets.permissions.ActivityWatcherForPermissionsRequest
 import com.glia.widgets.view.head.ActivityWatcherForChatHead
 import com.glia.widgets.view.head.ChatHeadContract
-import com.glia.widgets.view.snackbar.ActivityWatcherForLiveObservation
+import com.glia.widgets.view.snackbar.liveobservation.ActivityWatcherForLiveObservation
+import com.glia.widgets.view.snackbar.ActivityWatcherForSnackbar
 import com.glia.widgets.view.unifiedui.theme.UnifiedThemeManager
 
 
@@ -85,14 +86,11 @@ internal object Dependencies {
     val engagementLauncher: EngagementLauncher by lazy {
         EngagementLauncherImpl(
             activityLauncher = activityLauncher,
+            configurationManager = configurationManager,
+            snackbarController = controllerFactory.snackbarController,
             hasOngoingSecureConversationUseCase = useCaseFactory.hasPendingSecureConversationsWithTimeoutUseCase,
             isQueueingOrLiveEngagementUseCase = useCaseFactory.isQueueingOrEngagementUseCase,
-            endEngagementUseCase = useCaseFactory.endEngagementUseCase,
-            configurationManager = configurationManager,
-            engagementTypeUseCase = useCaseFactory.engagementTypeUseCase,
-            callVisualizerController = controllerFactory.callVisualizerController,
-            destroyChatController = controllerFactory::destroyChatController,
-            destroyCallController = controllerFactory::destroyCallController
+            engagementTypeUseCase = useCaseFactory.engagementTypeUseCase
         )
     }
 
@@ -199,6 +197,14 @@ internal object Dependencies {
             GliaActivityManagerImpl()
         )
         application.registerActivityLifecycleCallbacks(operatorRequestActivityWatcher)
+
+        val activityWatcherForSnackbar = ActivityWatcherForSnackbar(
+            controllerFactory.snackbarController,
+            GliaActivityManagerImpl(),
+            localeProvider,
+            gliaThemeManager
+        )
+        application.registerActivityLifecycleCallbacks(activityWatcherForSnackbar)
     }
 
     @JvmStatic

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -186,7 +186,7 @@ import com.glia.widgets.launcher.ConfigurationManager;
 import com.glia.widgets.locale.LocaleProvider;
 import com.glia.widgets.push.notifications.IsPushNotificationsSetUpUseCase;
 import com.glia.widgets.push.notifications.IsPushNotificationsSetUpUseCaseImpl;
-import com.glia.widgets.view.snackbar.LiveObservationPopupUseCase;
+import com.glia.widgets.view.snackbar.liveobservation.LiveObservationPopupUseCase;
 import com.glia.widgets.webbrowser.domain.GetUrlFromLinkUseCase;
 import com.glia.widgets.webbrowser.domain.GetUrlFromLinkUseCaseImpl;
 import com.google.gson.Gson;

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/ActivityWatcherForSnackbar.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/ActivityWatcherForSnackbar.kt
@@ -1,0 +1,48 @@
+package com.glia.widgets.view.snackbar
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import androidx.annotation.StringRes
+import com.glia.widgets.base.BaseSingleActivityWatcher
+import com.glia.widgets.helper.GliaActivityManager
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.OneTimeEvent
+import com.glia.widgets.helper.TAG
+import com.glia.widgets.locale.LocaleProvider
+import com.glia.widgets.view.unifiedui.theme.UnifiedThemeManager
+import io.reactivex.rxjava3.core.Flowable
+import java.lang.ref.WeakReference
+
+@SuppressLint("CheckResult")
+internal class ActivityWatcherForSnackbar(
+    controller: SnackbarContract.Controller,
+    gliaActivityManager: GliaActivityManager,
+    private val localeProvider: LocaleProvider,
+    private val themeManager: UnifiedThemeManager,
+) : BaseSingleActivityWatcher(gliaActivityManager) {
+
+    init {
+        Flowable.combineLatest(resumedActivity, controller.state, ::handleState).subscribe()
+    }
+
+    private fun handleState(
+        activityReference: WeakReference<Activity>,
+        event: OneTimeEvent<SnackbarContract.State>
+    ) {
+        val state = event.value
+        val activity = activityReference.get()
+
+        when {
+            event.consumed -> Logger.d(TAG, "Skipping. Activity is null or finishing.")
+            activity == null || activity.isFinishing -> Logger.d(TAG, "Skipping. Activity is null or finishing.")
+            state is SnackbarContract.State.ShowSnackBar -> event.consume { showSnackBar(activity, state.message) }
+        }
+    }
+
+    private fun showSnackBar(activity: Activity, @StringRes messageRes: Int) = SnackBarDelegateFactory(
+        activity,
+        messageRes,
+        localeProvider,
+        themeManager.theme
+    ).createDelegate().show()
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/SnackbarController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/SnackbarController.kt
@@ -1,0 +1,31 @@
+package com.glia.widgets.view.snackbar
+
+import androidx.annotation.StringRes
+import com.glia.widgets.helper.OneTimeEvent
+import com.glia.widgets.helper.asOneTimeStateFlowable
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.processors.PublishProcessor
+
+internal interface SnackbarContract {
+
+    sealed interface State {
+        data class ShowSnackBar(@StringRes val message: Int) : State
+    }
+
+    interface Controller {
+        val state: Flowable<OneTimeEvent<State>>
+
+        fun showSnackBar(@StringRes  message: Int)
+    }
+}
+
+internal class SnackbarController() : SnackbarContract.Controller {
+
+    private val _state: PublishProcessor<SnackbarContract.State> = PublishProcessor.create()
+    override val state: Flowable<OneTimeEvent<SnackbarContract.State>> = _state.asOneTimeStateFlowable()
+
+    override fun showSnackBar(@StringRes message: Int) {
+        _state.onNext(SnackbarContract.State.ShowSnackBar(message))
+    }
+}
+

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/ActivityWatcherForLiveObservation.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/ActivityWatcherForLiveObservation.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.view.snackbar
+package com.glia.widgets.view.snackbar.liveobservation
 
 import android.annotation.SuppressLint
 import android.app.Activity
@@ -8,6 +8,8 @@ import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.WeakReferenceDelegate
 import com.glia.widgets.locale.LocaleProvider
+import com.glia.widgets.view.snackbar.SnackBarDelegate
+import com.glia.widgets.view.snackbar.SnackBarDelegateFactory
 import com.glia.widgets.view.unifiedui.theme.UnifiedThemeManager
 
 @SuppressLint("CheckResult")

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/ActivityWatcherForLiveObservationContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/ActivityWatcherForLiveObservationContract.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.view.snackbar
+package com.glia.widgets.view.snackbar.liveobservation
 
 internal interface ActivityWatcherForLiveObservationContract {
     interface Controller {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/ActivityWatcherForLiveObservationController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/ActivityWatcherForLiveObservationController.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.view.snackbar
+package com.glia.widgets.view.snackbar.liveobservation
 
 import android.annotation.SuppressLint
 import com.glia.widgets.engagement.State

--- a/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/LiveObservationPopupUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/snackbar/liveobservation/LiveObservationPopupUseCase.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.view.snackbar
+package com.glia.widgets.view.snackbar.liveobservation
 
 import com.glia.widgets.chat.domain.SiteInfoUseCase
 import io.reactivex.rxjava3.core.Single

--- a/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/callvisualizer/controller/CallVisualizerControllerTest.kt
@@ -210,15 +210,6 @@ class CallVisualizerControllerTest {
     }
 
     @Test
-    fun `showAlreadyInCallSnackBar will show snackBar`() {
-        val testState = controller.state.test()
-
-        controller.showAlreadyInCvSnackBar()
-
-        testState.assertNotComplete().assertValue { it.value is CallVisualizerContract.State.ShowAlreadyInCvSnackBar }
-    }
-
-    @Test
     fun `onWebBrowserOpened will request to show CV Confirmation Dialog`() {
         controller.onWebBrowserOpened()
 

--- a/widgetssdk/src/test/java/com/glia/widgets/view/snackbar/liveobservation/LiveObservationPopupUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/snackbar/liveobservation/LiveObservationPopupUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.glia.widgets.view.snackbar
+package com.glia.widgets.view.snackbar.liveobservation
 
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback


### PR DESCRIPTION
**Jira issue:**
[[Android] Devs want to adjust the EngagementLauncher logic according to the diagram](https://glia.atlassian.net/browse/MOB-3969)

**What was solved?**
1. Adjusted the EngagementLauncher logic according to the [diagram](https://www.figma.com/board/XAwLSPaSzcaIv6BLTdgzXc/Mobile-Secure-Conversations-Flows?node-id=496-1078&t=PJqOvL8a8xQA6R5t-1).
2. Extracted Snackbar functionality from Call Visualizer to an app level. Decided to leave current Snackbar usages intact.
3. Moved Live Observation snackbar classes to a separate sub-directory of `snackbar` package (separate commit for easier review).
4. Revisited the unit tests (separate commit for easier review).

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

