### PR TITLE
Add LiveObservation interfaces

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -12,6 +12,7 @@ import com.glia.widgets.chat.adapter.CustomCardAdapter
 import com.glia.widgets.chat.adapter.WebViewCardAdapter
 import com.glia.widgets.core.authentication.toCoreType
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer
+import com.glia.widgets.core.liveobservation.LiveObservation
 import com.glia.widgets.core.secureconversations.SecureConversations
 import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.core.visitor.VisitorInfo
@@ -24,6 +25,7 @@ import com.glia.widgets.di.Dependencies.engagementLauncher
 import com.glia.widgets.di.Dependencies.entryWidget
 import com.glia.widgets.di.Dependencies.glia
 import com.glia.widgets.di.Dependencies.gliaThemeManager
+import com.glia.widgets.di.Dependencies.liveObservation
 import com.glia.widgets.di.Dependencies.onSdkInit
 import com.glia.widgets.di.Dependencies.pushNotifications
 import com.glia.widgets.di.Dependencies.repositoryFactory
@@ -446,6 +448,23 @@ object GliaWidgets {
     fun getSecureConversations(): SecureConversations {
         try {
             return secureConversations
+        } catch (gliaException: GliaException) {
+            throw mapCoreExceptionToWidgets(gliaException)
+        }
+    }
+
+    /**
+     * Handles Live Observation
+     *
+     * @return {@code LiveObservation} object or throws [GliaWidgetsException] if error happened.
+     * Exception may have the following cause:
+     * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized or initialization failed.
+     */
+    @Suppress("unused")
+    @JvmStatic
+    fun getLiveObservation(): LiveObservation {
+        try {
+            return liveObservation
         } catch (gliaException: GliaException) {
             throw mapCoreExceptionToWidgets(gliaException)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/liveobservation/LiveObservation.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/liveobservation/LiveObservation.kt
@@ -1,0 +1,42 @@
+package com.glia.widgets.core.liveobservation
+
+/**
+ * Class responsible for handling Live Observation.
+ *
+ * Live Observation displays visitor interactions with the app to the operator to help provide better support.
+ * At the moment, Live Observation on Android is only supported during ongoing engagements.
+ * For more information about Live Observation, see integration guides.
+ */
+interface LiveObservation {
+    /**
+     * Pauses the Live Observation stream that displays visitor interactions with the app to the operator.
+     *
+     * This method should only be used to prevent the disclosure of sensitive user data.
+     */
+    fun pause()
+
+
+    /**
+     * Resumes the Live Observation stream that displays visitor interactions with the app to the operator.
+     *
+     * This method should only be used after sensitive data is no longer visible on the screen.
+     */
+    fun resume()
+}
+
+/**
+ * @hide
+ */
+class LiveObservationImpl(
+    private val liveObservation: com.glia.androidsdk.liveobservation.LiveObservation
+) : LiveObservation {
+
+    override fun pause() {
+        liveObservation.pause()
+    }
+
+    override fun resume() {
+        liveObservation.resume()
+    }
+
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -17,6 +17,8 @@ import com.glia.widgets.core.authentication.AuthenticationManager
 import com.glia.widgets.core.callvisualizer.CallVisualizerManager
 import com.glia.widgets.core.chathead.ChatHeadManager
 import com.glia.widgets.core.dialog.PermissionDialogManager
+import com.glia.widgets.core.liveobservation.LiveObservation
+import com.glia.widgets.core.liveobservation.LiveObservationImpl
 import com.glia.widgets.core.notification.device.INotificationManager
 import com.glia.widgets.core.notification.device.NotificationManager
 import com.glia.widgets.core.permissions.PermissionManager
@@ -122,6 +124,11 @@ internal object Dependencies {
     @JvmStatic
     val secureConversations: SecureConversations by lazy {
         SecureConversationsImpl(gliaCore.secureConversations)
+    }
+
+    @JvmStatic
+    val liveObservation: LiveObservation by lazy {
+        LiveObservationImpl(gliaCore.liveObservation)
     }
 
     @Synchronized

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -11,6 +11,7 @@ import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.comms.EngagementOptions
 import com.glia.androidsdk.engagement.Survey
 import com.glia.androidsdk.fcm.PushNotifications
+import com.glia.androidsdk.liveobservation.LiveObservation
 import com.glia.androidsdk.omnibrowse.Omnibrowse
 import com.glia.androidsdk.queuing.Queue
 import com.glia.androidsdk.queuing.QueueTicket
@@ -30,6 +31,7 @@ internal interface GliaCore {
     val currentEngagement: Optional<Engagement>
     val callVisualizer: Omnibrowse
     val secureConversations: SecureConversations
+    val liveObservation: LiveObservation
     @Throws(GliaException::class)
     fun init(config: GliaConfig)
     fun init(config: GliaConfig, callback: RequestCallback<Boolean?>)

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -12,6 +12,7 @@ import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.comms.EngagementOptions
 import com.glia.androidsdk.engagement.Survey
 import com.glia.androidsdk.fcm.PushNotifications
+import com.glia.androidsdk.liveobservation.LiveObservation
 import com.glia.androidsdk.omnibrowse.Omnibrowse
 import com.glia.androidsdk.queuing.Queue
 import com.glia.androidsdk.queuing.QueueTicket
@@ -39,6 +40,9 @@ internal class GliaCoreImpl : GliaCore {
 
     override val secureConversations: SecureConversations
         get() = Glia.getSecureConversations()
+
+    override val liveObservation: LiveObservation
+        get() = Glia.getLiveObservation()
 
     @Synchronized
     @Throws(GliaException::class)


### PR DESCRIPTION
**What was solved?**
[Add getLiveObservation().pause() and getLiveObservation().resume() to Android Widgets SDK](https://glia.atlassian.net/browse/MOB-4210)

**Release notes:**
Something general once [MOB-4169](https://glia.atlassian.net/browse/MOB-4169) is done.

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-4169]: https://glia.atlassian.net/browse/MOB-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ