### PR TITLE
Add Authentication class to Android Widgets SDK

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -26,11 +26,11 @@ import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.fcm.GliaPushMessage
 import com.glia.androidsdk.omnibrowse.Omnibrowse
-import com.glia.androidsdk.visitor.Authentication
 import com.glia.exampleapp.ExampleAppConfigManager.createDefaultConfig
 import com.glia.exampleapp.Utils.getAuthenticationBehaviorFromPrefs
 import com.glia.widgets.GliaWidgets
 import com.glia.widgets.core.notification.NotificationActionReceiver
+import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.entrywidget.EntryWidget
 import com.glia.widgets.launcher.EngagementLauncher
 import com.google.android.material.appbar.MaterialToolbar

--- a/app/src/main/java/com/glia/exampleapp/Utils.java
+++ b/app/src/main/java/com/glia/exampleapp/Utils.java
@@ -6,7 +6,7 @@ import android.content.res.Resources;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
-import com.glia.androidsdk.visitor.Authentication;
+import com.glia.widgets.core.visitor.Authentication;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -114,7 +114,7 @@ class Utils {
             allowedDuringEngagementValue
         );
 
-        if (valueFromPrefs != null && valueFromPrefs.equals(allowedDuringEngagementValue)) {
+        if (valueFromPrefs.equals(allowedDuringEngagementValue)) {
             return Authentication.Behavior.ALLOWED_DURING_ENGAGEMENT;
         } else {
             return Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT;

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -4,14 +4,15 @@ import android.app.Application
 import android.content.Intent
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
-import com.glia.androidsdk.visitor.Authentication
 import com.glia.widgets.GliaWidgetsException.Companion.from
 import com.glia.widgets.callbacks.OnComplete
 import com.glia.widgets.callbacks.OnError
 import com.glia.widgets.callbacks.OnSuccess
 import com.glia.widgets.chat.adapter.CustomCardAdapter
 import com.glia.widgets.chat.adapter.WebViewCardAdapter
+import com.glia.widgets.core.authentication.toCoreType
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer
+import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.core.visitor.VisitorInfo
 import com.glia.widgets.core.visitor.VisitorInfoUpdateRequest
 import com.glia.widgets.di.Dependencies
@@ -323,9 +324,29 @@ object GliaWidgets {
      * Exception may have the following cause:
      * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized
      */
-    fun getAuthentication(behavior: Authentication.Behavior): Authentication {
+    @Deprecated("Please use getAuthentication(behavior: com.glia.widgets.core.visitor.Authentication.Behavior)")
+    fun getAuthentication(behavior: com.glia.androidsdk.visitor.Authentication.Behavior): Authentication {
         try {
             val authentication = glia().getAuthenticationManager(behavior)
+            setAuthenticationManager(authentication)
+            return authentication
+        } catch (gliaException: GliaException) {
+            throw mapCoreExceptionToWidgets(gliaException)
+        }
+    }
+
+    /**
+     * Creates `Authentication` instance for a given JWT token.
+     *
+     * @param behavior authentication behavior
+     * @return `Authentication` object or throws [GliaWidgetsException] if error happened.
+     * Exception may have the following cause:
+     * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized
+     */
+    fun getAuthentication(behavior: Authentication.Behavior): Authentication {
+        val widgetsBehavior = behavior.toCoreType() ?: throw GliaWidgetsException("Behavior value is not supported", GliaWidgetsException.Cause.INVALID_INPUT)
+        try {
+            val authentication = glia().getAuthenticationManager(widgetsBehavior)
             setAuthenticationManager(authentication)
             return authentication
         } catch (gliaException: GliaException) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/authentication/AuthenticationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/authentication/AuthenticationManager.kt
@@ -1,7 +1,7 @@
 package com.glia.widgets.core.authentication
 
 import com.glia.androidsdk.RequestCallback
-import com.glia.androidsdk.visitor.Authentication
+import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.di.Dependencies.repositoryFactory
 import com.glia.widgets.helper.Logger
@@ -13,9 +13,9 @@ import com.glia.widgets.helper.TAG
  *
  */
 internal class AuthenticationManager(
-    private val authentication: Authentication
+    private val authentication: com.glia.androidsdk.visitor.Authentication
 ) : Authentication {
-    override fun setBehavior(behavior: Authentication.Behavior) {
+    override fun setBehavior(behavior: com.glia.androidsdk.visitor.Authentication.Behavior) {
         authentication.setBehavior(behavior)
     }
 
@@ -55,4 +55,9 @@ internal class AuthenticationManager(
         Logger.i(TAG, "Refresh authentication")
         authentication.refresh(jwtToken, externalAccessToken, authCallback)
     }
+}
+
+internal fun Authentication.Behavior.toCoreType(): com.glia.androidsdk.visitor.Authentication.Behavior? {
+    return com.glia.androidsdk.visitor.Authentication.Behavior
+        .entries.firstOrNull { it.name == name }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/visitor/Authentication.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/visitor/Authentication.kt
@@ -1,0 +1,26 @@
+package com.glia.widgets.core.visitor
+
+import com.glia.androidsdk.visitor.Authentication as CoreAuthentication
+
+/**
+ * Interface for managing authentication and de-authentication.
+ *
+ * The `Behavior` enum defines behavior for authentication and de-authentication
+ * in different scenarios.
+ */
+interface Authentication: CoreAuthentication {
+    /**
+     * Behavior for authentication and de-authentication.
+     */
+    enum class Behavior {
+        /**
+         * Forbid authentication and de-authentication during ongoing engagement.
+         */
+        FORBIDDEN_DURING_ENGAGEMENT,
+
+        /**
+         * Allow authentication and de-authentication during ongoing engagement.
+         */
+        ALLOWED_DURING_ENGAGEMENT;
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -7,7 +7,6 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaConfig
-import com.glia.androidsdk.GliaException
 import com.glia.widgets.GliaWidgetsConfig
 import com.glia.widgets.StringProvider
 import com.glia.widgets.callvisualizer.CallVisualizerActivityWatcher
@@ -20,6 +19,7 @@ import com.glia.widgets.core.dialog.PermissionDialogManager
 import com.glia.widgets.core.notification.device.INotificationManager
 import com.glia.widgets.core.notification.device.NotificationManager
 import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.engagement.completion.EngagementCompletionActivityWatcher
 import com.glia.widgets.entrywidget.EntryWidget
 import com.glia.widgets.entrywidget.EntryWidgetImpl
@@ -298,6 +298,6 @@ internal object Dependencies {
 
     internal class AuthenticationManagerProvider {
         @JvmField
-        var authenticationManager: AuthenticationManager? = null
+        var authenticationManager: Authentication? = null
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -63,7 +63,6 @@ import com.glia.widgets.chat.domain.gva.ParseGvaGalleryCardsUseCase;
 import com.glia.widgets.core.audio.AudioControlManager;
 import com.glia.widgets.core.audio.domain.OnAudioStartedUseCase;
 import com.glia.widgets.core.audio.domain.TurnSpeakerphoneUseCase;
-import com.glia.widgets.core.authentication.AuthenticationManager;
 import com.glia.widgets.core.callvisualizer.domain.IsCallVisualizerScreenSharingUseCase;
 import com.glia.widgets.core.callvisualizer.domain.VisitorCodeViewBuilderUseCase;
 import com.glia.widgets.core.chathead.ChatHeadManager;
@@ -117,6 +116,7 @@ import com.glia.widgets.core.secureconversations.domain.SetLeaveSecureConversati
 import com.glia.widgets.core.secureconversations.domain.ShouldMarkMessagesReadUseCase;
 import com.glia.widgets.core.secureconversations.domain.ShowMessageLimitErrorUseCase;
 import com.glia.widgets.core.survey.domain.GliaSurveyAnswerUseCase;
+import com.glia.widgets.core.visitor.Authentication;
 import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCase;
 import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCaseImpl;
 import com.glia.widgets.engagement.domain.CheckMediaUpgradePermissionsUseCase;
@@ -568,7 +568,7 @@ public class UseCaseFactory {
     @NonNull
     public IsAuthenticatedUseCase createIsAuthenticatedUseCase() {
         return () -> Optional.ofNullable(authenticationManagerProvider.authenticationManager)
-            .map(AuthenticationManager::isAuthenticated)
+            .map(Authentication::isAuthenticated)
             .orElse(false);
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsExceptionTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsExceptionTest.kt
@@ -18,6 +18,7 @@ class GliaWidgetsExceptionTest {
         val allWidgetsCauses: List<GliaWidgetsException.Cause> = GliaWidgetsException.Cause.entries
         val gliaWidgetsExceptions = allWidgetsCauses.map { GliaWidgetsException("Test message", it) }
 
+        assertEquals(allCoreCauses.size, allWidgetsCauses.size)
         gliaCoreExceptions.forEachIndexed { index, item ->
             val widgetsException = GliaWidgetsException.from(item)
 

--- a/widgetssdk/src/test/java/com/glia/widgets/core/authentication/AuthenticationManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/authentication/AuthenticationManagerTest.kt
@@ -1,0 +1,23 @@
+package com.glia.widgets.core.authentication
+
+import com.glia.widgets.core.visitor.Authentication
+import junit.framework.TestCase.assertEquals
+import org.junit.Assert
+import org.junit.Test
+
+class AuthenticationManagerTest {
+
+    @Test
+    fun testWidgetsAuthenticationBehaviorsCorrespondToCoreAuthenticationBehaviors() {
+        val allCoreAuthBehaviors = com.glia.androidsdk.visitor.Authentication.Behavior.entries
+        val allWidgetsAuthBehaviors = Authentication.Behavior.entries
+
+        assertEquals(allCoreAuthBehaviors.size, allWidgetsAuthBehaviors.size)
+        allWidgetsAuthBehaviors.forEachIndexed { index, item ->
+            val coreBehavior = item.toCoreType()
+
+            Assert.assertNotNull(coreBehavior)
+            Assert.assertEquals(coreBehavior?.name, allWidgetsAuthBehaviors[index].name)
+        }
+    }
+}


### PR DESCRIPTION
**Jira issue:**
[Add Authentication class to Android Widgets SDK](https://glia.atlassian.net/browse/MOB-4206)

**What was solved?**
- Added own Authentication class to Widgets SDK
- Added own Behavior enum Widgets SDK
- Made sure the current approach through Core SDK classes is working without any changes

**Release notes:**
Something general once [MOB-4169](https://glia.atlassian.net/browse/MOB-4169) is done.

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.


[MOB-4169]: https://glia.atlassian.net/browse/MOB-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ