### PR TITLE
Add GliaFcmService to Android Widgets SDK

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
             android:configChanges="orientation|screenSize" />
 
         <service
-            android:name="com.glia.androidsdk.fcm.GliaFcmService"
+            android:name="com.glia.widgets.fcm.GliaFcmService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -34,6 +34,22 @@ def setupFilesForPublishing(publication) {
         }
     }
 
+    // Remove optional dependencies from the Widgets SDK
+    // to avoid requiring integrators to include them in their applications.
+    publication.pom.withXml {
+        final pomNode = asNode()
+        pomNode.dependencyManagement.dependencies.'*'.findAll() {
+            it.artifactId.text() == 'firebase-bom'
+        }.each() {
+            it.parent().remove(it)
+        }
+        pomNode.dependencies.'*'.findAll() {
+            it.artifactId.text() == 'firebase-messaging'
+        }.each() {
+            it.parent().remove(it)
+        }
+    }
+
     publication.pom {
         name = PUBLISH_ARTIFACT_ID
         description = PUBLISH_MODULE_DESCRIPTION

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -117,6 +117,9 @@ dependencies {
   implementation libs.java.core.ktx
   implementation libs.media.exif.interface
 
+  implementation platform(libs.firebase.bom)
+  implementation libs.firebase.messaging
+
   testImplementation libs.test.junit
   testImplementation libs.test.mockito.kotlin
   testImplementation libs.test.core.testing

--- a/widgetssdk/src/main/java/com/glia/widgets/fcm/GliaFcmService.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/fcm/GliaFcmService.kt
@@ -1,0 +1,40 @@
+package com.glia.widgets.fcm
+
+import com.glia.androidsdk.Glia
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+/**
+ * Class which is intended to be registered in integrator's application if and only if integrator
+ * does not have any FCM services besides Glia's one. In that case integrator should declare this
+ * class in his app's manifest:
+ *
+ * ```xml
+ * <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+ *     <application ...>
+ *
+ *         <service
+ *             android:name="com.glia.widgets.fcm.GliaFcmService"
+ *             android:exported="false">
+ *             <intent-filter>
+ *                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
+ *             </intent-filter>
+ *         </service>
+ *
+ *     </application>
+ * </manifest>
+ * ```
+ */
+class GliaFcmService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        Glia.getPushNotifications()
+            .updateFcmToken(token)
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        Glia.getPushNotifications()
+            .onNewMessage(remoteMessage)
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4207

**What was solved?**
GliaFcmService was added to Android Widgets SDK

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
