### PR TITLE
Add callback to GliaWidgets.init() so that integrators could know when SDK init finishes

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -492,7 +492,7 @@ class MainFragment : Fragment() {
     }
 
     private fun initGliaWidgets() {
-        if (Glia.isInitialized()) {
+        if (GliaWidgets.isInitialized()) {
             setupAuthButtonsVisibility()
             listenForCallVisualizerEngagements()
             return
@@ -503,13 +503,18 @@ class MainFragment : Fragment() {
                 context = requireActivity().applicationContext,
 //                uiJsonRemoteConfig = UnifiedUiConfigurationLoader.fetchLocalConfigSample(requireContext()),
 //                region = "us"
-            )
-        )
-        prepareAuthentication()
-        setupAuthButtonsVisibility()
-        listenForCallVisualizerEngagements()
+            ),
+            onComplete = {
+                prepareAuthentication()
+                setupAuthButtonsVisibility()
+                listenForCallVisualizerEngagements()
 
-        view?.post { initMenu() }
+                view?.post { initMenu() }
+            },
+            onError = { error ->
+                error?.let { showToast(it.message.toString()) }
+            }
+        )
     }
 
     private fun prepareAuthentication() {

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -118,6 +118,7 @@ object GliaWidgets {
 
     /**
      * Initializes the Glia Core SDK using [GliaWidgetsConfig].
+     * [GliaWidgets.isInitialized] will return `true` regardless of the initialization result.
      *
      * @param gliaWidgetsConfig Glia configuration
      * @throws GliaWidgetsException with [GliaWidgetsException.Cause]
@@ -130,9 +131,73 @@ object GliaWidgets {
             onSdkInit(gliaWidgetsConfig)
             setupLoggingMetadata(gliaWidgetsConfig)
             gliaThemeManager.applyJsonConfig(gliaWidgetsConfig.uiJsonRemoteConfig)
+            glia().isInitialized = true
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            val gliaWidgetsException = mapCoreExceptionToWidgets(gliaException)
+            throw gliaWidgetsException
         }
+    }
+
+    /**
+     * Initializes the Glia Core SDK using [GliaWidgetsConfig].
+     * [GliaWidgets.isInitialized] will return `true` after initialization succeeds.
+     *
+     * @param gliaWidgetsConfig Glia configuration
+     * @throws GliaWidgetsException with [GliaWidgetsException.Cause]
+     */
+    @JvmStatic
+    @Synchronized
+    fun init(gliaWidgetsConfig: GliaWidgetsConfig,
+             onComplete: OnComplete? = null,
+             onError: OnError? = null) {
+        Logger.i(TAG, "Initialize Glia Widgets SDK")
+        try {
+            val callback: RequestCallback<Boolean?> =
+                RequestCallback { _, exception ->
+                    if (exception == null) {
+                        glia().isInitialized = true
+                        onComplete?.onComplete()
+                    } else {
+                        Logger.i(TAG, "Glia Widgets SDK initialization failed")
+                        val invalidInputError = GliaWidgetsException(
+                            "Failed to initialise Glia Widgets SDK. Please check credentials.",
+                            GliaWidgetsException.Cause.INVALID_INPUT
+                        )
+                        onError?.onError(invalidInputError)
+                    }
+                }
+
+            onSdkInit(gliaWidgetsConfig, callback)
+            setupLoggingMetadata(gliaWidgetsConfig)
+            gliaThemeManager.applyJsonConfig(gliaWidgetsConfig.uiJsonRemoteConfig)
+        } catch (exception: Exception) {
+            if (exception is GliaException) {
+                val mappedException = mapCoreExceptionToWidgets(exception)
+                if (mappedException is GliaWidgetsException) {
+                    onError?.onError(mappedException)
+                    return
+                }
+            }
+
+            Logger.e(TAG, "Glia Widgets SDK initialization failed")
+            val internalError = GliaWidgetsException(
+                "Internal SDK error",
+                GliaWidgetsException.Cause.INTERNAL_ERROR
+            )
+            onError?.onError(internalError)
+        }
+    }
+
+    /**
+     * Checks result of Glia Widgets SDK initialization
+     *
+     * @return `true` if [GliaWidgets.init] is called without exceptions.
+     *
+     *  Please note, that `true` doesn't mean that credentials are valid/correct.
+     * @see [GliaWidgets.init]
+     */
+    fun isInitialized(): Boolean {
+        return glia().isInitialized
     }
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaConfig
+import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.GliaWidgetsConfig
 import com.glia.widgets.StringProvider
 import com.glia.widgets.callvisualizer.CallVisualizerActivityWatcher
@@ -223,6 +224,20 @@ internal object Dependencies {
         repositoryFactory.initialize()
         configurationManager.applyConfiguration(gliaWidgetsConfig)
         localeProvider.setCompanyName(gliaWidgetsConfig.companyName)
+    }
+
+    @JvmStatic
+    fun onSdkInit(gliaWidgetsConfig: GliaWidgetsConfig, callback: RequestCallback<Boolean?>? = null) {
+        val gliaConfig = createGliaConfig(gliaWidgetsConfig)
+        gliaCore.init(gliaConfig) { success, error ->
+            if (error == null) {
+                controllerFactory.init()
+                repositoryFactory.initialize()
+                configurationManager.applyConfiguration(gliaWidgetsConfig)
+                localeProvider.setCompanyName(gliaWidgetsConfig.companyName)
+            }
+            callback?.onResult(success, error)
+        }
     }
 
     private fun createGliaConfig(gliaWidgetsConfig: GliaWidgetsConfig): GliaConfig {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.di
 
-import android.app.Application
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Glia.OmnicoreEvent
 import com.glia.androidsdk.GliaConfig
@@ -26,13 +25,14 @@ import java.util.Optional
 import java.util.function.Consumer
 
 internal interface GliaCore {
-    val isInitialized: Boolean
+    var isInitialized: Boolean
     val pushNotifications: PushNotifications
     val currentEngagement: Optional<Engagement>
     val callVisualizer: Omnibrowse
     val secureConversations: SecureConversations
     @Throws(GliaException::class)
     fun init(config: GliaConfig)
+    fun init(config: GliaConfig, callback: RequestCallback<Boolean?>)
     fun getVisitorInfo(visitorCallback: RequestCallback<VisitorInfo?>)
     fun updateVisitorInfo(visitorInfoUpdateRequest: VisitorInfoUpdateRequest, visitorCallback: Consumer<GliaException?>)
     fun <T> on(event: OmnicoreEvent<T>, listener: Consumer<T>)

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.di
 
-import android.app.Application
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.Glia.OmnicoreEvent
@@ -27,8 +26,7 @@ import java.util.Optional
 import java.util.function.Consumer
 
 internal class GliaCoreImpl : GliaCore {
-    override val isInitialized: Boolean
-        get() = Glia.isInitialized()
+    override var isInitialized: Boolean = false
 
     override val pushNotifications: PushNotifications
         get() = Glia.getPushNotifications()
@@ -46,6 +44,12 @@ internal class GliaCoreImpl : GliaCore {
     @Throws(GliaException::class)
     override fun init(config: GliaConfig) {
         Glia.init(config)
+    }
+
+    @Synchronized
+    @Throws(GliaException::class)
+    override fun init(config: GliaConfig, callback: RequestCallback<Boolean?>) {
+        Glia.init(config, callback)
     }
 
     override fun getVisitorInfo(visitorCallback: RequestCallback<VisitorInfo?>) {

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
@@ -3,8 +3,12 @@ package com.glia.widgets
 import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.glia.androidsdk.GliaConfig
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.SiteApiKey
 import com.glia.androidsdk.omnibrowse.Omnibrowse
+import com.glia.widgets.callbacks.OnComplete
+import com.glia.widgets.callbacks.OnError
 import com.glia.widgets.callvisualizer.controller.CallVisualizerController
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.di.ControllerFactory
@@ -19,6 +23,8 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
@@ -80,4 +86,53 @@ class GliaWidgetsTest {
         Assert.assertEquals(applicationContext, gliaConfig.context)
     }
 
+    @Test
+    fun `init should invoke onComplete when initialization succeeds`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val gliaWidgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .setSiteId("SiteId")
+            .setRegion("Region")
+            .setContext(mock())
+            .build()
+        val onComplete = mock<OnComplete>()
+        val onError = mock<OnError>()
+        val callbackCaptor = argumentCaptor<RequestCallback<Boolean?>>()
+        whenever(gliaCore.init(any(), callbackCaptor.capture())).thenAnswer {
+            // Simulate success by invoking the captured callback
+            callbackCaptor.firstValue.onResult(true, null)
+        }
+
+        GliaWidgets.init(gliaWidgetsConfig, onComplete, onError)
+
+        verify(onComplete).onComplete()
+        verify(onError, never()).onError(any())
+    }
+
+    @Test
+    fun `init should invoke onError with specific exception when initialization fails`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val gliaWidgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .setSiteId("SiteId")
+            .setRegion("Region")
+            .setContext(mock())
+            .build()
+        val onComplete = mock<OnComplete>()
+        val onError = mock<OnError>()
+        val callbackCaptor = argumentCaptor<RequestCallback<Boolean?>>()
+        whenever(gliaCore.init(any(), callbackCaptor.capture())).thenAnswer {
+            // Simulate error by invoking the captured callback
+            callbackCaptor.firstValue.onResult(null, GliaException("Glia Core SDK exception", GliaException.Cause.INVALID_INPUT))
+        }
+
+        GliaWidgets.init(gliaWidgetsConfig, onComplete, onError)
+
+        verify(onComplete, never()).onComplete()
+        argumentCaptor<GliaWidgetsException>().apply {
+            verify(onError).onError(capture())
+            Assert.assertEquals(GliaWidgetsException.Cause.INVALID_INPUT, firstValue.gliaCause)
+            Assert.assertEquals("Failed to initialise Glia Widgets SDK. Please check credentials.", firstValue.debugMessage)
+        }
+    }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/di/DependenciesTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/di/DependenciesTest.kt
@@ -1,0 +1,112 @@
+package com.glia.widgets.di
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.RequestCallback
+import com.glia.androidsdk.SiteApiKey
+import com.glia.widgets.GliaWidgetsConfig
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@get:ClassRule
+val rule: TestRule = InstantTaskExecutorRule()
+
+@RunWith(RobolectricTestRunner::class)
+class DependenciesTest {
+
+    private lateinit var gliaCore: GliaCore
+    private lateinit var controllerFactory: ControllerFactory
+    private lateinit var repositoryFactory: RepositoryFactory
+
+    @Before
+    fun setUp() {
+        gliaCore = Mockito.mock()
+        controllerFactory = Mockito.mock()
+        repositoryFactory = Mockito.mock()
+        Dependencies.gliaCore = gliaCore
+        Dependencies.controllerFactory = controllerFactory
+        Dependencies.repositoryFactory = repositoryFactory
+        Dependencies.localeProvider = Mockito.mock()
+    }
+
+    @Test
+    fun `onSdkInit without callbacks should initialize controllerFactory, and repositoryFactory regardless of gliaCore init result`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val widgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .build()
+
+        Dependencies.onSdkInit(widgetsConfig)
+
+        verify(Dependencies.gliaCore).init(any())
+        verify(Dependencies.controllerFactory).init()
+        verify(Dependencies.repositoryFactory).initialize()
+    }
+
+    @Test
+    fun `onSdkInit with callbacks should not initialize controllerFactory, and repositoryFactory until gliaCore init finishes`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val widgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .build()
+        val callback = mock<RequestCallback<Boolean?>>()
+
+        Dependencies.onSdkInit(gliaWidgetsConfig = widgetsConfig, callback = callback)
+
+        verify(Dependencies.gliaCore).init(any(), any())
+        verify(Dependencies.controllerFactory, never()).init()
+        verify(Dependencies.repositoryFactory, never()).initialize()
+    }
+
+    @Test
+    fun `onSdkInit with callbacks should initialize controllerFactory, and repositoryFactory when gliaCore init succeeds`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val widgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .build()
+        val callback = mock<RequestCallback<Boolean?>>()
+        val callbackCaptor = argumentCaptor<RequestCallback<Boolean?>>()
+
+        whenever(gliaCore.init(any(), callbackCaptor.capture())).thenAnswer {
+            // Simulate success by invoking the captured callback
+            callbackCaptor.firstValue.onResult(true, null)
+        }
+
+        Dependencies.onSdkInit(gliaWidgetsConfig = widgetsConfig, callback = callback)
+
+        verify(Dependencies.gliaCore).init(any(), any())
+        verify(Dependencies.controllerFactory).init()
+        verify(Dependencies.repositoryFactory).initialize()
+    }
+
+    @Test
+    fun `onSdkInit with callbacks should not initialize controllerFactory, and repositoryFactory when gliaCore init fails`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val widgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .build()
+        val callback = mock<RequestCallback<Boolean?>>()
+        val callbackCaptor = argumentCaptor<RequestCallback<Boolean?>>()
+        whenever(gliaCore.init(any(), callbackCaptor.capture())).thenAnswer {
+            // Simulate error by invoking the captured callback
+            callbackCaptor.firstValue.onResult(null, GliaException("Test Exception", GliaException.Cause.INVALID_INPUT))
+        }
+
+        Dependencies.onSdkInit(gliaWidgetsConfig = widgetsConfig, callback = callback)
+
+        verify(Dependencies.gliaCore).init(any(), any())
+        verify(Dependencies.controllerFactory, never()).init()
+        verify(Dependencies.repositoryFactory, never()).initialize()
+    }
+}


### PR DESCRIPTION
**What was solved?**
- [Add callback to GliaWidgets.init() so that integrators could know when SDK init finishes](https://glia.atlassian.net/browse/MOB-4273)
- [Add GliaWidgets.isInitialized() to Android Widgets SDK](https://glia.atlassian.net/browse/MOB-4211)
- [In progress] I will review the unit tests

These changes rely on [this Core SDK PR](https://github.com/salemove/android-sdk/pull/813).

**Release notes:**
Add callback to GliaWidgets.init() so that integrators could know when SDK init finishes

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.
