### PR TITLE
Fix the auto updating entry widget fails after being on background

### DIFF
--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <queries>
         <intent>
@@ -22,6 +23,7 @@
         </intent>
     </queries>
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
@@ -88,7 +90,8 @@
         <service
             android:name=".core.screensharing.MediaProjectionService"
             android:exported="false"
-            android:foregroundServiceType="mediaProjection" />
+            android:foregroundServiceType="mediaProjection"
+            tools:targetApi="o" />
 
         <service android:name=".core.notification.NotificationRemovalService" />
 

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -24,6 +24,7 @@ import com.glia.widgets.entrywidget.EntryWidget
 import com.glia.widgets.entrywidget.EntryWidgetImpl
 import com.glia.widgets.filepreview.data.source.local.DownloadsFolderDataSource
 import com.glia.widgets.helper.ApplicationLifecycleManager
+import com.glia.widgets.helper.DeviceMonitor
 import com.glia.widgets.helper.GliaActivityManagerImpl
 import com.glia.widgets.helper.IntentHelperImpl
 import com.glia.widgets.helper.ResourceProvider
@@ -113,7 +114,8 @@ internal object Dependencies {
         localeProvider = LocaleProvider(resourceProvider)
         notificationManager = NotificationManager(application)
         val downloadsFolderDataSource = DownloadsFolderDataSource(application)
-        repositoryFactory = RepositoryFactory(gliaCore, downloadsFolderDataSource, configurationManager)
+        val deviceMonitor = DeviceMonitor(application)
+        repositoryFactory = RepositoryFactory(gliaCore, downloadsFolderDataSource, configurationManager, deviceMonitor)
 
         val permissionManager = PermissionManager(
             application,

--- a/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java
@@ -19,6 +19,7 @@ import com.glia.widgets.filepreview.data.GliaFileRepository;
 import com.glia.widgets.filepreview.data.GliaFileRepositoryImpl;
 import com.glia.widgets.filepreview.data.source.local.DownloadsFolderDataSource;
 import com.glia.widgets.filepreview.data.source.local.InAppBitmapCache;
+import com.glia.widgets.helper.DeviceMonitor;
 import com.glia.widgets.launcher.ConfigurationManager;
 import com.glia.widgets.permissions.PermissionsRequestRepository;
 
@@ -37,17 +38,20 @@ public class RepositoryFactory {
     private final GliaCore gliaCore;
     private final DownloadsFolderDataSource downloadsFolderDataSource;
     private final ConfigurationManager configurationManager;
+    private final DeviceMonitor deviceMonitor;
     private ChatScreenRepository chatScreenRepository;
     private EngagementRepository engagementRepository;
 
     public RepositoryFactory(
         GliaCore gliaCore,
         DownloadsFolderDataSource downloadsFolderDataSource,
-        ConfigurationManager configurationManager
+        ConfigurationManager configurationManager,
+        DeviceMonitor deviceMonitor
     ) {
         this.downloadsFolderDataSource = downloadsFolderDataSource;
         this.gliaCore = gliaCore;
         this.configurationManager = configurationManager;
+        this.deviceMonitor = deviceMonitor;
     }
 
     public void initialize() {
@@ -61,7 +65,7 @@ public class RepositoryFactory {
 
     public QueueRepository getQueueRepository() {
         if (queueRepository == null) {
-            queueRepository = new QueueRepositoryImpl(gliaCore, configurationManager);
+            queueRepository = new QueueRepositoryImpl(gliaCore, configurationManager, deviceMonitor);
         }
         return queueRepository;
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/DeviceMonitor.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/DeviceMonitor.kt
@@ -1,0 +1,99 @@
+package com.glia.widgets.helper
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import androidx.core.content.getSystemService
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.processors.BehaviorProcessor
+
+internal enum class NetworkState {
+    CONNECTED,
+    DISCONNECTED;
+
+    companion object {
+        fun from(isConnected: Boolean): NetworkState = if (isConnected) CONNECTED else DISCONNECTED
+    }
+}
+
+internal enum class DeviceState {
+    // when the user is present after device wakes up (e.g when the keyguard is gone).
+    USER_PRESENT,
+
+    // when the device is interactive and the screen is on.
+    // Device can still be locked.
+    INTERACTIVE,
+
+    // when the device is not interactive and the screen is off.
+    NON_INTERACTIVE
+}
+
+internal class DeviceMonitor(context: Context) : ConnectivityManager.NetworkCallback() {
+
+    private val connectivityManager = context.getSystemService<ConnectivityManager>()
+    private val networkCapabilities: NetworkCapabilities? get() = connectivityManager?.run { getNetworkCapabilities(activeNetwork) }
+    private val isConnected: Boolean get() = networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+
+    private val _networkState: BehaviorProcessor<NetworkState> = BehaviorProcessor.createDefault(NetworkState.from(isConnected))
+    val networkState: Flowable<NetworkState> = _networkState.distinctUntilChanged().hide()
+
+    private val _deviceState: BehaviorProcessor<DeviceState> = BehaviorProcessor.createDefault(DeviceState.USER_PRESENT)
+    val deviceState: Flowable<DeviceState> = _deviceState.distinctUntilChanged().hide()
+
+    private val userPresentReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == Intent.ACTION_USER_PRESENT) {
+                _deviceState.onNext(DeviceState.USER_PRESENT)
+            }
+        }
+    }
+
+    private val screenOnReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == Intent.ACTION_SCREEN_ON) {
+                _deviceState.onNext(DeviceState.INTERACTIVE)
+            }
+        }
+    }
+
+    private val screenOffReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == Intent.ACTION_SCREEN_OFF) {
+                _deviceState.onNext(DeviceState.NON_INTERACTIVE)
+            }
+        }
+    }
+
+    init {
+        // Listen for all network changes (Wi-Fi, Cellular, etc.).
+        val networkRequest = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        connectivityManager?.registerNetworkCallback(networkRequest, this)
+
+        context.registerReceiver(userPresentReceiver, IntentFilter(Intent.ACTION_USER_PRESENT))
+        context.registerReceiver(screenOnReceiver, IntentFilter(Intent.ACTION_SCREEN_ON))
+        context.registerReceiver(screenOffReceiver, IntentFilter(Intent.ACTION_SCREEN_OFF))
+    }
+
+    override fun onAvailable(network: Network) {
+        super.onAvailable(network)
+        _networkState.onNext(NetworkState.from(isConnected))
+    }
+
+    override fun onLost(network: Network) {
+        super.onLost(network)
+        _networkState.onNext(NetworkState.from(isConnected))
+    }
+
+    override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+        super.onCapabilitiesChanged(network, networkCapabilities)
+        _networkState.onNext(NetworkState.from(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)))
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4052

**What was solved?**
Added monitoring for internet connection and device unlock.
The queue repository will re-fetch queues each time the device is unlocked or the internet connection is restored.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
