### PR TITLE
Remove deprecated setUseOverlay interface

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -206,19 +206,6 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
         }
 
         /**
-         * @param useOverlay - is it allowed to overlay the application
-         * @return Builder instance
-         * @deprecated Use [GliaWidgetsConfig.enableBubbleOutsideApp] and [GliaWidgetsConfig.enableBubbleInsideApp]
-         */
-        @Deprecated("Please use GliaWidgetsConfig.enableBubbleOutsideApp and GliaWidgetsConfig.enableBubbleInsideApp")
-        fun setUseOverlay(useOverlay: Boolean): Builder {
-            Logger.logDeprecatedMethodUse(TAG, "GliaWidgetsConfig.setUseOverlay()")
-            this.enableBubbleOutsideApp = useOverlay
-            this.enableBubbleInsideApp = useOverlay
-            return this
-        }
-
-        /**
          * @param enableBubbleOutsideApp - is bubble enabled outside the app
          * @return Builder instance
          */


### PR DESCRIPTION
**Jira issue:**
- [MOB-3003](https://glia.atlassian.net/browse/MOB-3003)
- [MOB-3281](https://glia.atlassian.net/browse/MOB-3281)

**What was solved?**
- Remove deprecated setUseOverlay interface. We have it mentioned in Widgets SDK 3.0.0 migration guide

**Release notes:**
It's already there. But I'll ask tech the writer to add to the table a new interface that should be used instead.

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-3003]: https://glia.atlassian.net/browse/MOB-3003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-3281]: https://glia.atlassian.net/browse/MOB-3281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ