### PR TITLE
Operator typing status remains after engagement ended

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -207,6 +207,7 @@ internal class EngagementRepositoryImpl(
         _visitorMediaState.onNext(Data.Empty)
         _currentOperator.onNext(Data.Empty)
         _onHoldState.onNext(false)
+        _operatorTypingStatus.onNext(false)
         markScreenSharingEnded()
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
@@ -614,9 +614,13 @@ class EngagementRepositoryTest {
 
     @Test
     fun `endEngagement() will emit EngagementEnded state`() {
+        val operatorTypingStatusTestObserver = repository.operatorTypingStatus.test()
         mockEngagementAndStart()
         fillStates()
+        operatorTypingCallbackSlot.captured.accept(OperatorTypingStatus { true })
         repository.endEngagement(EndedBy.CLEAR_STATE)
+        operatorTypingStatusTestObserver.assertNotComplete().assertValues(true, false)
+
         verifyEngagementEnd()
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4060

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
