### PR TITLE
Show unread message badge if visitor is on non-Glia screen, engagement starts and bubble is shown

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/MessagesNotSeenHandler.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/MessagesNotSeenHandler.java
@@ -30,6 +30,7 @@ public class MessagesNotSeenHandler {
     public void init() {
         Logger.d(TAG, "init");
         gliaOnMessageUseCase.invoke().doOnNext(this::onMessage).subscribe();
+        isCounting = true;
     }
 
     public void chatOnBackClicked() {

--- a/widgetssdk/src/test/java/com/glia/widgets/view/MessagesNotSeenHandlerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/MessagesNotSeenHandlerTest.kt
@@ -1,0 +1,75 @@
+package com.glia.widgets.view
+
+import com.glia.widgets.chat.domain.GliaOnMessageUseCase
+import com.glia.widgets.core.engagement.domain.model.ChatMessageInternal
+import com.glia.widgets.helper.Logger
+import io.mockk.*
+import io.reactivex.rxjava3.core.Observable
+import org.junit.Before
+import org.junit.Test
+
+class MessagesNotSeenHandlerTest {
+
+    private lateinit var gliaOnMessageUseCase: GliaOnMessageUseCase
+    private lateinit var messagesNotSeenHandlerListener: MessagesNotSeenHandler.MessagesNotSeenHandlerListener
+    private lateinit var messagesNotSeenHandler: MessagesNotSeenHandler
+
+    @Before
+    fun setUp() {
+        Logger.setIsDebug(false)
+        gliaOnMessageUseCase = mockk()
+        messagesNotSeenHandlerListener = mockk(relaxed = true)
+        messagesNotSeenHandler = MessagesNotSeenHandler(gliaOnMessageUseCase)
+        messagesNotSeenHandler.addListener(messagesNotSeenHandlerListener)
+    }
+
+    @Test
+    fun `init invokes gliaOnMessageUseCase`() {
+        every { gliaOnMessageUseCase.invoke() } returns Observable.empty()
+        messagesNotSeenHandler.init()
+        verify { gliaOnMessageUseCase.invoke() }
+    }
+
+    @Test
+    fun `chatOnBackClicked invokes onNewCount with zero`() {
+        messagesNotSeenHandler.chatOnBackClicked()
+        verify { messagesNotSeenHandlerListener.onNewCount(0) }
+    }
+
+    @Test
+    fun `callChatButtonClicked triggers onNewCount with zero`() {
+        messagesNotSeenHandler.callChatButtonClicked()
+        verify { messagesNotSeenHandlerListener.onNewCount(0) }
+    }
+
+    @Test
+    fun `chatUpgradeOfferAccepted triggers onNewCount with zero`() {
+        messagesNotSeenHandler.chatUpgradeOfferAccepted()
+        verify { messagesNotSeenHandlerListener.onNewCount(0) }
+    }
+
+    @Test
+    fun `addListener triggers onNewCount with zero`() {
+        messagesNotSeenHandler.addListener(messagesNotSeenHandlerListener)
+        verify { messagesNotSeenHandlerListener.onNewCount(0) }
+    }
+
+    @Test
+    fun `onMessage triggers onNewCount after init`() {
+        val message = mockk<ChatMessageInternal>()
+        every { message.isNotVisitor } returns true
+        every { message.chatMessage.id } returns "1"
+        every { gliaOnMessageUseCase.invoke() } returns Observable.empty()
+
+        messagesNotSeenHandler.init()
+        messagesNotSeenHandler.onMessage(message)
+
+        verify { messagesNotSeenHandlerListener.onNewCount(1) }
+    }
+
+    @Test
+    fun `onDestroy triggers onNewCount when called`() {
+        messagesNotSeenHandler.onDestroy()
+        verify { messagesNotSeenHandlerListener.onNewCount(0) }
+    }
+}


### PR DESCRIPTION
**Jira issue:**
[[Android] Unread message count is NOT displayed on bubble in a specific test case](https://glia.atlassian.net/browse/MOB-4055)

**What was solved?**
Test case:
1. Authenticate
2. Open secure conversations and send a message
3. Close Glia SDK, return to integrator app and authenticate
4. Operator picks up (bubble is shown)
5. Operator sends a message

Actual result without these changes: unread message badge IS NOT SHOWN on bubble
Actual result with the changes: unread message badge IS SHOWN on bubble

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

