### PR TITLE
Fix ConcurrentModificationException in GliaOperatorRepository

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaOperatorRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/GliaOperatorRepository.kt
@@ -25,7 +25,10 @@ internal class GliaOperatorRepositoryImpl(private val gliaCore: GliaCore) : Glia
     var isAlwaysUseDefaultOperatorPicture: Boolean = false
 
     override fun getOperatorById(operatorId: String, callback: Consumer<LocalOperator?>) {
-        val cachedOperator = cachedOperators[operatorId]
+        val cachedOperator: LocalOperator?
+        synchronized(cachedOperators) {
+            cachedOperator = cachedOperators[operatorId]
+        }
         if (cachedOperator != null) {
             callback.accept(cachedOperator)
             return
@@ -49,7 +52,9 @@ internal class GliaOperatorRepositoryImpl(private val gliaCore: GliaCore) : Glia
 
     @VisibleForTesting
     fun putOperator(operator: LocalOperator) {
-        operator.apply { cachedOperators.put(id, this) }
+        synchronized(cachedOperators) {
+            operator.apply { cachedOperators.put(id, this) }
+        }
     }
 
     override fun updateOperatorDefaultImageUrl(imageUrl: String?) {


### PR DESCRIPTION
**What was solved?**
Fix ConcurrentModificationException in putOperator(GliaOperatorRepository.kt:52)

Crash log: https://glia.sentry.io/issues/6328957069/

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

