### PR TITLE
Add getPushNotifications().handleOnMainActivityCreate()

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -451,6 +451,12 @@ object GliaWidgets {
         }
     }
 
+    /**
+     * Handles FCM tokens and push messages.
+     *
+     * @return [PushNotifications]
+     */
+    @JvmStatic
     fun getPushNotifications(): PushNotifications {
         return pushNotifications
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/fcm/GliaPushMessage.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/fcm/GliaPushMessage.kt
@@ -1,0 +1,74 @@
+package com.glia.widgets.fcm
+
+/**
+ * Push object sent by the Glia client library
+ */
+interface GliaPushMessage {
+    /**
+     * Defines the possible types of the Glia push notifications
+     */
+    enum class PushType {
+        /**
+         * When a chat message is sent
+         */
+        CHAT_MESSAGE,
+
+        /**
+         * When a queued message is sent
+         */
+        QUEUED_MESSAGE,
+
+        /**
+         * Default value, could be received if value returned by server is not supported by current version of SDK
+         */
+        UNIDENTIFIED
+    }
+
+    /**
+     * Defines the possible types of the push notification actions
+     */
+    enum class Action {
+        /**
+         * When Firebase messaging service receives a push notification
+         */
+        NOTIFICATION_RECEIVED,
+
+        /**
+         * When a visitor clicks on the notification
+         */
+        NOTIFICATION_OPENED
+    }
+
+    /**
+     * @return [Action]
+     */
+    val action: Action
+
+    /**
+     * @return [PushType]
+     */
+    val type: PushType
+}
+
+internal class GliaPushMessageImpl(
+    override val action: GliaPushMessage.Action,
+    override val type: GliaPushMessage.PushType
+) : GliaPushMessage {
+    constructor(gliaPushMessage: com.glia.androidsdk.fcm.GliaPushMessage) : this(
+        action = gliaPushMessage.action.toWidgetsType(),
+        type = gliaPushMessage.type.toWidgetsType()
+    )
+}
+
+internal fun com.glia.androidsdk.fcm.GliaPushMessage.Action.toWidgetsType() : GliaPushMessage.Action =
+    when (this) {
+        com.glia.androidsdk.fcm.GliaPushMessage.Action.NOTIFICATION_RECEIVED -> GliaPushMessage.Action.NOTIFICATION_RECEIVED
+        com.glia.androidsdk.fcm.GliaPushMessage.Action.NOTIFICATION_OPENED -> GliaPushMessage.Action.NOTIFICATION_OPENED
+    }
+
+internal fun com.glia.androidsdk.fcm.GliaPushMessage.PushType.toWidgetsType() : GliaPushMessage.PushType =
+    when (this) {
+        com.glia.androidsdk.fcm.GliaPushMessage.PushType.CHAT_MESSAGE -> GliaPushMessage.PushType.CHAT_MESSAGE
+        com.glia.androidsdk.fcm.GliaPushMessage.PushType.QUEUED_MESSAGE -> GliaPushMessage.PushType.QUEUED_MESSAGE
+        com.glia.androidsdk.fcm.GliaPushMessage.PushType.UNIDENTIFIED -> GliaPushMessage.PushType.UNIDENTIFIED
+    }

--- a/widgetssdk/src/main/java/com/glia/widgets/fcm/PushNotifications.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/fcm/PushNotifications.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.fcm
 
+import android.os.Bundle
 import com.google.firebase.messaging.RemoteMessage
 
 /**
@@ -32,12 +33,32 @@ interface PushNotifications {
      * @param message - New FCM message
      */
     fun onNewMessage(message: RemoteMessage)
+
+    /**
+     * Should be called when the main activity is created.
+     *
+     * **Usage example:**
+     * ```kotlin
+     * override fun onCreate(savedInstanceState: Bundle?) {
+     *    super.onCreate(savedInstanceState)
+     *
+     *    ...
+     *
+     *    val pushMessage = GliaWidgets.getPushNotifications().handleOnMainActivityCreate(intent.extras)
+     *
+     *    if (pushMessage?.type == GliaPushMessage.PushType.CHAT_MESSAGE) {
+     *        // handle the opening of the push notification
+     *    }
+     * }
+     * ```
+     *
+     * @param bundle - Bundle passed to the main activity
+     * @return GliaPushMessage if the main activity is opened by clicking on the notification or {@code null} if not.
+     */
+    fun handleOnMainActivityCreate(bundle: Bundle?): GliaPushMessage?
 }
 
-/**
- * @hide
- */
-class PushNotificationsImpl(
+internal class PushNotificationsImpl(
     private val pushNotifications: com.glia.androidsdk.fcm.PushNotifications
 ) : PushNotifications {
 
@@ -47,5 +68,10 @@ class PushNotificationsImpl(
 
     override fun onNewMessage(message: RemoteMessage) {
         pushNotifications.onNewMessage(message)
+    }
+
+    override fun handleOnMainActivityCreate(bundle: Bundle?): GliaPushMessage? {
+        val pushMessage = pushNotifications.handleOnMainActivityCreate(bundle)
+        return pushMessage?.let { GliaPushMessageImpl(it) }
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/fcm/GliaPushMessageTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/fcm/GliaPushMessageTest.kt
@@ -1,0 +1,32 @@
+package com.glia.widgets.fcm
+
+import org.junit.Test
+
+class GliaPushMessageTest {
+
+    @Test
+    fun testWidgetsPushMessageActionsCorrespondToCorePushMessageActions() {
+        val allCorePushActions = com.glia.androidsdk.fcm.GliaPushMessage.Action.entries
+        val allWidgetsPushActions = GliaPushMessage.Action.entries
+
+        assert(allCorePushActions.size == allWidgetsPushActions.size)
+        allCorePushActions.forEachIndexed { index, item ->
+            val widgetsAction = item.toWidgetsType()
+
+            assert(widgetsAction.name == allCorePushActions[index].name)
+        }
+    }
+
+    @Test
+    fun testWidgetsPushMessageTypesCorrespondToCorePushMessageTypes() {
+        val allCorePushTypes = com.glia.androidsdk.fcm.GliaPushMessage.PushType.entries
+        val allWidgetsPushTypes = GliaPushMessage.PushType.entries
+
+        assert(allCorePushTypes.size == allWidgetsPushTypes.size)
+        allCorePushTypes.forEachIndexed { index, item ->
+            val widgetsType = item.toWidgetsType()
+
+            assert(widgetsType.name == allCorePushTypes[index].name)
+        }
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4232

**What was solved?**
Add GliaWidgets.getPushNotifications().handleOnMainActivityCreate() method.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
