### PR TITLE
Add Secure Conversations interfaces for unread message count

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -12,6 +12,7 @@ import com.glia.widgets.chat.adapter.CustomCardAdapter
 import com.glia.widgets.chat.adapter.WebViewCardAdapter
 import com.glia.widgets.core.authentication.toCoreType
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer
+import com.glia.widgets.core.secureconversations.SecureConversations
 import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.core.visitor.VisitorInfo
 import com.glia.widgets.core.visitor.VisitorInfoUpdateRequest
@@ -26,6 +27,7 @@ import com.glia.widgets.di.Dependencies.gliaThemeManager
 import com.glia.widgets.di.Dependencies.onSdkInit
 import com.glia.widgets.di.Dependencies.pushNotifications
 import com.glia.widgets.di.Dependencies.repositoryFactory
+import com.glia.widgets.di.Dependencies.secureConversations
 import com.glia.widgets.di.Dependencies.setAuthenticationManager
 import com.glia.widgets.di.Dependencies.useCaseFactory
 import com.glia.widgets.engagement.EndedBy
@@ -427,6 +429,23 @@ object GliaWidgets {
             val authentication = glia().getAuthenticationManager(widgetsBehavior)
             setAuthenticationManager(authentication)
             return authentication
+        } catch (gliaException: GliaException) {
+            throw mapCoreExceptionToWidgets(gliaException)
+        }
+    }
+
+    /**
+     * Creates `SecureConversations` instance for secure conversations.
+     *
+     * @return {@code SecureConversations} object or throws [GliaWidgetsException] if error happened.
+     * Exception may have the following cause:
+     * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized
+     */
+    @Suppress("unused")
+    @JvmStatic
+    fun getSecureConversations(): SecureConversations {
+        try {
+            return secureConversations
         } catch (gliaException: GliaException) {
             throw mapCoreExceptionToWidgets(gliaException)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversations.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/SecureConversations.kt
@@ -1,0 +1,57 @@
+package com.glia.widgets.core.secureconversations
+
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.RequestCallback
+
+/**
+ * Secure Conversations offers the ability to asynchronously and securely communications for authenticated visitors.
+ * It is a secure alternative to SMS and email which also allow asynchronous interactions but are considered less secure.
+ *
+ * Read more about [Secure Conversations](https://docs.glia.com/glia-mobile/docs/android-widgets-secure-conversations)
+ */
+interface SecureConversations {
+    /**
+     * Returns the number of unread messages for the secure conversations.
+     * This number will increase with each message sent by the operator
+     * that the visitor has not yet marked as read.
+     *
+     * @param callback a callback that returns [RequestCallback] with the number of unread
+     * secure messages on success, or [GliaException] on failure.
+     *
+     * Exception may have one of the following causes:
+     * [GliaException.Cause.AUTHENTICATION_ERROR] -when a visitor is not authenticated
+     * [GliaException.Cause.INVALID_INPUT] - when SDK is not initialized
+     */
+    fun getUnreadMessageCount(callback: RequestCallback<Int?>)
+
+    /**
+     * The same as [SecureConversations.getUnreadMessageCount] but with the ability to subscribe to updates.
+     */
+    fun subscribeToUnreadMessageCount(callback: RequestCallback<Int?>)
+
+    /**
+     * Unsubscribe from updates of the unread message count.
+     */
+    fun unSubscribeFromUnreadMessageCount(callback: RequestCallback<Int?>)
+}
+
+/**
+ * @hide
+ */
+class SecureConversationsImpl(
+    private val secureConversations: com.glia.androidsdk.secureconversations.SecureConversations
+) : SecureConversations {
+
+    override fun getUnreadMessageCount(callback: RequestCallback<Int?>) {
+        secureConversations.getUnreadMessageCount(callback)
+    }
+
+    override fun subscribeToUnreadMessageCount(callback: RequestCallback<Int?>) {
+        secureConversations.subscribeToUnreadMessageCount(callback)
+    }
+
+    override fun unSubscribeFromUnreadMessageCount(callback: RequestCallback<Int?>) {
+        secureConversations.unSubscribeFromUnreadMessageCount(callback)
+    }
+}
+

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -20,6 +20,8 @@ import com.glia.widgets.core.dialog.PermissionDialogManager
 import com.glia.widgets.core.notification.device.INotificationManager
 import com.glia.widgets.core.notification.device.NotificationManager
 import com.glia.widgets.core.permissions.PermissionManager
+import com.glia.widgets.core.secureconversations.SecureConversations
+import com.glia.widgets.core.secureconversations.SecureConversationsImpl
 import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.engagement.completion.EngagementCompletionActivityWatcher
 import com.glia.widgets.entrywidget.EntryWidget
@@ -116,6 +118,11 @@ internal object Dependencies {
     @JvmStatic
     lateinit var repositoryFactory: RepositoryFactory
         @VisibleForTesting set
+
+    @JvmStatic
+    val secureConversations: SecureConversations by lazy {
+        SecureConversationsImpl(gliaCore.secureConversations)
+    }
 
     @Synchronized
     @JvmStatic


### PR DESCRIPTION
**Jira issue:**
[MOB-4214](https://glia.atlassian.net/browse/MOB-4214), [MOB-4215](https://glia.atlassian.net/browse/MOB-4215), [MOB-4216](https://glia.atlassian.net/browse/MOB-4216)

**What was solved?**
- Add Secure Conversations interfaces for unread message count

**Release notes:**
Something general once [MOB-4169](https://glia.atlassian.net/browse/MOB-4169) is done.

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-4214]: https://glia.atlassian.net/browse/MOB-4214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-4215]: https://glia.atlassian.net/browse/MOB-4215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-4216]: https://glia.atlassian.net/browse/MOB-4216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-4169]: https://glia.atlassian.net/browse/MOB-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ