### PR TITLE
Fix Empty State Screen is shown instead of Error State Screen

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -54,8 +54,8 @@ internal class EntryWidgetController @JvmOverloads constructor(
         listOf(EntryWidgetContract.ItemType.EmptyState)
     }
 
-    private val errorState: List<EntryWidgetContract.ItemType.EmptyState> by lazy {
-        listOf(EntryWidgetContract.ItemType.EmptyState)
+    private val errorState: List<EntryWidgetContract.ItemType.ErrorState> by lazy {
+        listOf(EntryWidgetContract.ItemType.ErrorState)
     }
 
     private val messagingChatObservableItemType: Flowable<List<EntryWidgetContract.ItemType>>

--- a/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
@@ -53,7 +53,7 @@ class EntryWidgetControllerTest {
     }
 
     private val errorState by lazy {
-        listOf(EntryWidgetContract.ItemType.EmptyState)
+        listOf(EntryWidgetContract.ItemType.ErrorState)
     }
 
     private val sdkNotInitializedState by lazy {
@@ -412,7 +412,7 @@ class EntryWidgetControllerTest {
 
         controller.setView(view, EntryWidgetContract.ViewType.EMBEDDED_VIEW)
 
-        verify { view.showItems(emptyState) }
+        verify { view.showItems(errorState) }
         verify { queueRepository.queuesState }
         verify { secureConversationsRepository.unreadMessagesCountObservable }
         verify { hasOngoingSecureConversationUseCase.invoke() }
@@ -430,7 +430,7 @@ class EntryWidgetControllerTest {
 
         controller.setView(view, EntryWidgetContract.ViewType.EMBEDDED_VIEW)
 
-        verify { view.showItems(emptyState + poweredByItem) }
+        verify { view.showItems(errorState + poweredByItem) }
         verify { queueRepository.queuesState }
         verify { secureConversationsRepository.unreadMessagesCountObservable }
         verify { hasOngoingSecureConversationUseCase.invoke() }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4057

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
