### PR TITLE
Add getVisitorInfo() and updateVisitorInfo() to Android Widgets SDK

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.java
@@ -10,11 +10,17 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.glia.androidsdk.GliaException;
+import com.glia.androidsdk.RequestCallback;
 import com.glia.androidsdk.visitor.Authentication;
+import com.glia.widgets.callbacks.OnError;
+import com.glia.widgets.callbacks.OnSuccess;
+import com.glia.widgets.callbacks.OnComplete;
 import com.glia.widgets.chat.adapter.CustomCardAdapter;
 import com.glia.widgets.chat.adapter.WebViewCardAdapter;
 import com.glia.widgets.core.authentication.AuthenticationManager;
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer;
+import com.glia.widgets.core.visitor.VisitorInfo;
+import com.glia.widgets.core.visitor.VisitorInfoUpdateRequest;
 import com.glia.widgets.di.Dependencies;
 import com.glia.widgets.engagement.EndedBy;
 import com.glia.widgets.entrywidget.EntryWidget;
@@ -23,6 +29,7 @@ import com.glia.widgets.launcher.EngagementLauncher;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Consumer;
 
 import io.reactivex.rxjava3.exceptions.UndeliverableException;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
@@ -169,6 +176,37 @@ public class GliaWidgets {
         } catch (GliaException gliaException) {
             throw mapCoreExceptionToWidgets(gliaException);
         }
+    }
+
+    /**
+     * Fetches the visitor's information
+     */
+    public static void getVisitorInfo(OnSuccess<VisitorInfo> onSuccess,
+                                      OnError onError) {
+        RequestCallback<com.glia.androidsdk.visitor.VisitorInfo> callback = (visitorInfo, e) -> {
+            if (e != null || visitorInfo == null) {
+                onError.onError(GliaWidgetsException.Companion.from(e));
+            } else {
+                onSuccess.onSuccess(new VisitorInfo(visitorInfo));
+            }
+        };
+        Dependencies.glia().getVisitorInfo(callback);
+    }
+
+    /**
+     * Updates the visitor's information
+     */
+    public static void updateVisitorInfo(VisitorInfoUpdateRequest visitorInfoUpdateRequest,
+                                         OnComplete onComplete,
+                                         OnError onError) {
+        Consumer<GliaException> updateCallback = error -> {
+            if (error == null) {
+                onComplete.onComplete();
+            } else {
+                onError.onError(GliaWidgetsException.Companion.from(error));
+            }
+        };
+        Dependencies.glia().updateVisitorInfo(visitorInfoUpdateRequest.toCoreType(), updateCallback);
     }
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/core/visitor/VisitorInfo.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/visitor/VisitorInfo.kt
@@ -1,0 +1,32 @@
+package com.glia.widgets.core.visitor
+
+/**
+ * Provide Visitor information
+ *
+ * @see com.glia.widgets.GliaWidgets.getVisitorInfo()
+ */
+data class VisitorInfo(
+    val name: String? = null,
+    val email: String? = null,
+    val phone: String? = null,
+    val note: String? = null,
+    val customAttributesMap: Map<String, String>,
+    val generatedName: String? = null,
+    val banned: Boolean? = null,
+    val href: String? = null,
+    val id: String? = null,
+    val externalId: String? = null,
+) {
+    constructor(visitorInfo: com.glia.androidsdk.visitor.VisitorInfo) : this(
+        visitorInfo.name,
+        visitorInfo.email,
+        visitorInfo.phone,
+        visitorInfo.note,
+        visitorInfo.customAttributesMap,
+        visitorInfo.generatedName,
+        visitorInfo.banned,
+        visitorInfo.href,
+        visitorInfo.id,
+        visitorInfo.externalId
+    )
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/visitor/VisitorInfoUpdateRequest.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/visitor/VisitorInfoUpdateRequest.kt
@@ -1,0 +1,74 @@
+package com.glia.widgets.core.visitor
+
+import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest
+
+/**
+ * Object that can be used for updating the visitor's information on the backend.
+ * <p>
+ *
+ * @see {@link GliaWidgets#updateVisitorInfo(VisitorInfoUpdateRequest, OnWidgetsSuccess, OnWidgetsError)}
+ */
+data class VisitorInfoUpdateRequest(
+    val name: String?,
+    val email: String?,
+    val phone: String?,
+    val note: String?,
+    val noteUpdateMethod: NoteUpdateMethod?,
+    val customAttributes: Map<String, String>?,
+    val customAttrsUpdateMethod: CustomAttributesUpdateMethod?
+) {
+
+    fun toCoreType(): VisitorInfoUpdateRequest {
+        return VisitorInfoUpdateRequest.Builder()
+            .setName(name)
+            .setEmail(email)
+            .setPhone(phone)
+            .setNote(note)
+            .setCustomAttributes(customAttributes)
+            .setCustomAttrsUpdateMethod(customAttrsUpdateMethod?.toCoreType())
+            .setNoteUpdateMethod(noteUpdateMethod?.toCoreType())
+            .build()
+    }
+
+    /**
+     * Specifies a method for updating the visitor's note.
+     */
+    enum class NoteUpdateMethod {
+        /**
+         * The notes for the visitor will be overwritten with the specified in the request
+         */
+        REPLACE,
+
+        /**
+         * The line break (\n) will be added and specified in the request notes will be appended to the existing
+         * visitor’s notes.
+         */
+        APPEND;
+
+        internal fun toCoreType(): VisitorInfoUpdateRequest.NoteUpdateMethod? {
+            return com.glia.androidsdk.visitor.VisitorInfoUpdateRequest.NoteUpdateMethod
+                .entries.firstOrNull { it.name == name }
+        }
+    }
+
+    /**
+     * Specifies the method for updating custom attributes.
+     */
+    enum class CustomAttributesUpdateMethod {
+        /**
+         * All custom attributes for the visitor will be overwritten with the specified in the request
+         */
+        REPLACE,
+
+        /**
+         * Only custom attributes present in the request will be added or updated. In case of merge it is
+         * possible to remove a custom attribute by setting its value to `null`.
+         */
+        MERGE;
+
+        internal fun toCoreType(): VisitorInfoUpdateRequest.CustomAttributesUpdateMethod? {
+            return com.glia.androidsdk.visitor.VisitorInfoUpdateRequest.CustomAttributesUpdateMethod
+                .entries.firstOrNull { it.name == name }
+        }
+    }
+}


### PR DESCRIPTION
**Jira issue:**
[Add getVisitorInfo() to Android Widgets SDK](https://glia.atlassian.net/browse/MOB-4203)
[Add updateVisitorInfo() to Android Widgets SDK](https://glia.atlassian.net/browse/MOB-4204)

**What was solved?**

1. Added public `GliaWidgets.getVisitorInfo(callback)`
2. Added public `GliaWidgets.updateVisitorInfo(visitorInfo)`
3. Added public `VisitorInfo` class
4. Added public `VisitorInfoUpdateRequest` class
5. Integrators who use `Glia.getVisitorInfo()` and `Glia.updateVisitorInfo()` Core SDK interfaces can still use them and do not need to change anything until we hide Core SDK.

**Release notes:**
Something general once [MOB-4169](https://glia.atlassian.net/browse/MOB-4169) is done.

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-4169]: https://glia.atlassian.net/browse/MOB-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ