### PR TITLE
Revert "Quick fix for onAppCreate()"

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/Application.java
+++ b/app/src/main/java/com/glia/exampleapp/Application.java
@@ -3,7 +3,6 @@ package com.glia.exampleapp;
 import android.text.TextUtils;
 import android.util.Log;
 
-import com.glia.androidsdk.Glia;
 import com.glia.widgets.GliaWidgets;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -14,8 +13,6 @@ public class Application extends android.app.Application {
     public void onCreate() {
         super.onCreate();
         initFirebase();
-
-        Glia.onAppCreate(this); // TODO: remove this line when Core SDK is updated
 
         GliaWidgets.setCustomCardAdapter(new ExampleCustomCardAdapter());
     }


### PR DESCRIPTION
**What was solved?**
Just revert the quick fix changes.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
