### PR TITLE
Fix IllegalStateException when starting NotificationRemovalService

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/notification/device/NotificationManager.kt
@@ -10,6 +10,8 @@ import com.glia.widgets.R
 import com.glia.widgets.core.notification.NotificationFactory
 import com.glia.widgets.core.notification.NotificationRemovalService
 import com.glia.widgets.core.notification.areNotificationsEnabledForChannel
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
 
 internal class NotificationManager(private val applicationContext: Application) : INotificationManager {
     private val notificationManager: NotificationManager by lazy {
@@ -88,7 +90,12 @@ internal class NotificationManager(private val applicationContext: Application) 
     override fun startNotificationRemovalService() {
         // If this service is not already running, it will be instantiated and started (creating a process for it if needed);
         // if it is running then it remains running.
-        applicationContext.startService(Intent(applicationContext, NotificationRemovalService::class.java))
+        try {
+            applicationContext.startService(Intent(applicationContext, NotificationRemovalService::class.java))
+        } catch (error: Throwable) {
+            // Above code is known to throw an error if app is in background
+            Logger.e(TAG, "Failed to launch 'NotificationRemovalService'", error)
+        }
     }
 
     override fun removeCallNotification() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -252,13 +252,17 @@ internal object Dependencies {
         chatBubbleController: ChatHeadContract.Controller
     ) {
         lifecycleManager.addObserver { _, event: Lifecycle.Event ->
-            if (event == Lifecycle.Event.ON_STOP) {
-                chatBubbleController.onApplicationStop()
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && Glia.isInitialized()) {
-                    notificationManager.startNotificationRemovalService()
+            when(event) {
+                Lifecycle.Event.ON_PAUSE -> {
+                    // Moved to on pause due to "IllegalStateException: Not allowed to start service app is in background"
+                    // Related bug ticket MOB-4011
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && Glia.isInitialized()) {
+                        notificationManager.startNotificationRemovalService()
+                    }
                 }
-            } else if (event == Lifecycle.Event.ON_DESTROY) {
-                chatBubbleController.onDestroy()
+                Lifecycle.Event.ON_STOP -> chatBubbleController.onApplicationStop()
+                Lifecycle.Event.ON_DESTROY -> chatBubbleController.onDestroy()
+                else -> { /* no-op */ }
             }
         }
     }


### PR DESCRIPTION




**Jira issue:**
https://glia.atlassian.net/browse/MOB-4011

**What was solved?**

We were not able to reproduce the issue which was reported by the client. However, theoretically Lifecycle.Event.ON_STOP might be called when the app is in the background causing the error 'IllegalStateException: Not allowed to start service app is in the background' but in case of Lifecycle.Event.ON_PAUSE app can't be in the background state.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes: bug reported by client: SSD-50160
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [x] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
