### PR TITLE
Fix chat screen is getting stuck after Visitor ends engagement

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcher.kt
@@ -76,7 +76,10 @@ internal class EngagementCompletionActivityWatcher(
         if (actionOnEnd == Engagement.ActionOnEnd.UNKNOWN) {
             Logger.w(TAG, "Engagement ended with unknown case.")
         }
-        if (isEndedByVisitor || actionOnEnd == Engagement.ActionOnEnd.RETAIN || actionOnEnd == Engagement.ActionOnEnd.SHOW_SURVEY) {
+        if (isEndedByVisitor) {
+            finishActivities()
+            onEventHandled()
+        } else if (actionOnEnd == Engagement.ActionOnEnd.RETAIN || actionOnEnd == Engagement.ActionOnEnd.SHOW_SURVEY) {
             onEventHandled()
         } else if (actionOnEnd == Engagement.ActionOnEnd.END_NOTIFICATION || actionOnEnd == Engagement.ActionOnEnd.UNKNOWN) {
             showOperatorEndedEngagementDialog(activity, onEventHandled)

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcher.kt
@@ -76,13 +76,17 @@ internal class EngagementCompletionActivityWatcher(
         if (actionOnEnd == Engagement.ActionOnEnd.UNKNOWN) {
             Logger.w(TAG, "Engagement ended with unknown case.")
         }
-        if (isEndedByVisitor) {
-            finishActivities()
-            onEventHandled()
-        } else if (actionOnEnd == Engagement.ActionOnEnd.RETAIN || actionOnEnd == Engagement.ActionOnEnd.SHOW_SURVEY) {
-            onEventHandled()
-        } else if (actionOnEnd == Engagement.ActionOnEnd.END_NOTIFICATION || actionOnEnd == Engagement.ActionOnEnd.UNKNOWN) {
-            showOperatorEndedEngagementDialog(activity, onEventHandled)
+        when {
+            isEndedByVisitor || isCallVisualizer -> {
+                finishActivities()
+                onEventHandled()
+            }
+            actionOnEnd == Engagement.ActionOnEnd.RETAIN || actionOnEnd == Engagement.ActionOnEnd.SHOW_SURVEY -> {
+                onEventHandled()
+            }
+            actionOnEnd == Engagement.ActionOnEnd.END_NOTIFICATION || actionOnEnd == Engagement.ActionOnEnd.UNKNOWN -> {
+                showOperatorEndedEngagementDialog(activity, onEventHandled)
+            }
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionController.kt
@@ -40,7 +40,7 @@ internal class EngagementCompletionController(
                     // Even though we need to retain the chat screen we still need to reset view states and controllers and later setup them again
                     releaseResourcesUseCase()
                 }
-                _state.onNext(EngagementCompletionState.EngagementEnded(state.isEndedByVisitor, state.onEnd))
+                _state.onNext(EngagementCompletionState.EngagementEnded(state.isEndedByVisitor, state.isCallVisualizer, state.onEnd))
             }
 
             State.QueueUnstaffed -> {

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionState.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionState.kt
@@ -6,6 +6,6 @@ import com.glia.androidsdk.engagement.Survey
 internal sealed interface EngagementCompletionState {
     data object QueueUnstaffed : EngagementCompletionState
     data object UnexpectedErrorHappened : EngagementCompletionState
-    data class EngagementEnded(val isEndedByVisitor: Boolean, val actionOnEnd: ActionOnEnd) : EngagementCompletionState
+    data class EngagementEnded(val isEndedByVisitor: Boolean, val isCallVisualizer: Boolean, val actionOnEnd: ActionOnEnd) : EngagementCompletionState
     data class SurveyLoaded(val survey: Survey) : EngagementCompletionState
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionActivityWatcherTest.kt
@@ -86,7 +86,7 @@ class EngagementCompletionActivityWatcherTest {
         Logger.setIsDebug(false)
         every { Logger.d(any(), any()) } just Runs
 
-        val event = createMockEvent(EngagementCompletionState.EngagementEnded(true, Engagement.ActionOnEnd.END_NOTIFICATION))
+        val event = createMockEvent(EngagementCompletionState.EngagementEnded(true, false, Engagement.ActionOnEnd.END_NOTIFICATION))
         every { event.consumed } returns true
 
         val activity = mockkActivity<Activity>()
@@ -113,7 +113,7 @@ class EngagementCompletionActivityWatcherTest {
 
     @Test
     fun `handleState will finish activities when state is EngagementEnded even if activity is null or finishing`() {
-        val event = createMockEvent(EngagementCompletionState.EngagementEnded(true, Engagement.ActionOnEnd.END_NOTIFICATION))
+        val event = createMockEvent(EngagementCompletionState.EngagementEnded(true, false, Engagement.ActionOnEnd.END_NOTIFICATION))
         val activity = mockkActivity<Activity>()
 
         every { activity.isFinishing } returns true
@@ -244,7 +244,7 @@ class EngagementCompletionActivityWatcherTest {
 
     @Test
     fun `handleState will show operator ended engagement dialog when event is ActionOnEnd is END_NOTIFICATION`() {
-        val event = createMockEvent(EngagementCompletionState.EngagementEnded(false, Engagement.ActionOnEnd.END_NOTIFICATION))
+        val event = createMockEvent(EngagementCompletionState.EngagementEnded(false, false, Engagement.ActionOnEnd.END_NOTIFICATION))
 
         val activity = mockkActivity<ChatActivity>()
 

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/completion/EngagementCompletionControllerTest.kt
@@ -60,7 +60,7 @@ class EngagementCompletionControllerTest {
         engagementStateProcessor.onNext(State.EngagementEnded(EngagementType.CallVisualizer, true, Engagement.ActionOnEnd.UNKNOWN))
 
         verify { releaseResourcesUseCase() }
-        assertEquals(EngagementCompletionState.EngagementEnded(true, Engagement.ActionOnEnd.UNKNOWN), controller.state.blockingFirst().value)
+        assertEquals(EngagementCompletionState.EngagementEnded(true, true, Engagement.ActionOnEnd.UNKNOWN), controller.state.blockingFirst().value)
     }
 
     @Test
@@ -68,7 +68,7 @@ class EngagementCompletionControllerTest {
         engagementStateProcessor.onNext(State.EngagementEnded(EngagementType.OmniCore, true, Engagement.ActionOnEnd.UNKNOWN))
 
         verify { releaseResourcesUseCase() }
-        assertEquals(EngagementCompletionState.EngagementEnded(true, Engagement.ActionOnEnd.UNKNOWN), controller.state.blockingFirst().value)
+        assertEquals(EngagementCompletionState.EngagementEnded(true, false, Engagement.ActionOnEnd.UNKNOWN), controller.state.blockingFirst().value)
     }
 
     @Test
@@ -121,7 +121,7 @@ class EngagementCompletionControllerTest {
 
         verify { releaseResourcesUseCase() }
 
-        testState.assertValues(EngagementCompletionState.EngagementEnded(false, Engagement.ActionOnEnd.UNKNOWN))
+        testState.assertValues(EngagementCompletionState.EngagementEnded(false, false, Engagement.ActionOnEnd.UNKNOWN))
     }
 
     @Test


### PR DESCRIPTION


**Jira issue:**
https://glia.atlassian.net/browse/MOB-3975

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
