### PR TITLE
Fix Gradle script logging in the Quiet mode

### DIFF
--- a/scripts/direct-core.gradle
+++ b/scripts/direct-core.gradle
@@ -110,6 +110,10 @@ def absolutePath(String path) {
 }
 
 def printDirectCoreSdkInfo(Boolean gliaCoreSdkUseDirect, String coreSdkPath, String coreSdkPathEnv, String coreSdkDefaultPath) {
+  if (gradle.startParameter.logLevel == LogLevel.QUIET) {
+    return
+  }
+
   println("\n----------------------Direct Core SDK-----------------------")
   if (gliaCoreSdkUseDirect) {
     if (coreSdkPath || coreSdkPathEnv) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4275

**What was solved?**
Do not log in if the Quiet mode is on for Gradle tasks.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
