### PR TITLE
Add button to request PN permission in testing app

### DIFF
--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -39,7 +39,7 @@
                     android:minHeight="?attr/actionBarSize"
                     app:elevation="0dp"
                     app:menu="@menu/menu_main_fragment"
-                    app:title="@string/app_name" />
+                    app:title="Widgets Testing App" />
 
             </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/menu/menu_main_fragment.xml
+++ b/app/src/main/res/menu/menu_main_fragment.xml
@@ -52,9 +52,9 @@
         app:showAsAction="never" />
 
     <item
-        android:id="@+id/menu_broadcast_end_screen_sharing_event"
+        android:id="@+id/request_push_notifications_permission"
         android:enabled="true"
-        android:title="Broadcast End Screen Sharing Event"
+        android:title="Request Push Notifications Permission"
         android:visible="true"
         app:showAsAction="never" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,4 +122,8 @@
     <string name="visitor_info_saving">Saving…</string>
     <string name="visitor_info_loading">Loading…</string>
 
+   <string name="push_notification_permission_granted">PN permission: Granted</string>
+   <string name="push_notification_permission_not_granted">PN permission: Not Granted</string>
+   <string name="push_notification_permission_not_required">PN permission: Not Required</string>
+
 </resources>


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4321

**What was solved?**

https://github.com/user-attachments/assets/02b257ef-1df0-4e65-8849-4a4e1dc3fe3f

For the API versions that not require PN permission, the subtitle will show that the PN is not required.

https://github.com/user-attachments/assets/02a2eaf5-1dc3-413d-8bef-805fea3e3c68


**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
