### PR TITLE
Do not call Core SDK onAppCreate() method

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,5 +54,10 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_notification" />
+
+        <provider
+            android:name=".InitializationProvider"
+            android:authorities="${applicationId}.InitializationProvider"
+            android:exported="false"/>
     </application>
 </manifest>

--- a/app/src/main/java/com/glia/exampleapp/Application.java
+++ b/app/src/main/java/com/glia/exampleapp/Application.java
@@ -14,7 +14,6 @@ public class Application extends android.app.Application {
         super.onCreate();
         initFirebase();
 
-        GliaWidgets.onAppCreate(this);
         GliaWidgets.setCustomCardAdapter(new ExampleCustomCardAdapter());
     }
 

--- a/app/src/main/java/com/glia/exampleapp/InitializationProvider.kt
+++ b/app/src/main/java/com/glia/exampleapp/InitializationProvider.kt
@@ -1,0 +1,16 @@
+package com.glia.exampleapp
+
+import android.widget.Toast
+
+class InitializationProvider : com.glia.widgets.InitializationProvider() {
+    override fun onCreate(): Boolean {
+        val startTimestamp = System.currentTimeMillis()
+        super.onCreate()
+        val endTimestamp = System.currentTimeMillis()
+
+        context?.let {
+            Toast.makeText(it, "onAppCreate time is ${endTimestamp - startTimestamp} ms", Toast.LENGTH_LONG).show()
+        }
+        return true
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -44,7 +44,6 @@ public class GliaWidgets {
      * @param application the application where it is initialized
      */
     public synchronized static void onAppCreate(Application application) {
-        Dependencies.glia().onAppCreate(application);
         Dependencies.onAppCreate(application);
         setupRxErrorHandler();
         Logger.d(TAG, "onAppCreate");

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -47,9 +47,14 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
     val manualLocaleOverride: String?
 
     init {
+        // The Context can be an Activity that has its life cycle.
+        // To prevent storing the link to an Activity that can be destroyed, we need to take the Application Context.
+        // An Application object lives all the time when the application is active, so it is safe to store it.
+        val applicationContext = builder.context?.applicationContext
+
         siteApiKey = builder.siteApiKey
         siteId = builder.siteId
-        context = builder.context
+        context = applicationContext
         region = builder.region
         baseDomain = builder.baseDomain
         requestCode = builder.requestCode

--- a/widgetssdk/src/main/java/com/glia/widgets/InitializationProvider.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/InitializationProvider.kt
@@ -1,0 +1,56 @@
+package com.glia.widgets
+
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+/**
+ * @hide
+ */
+open class InitializationProvider : ContentProvider() {
+    override fun onCreate(): Boolean {
+        (context as? Application)?.let { GliaWidgets.onAppCreate(it) }
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? {
+        return null
+    }
+
+    override fun getType(uri: Uri): String? {
+        return null
+    }
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?
+    ): Uri? {
+        return null
+    }
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs:
+        Array<out String>?
+    ): Int {
+        return 0
+    }
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int {
+        return 0
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaConfig
+import com.glia.androidsdk.GliaException
 import com.glia.widgets.GliaWidgetsConfig
 import com.glia.widgets.StringProvider
 import com.glia.widgets.callvisualizer.CallVisualizerActivityWatcher
@@ -108,8 +109,13 @@ internal object Dependencies {
     lateinit var repositoryFactory: RepositoryFactory
         @VisibleForTesting set
 
+    @Synchronized
     @JvmStatic
     fun onAppCreate(application: Application) {
+        if (this::resourceProvider.isInitialized) {
+            return
+        }
+
         resourceProvider = ResourceProvider(application.baseContext)
         localeProvider = LocaleProvider(resourceProvider)
         notificationManager = NotificationManager(application)

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -33,8 +33,6 @@ internal interface GliaCore {
     val secureConversations: SecureConversations
     @Throws(GliaException::class)
     fun init(config: GliaConfig)
-    @Throws(GliaException::class)
-    fun onAppCreate(application: Application)
     fun getVisitorInfo(visitorCallback: RequestCallback<VisitorInfo?>)
     fun updateVisitorInfo(visitorInfoUpdateRequest: VisitorInfoUpdateRequest, visitorCallback: Consumer<GliaException?>)
     fun <T> on(event: OmnicoreEvent<T>, listener: Consumer<T>)

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -48,12 +48,6 @@ internal class GliaCoreImpl : GliaCore {
         Glia.init(config)
     }
 
-    @Synchronized
-    @Throws(GliaException::class)
-    override fun onAppCreate(application: Application) {
-        Glia.onAppCreate(application)
-    }
-
     override fun getVisitorInfo(visitorCallback: RequestCallback<VisitorInfo?>) {
         Glia.getVisitorInfo(visitorCallback)
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
@@ -21,11 +21,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @get:ClassRule
 val rule: TestRule = InstantTaskExecutorRule()
@@ -49,18 +47,14 @@ class GliaWidgetsTest {
     }
 
     @Test
-    fun onAppCreate_setApplicationToGliaCore_whenCalled() {
-        val application = RuntimeEnvironment.getApplication()
-        GliaWidgets.onAppCreate(application)
-        verify(gliaCore).onAppCreate(eq(application))
-    }
-
-    @Test
     fun onSdkInit_setConfigToGliaCore_whenCalled() {
         val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
         val siteId = "SiteId"
         val region = "Region"
+        val applicationContext = mock<Context>()
+        whenever(applicationContext.applicationContext).thenReturn(applicationContext)
         val context = mock<Context>()
+        whenever(context.applicationContext).thenReturn(applicationContext)
         val widgetsConfig = GliaWidgetsConfig.Builder()
             .setSiteApiKey(siteApiKey)
             .setSiteId(siteId)
@@ -83,7 +77,7 @@ class GliaWidgetsTest {
         Assert.assertEquals(siteApiKey, gliaConfig.siteApiKey)
         Assert.assertEquals(siteId, gliaConfig.siteId)
         Assert.assertEquals(region, gliaConfig.region)
-        Assert.assertEquals(context, gliaConfig.context)
+        Assert.assertEquals(applicationContext, gliaConfig.context)
     }
 
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4198

**What was solved?**
Widgets SDK doesn't call Core SDK `.onAppCreate()` method.
Added the `InitializationProvider`. The provider can be used to call `GliaWidgets.onAppCreate()`. A custom application class in the application or library is not necessary anymore.

**Release notes:**

 - [x] Feature
 - [?] Ignore
 - [?] Release notes (Is it clear from the description here?)
 - [?] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
