### PR TITLE
Add getQueues() to Android Widgets SDK

### DIFF
--- a/widgetssdk/src/androidTest/java/com/glia/widgets/call/CallStateHelper.java
+++ b/widgetssdk/src/androidTest/java/com/glia/widgets/call/CallStateHelper.java
@@ -1,6 +1,6 @@
 package com.glia.widgets.call;
 
-import com.glia.androidsdk.Engagement;
+import com.glia.widgets.core.engagement.MediaType;
 
 public class CallStateHelper {
     public final boolean integratorCallStarted;
@@ -11,7 +11,7 @@ public class CallStateHelper {
     public final boolean isMuted;
     public final boolean hasVideo;
     public final String companyName;
-    public final Engagement.MediaType requestedMediaType;
+    public final MediaType requestedMediaType;
     public final boolean isSpeakerOn;
 
     public CallStateHelper(boolean integratorCallStarted,
@@ -23,7 +23,7 @@ public class CallStateHelper {
                            boolean hasVideo,
                            String queueTicketId,
                            String companyName,
-                           Engagement.MediaType requestedMediaType,
+                           MediaType requestedMediaType,
                            boolean isSpeakerOn) {
         this.integratorCallStarted = integratorCallStarted;
         this.isVisible = isVisible;
@@ -47,7 +47,7 @@ public class CallStateHelper {
         private boolean hasVideo;
         private String queueTicketId;
         private String companyName;
-        private Engagement.MediaType requestedMediaType;
+        private MediaType requestedMediaType;
         private boolean isSpeakerOn;
 
         public CallStateHelper.Builder setIntegratorCallStarted(boolean integratorCallStarted) {
@@ -95,7 +95,7 @@ public class CallStateHelper {
             return this;
         }
 
-        public CallStateHelper.Builder setRequestedMediaType(Engagement.MediaType requestedMediaType) {
+        public CallStateHelper.Builder setRequestedMediaType(MediaType requestedMediaType) {
             this.requestedMediaType = requestedMediaType;
             return this;
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -13,6 +13,8 @@ import com.glia.widgets.chat.adapter.WebViewCardAdapter
 import com.glia.widgets.core.authentication.toCoreType
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer
 import com.glia.widgets.core.liveobservation.LiveObservation
+import com.glia.widgets.core.queue.Queue
+import com.glia.widgets.core.queue.toWidgetsType
 import com.glia.widgets.core.secureconversations.SecureConversations
 import com.glia.widgets.core.visitor.Authentication
 import com.glia.widgets.core.visitor.VisitorInfo
@@ -205,6 +207,29 @@ object GliaWidgets {
     @JvmStatic
     fun isInitialized(): Boolean {
         return glia().isInitialized
+    }
+
+    /**
+     * Fetches all queues and their information for the current site.
+     *
+     * @param onSuccess Callback invoked when the queues are successfully retrieved.
+     *                  Provides a collection of [Queue] objects or `null` if no queues are available.
+     * @param onError Callback invoked when an error occurs during the retrieval process.
+     *                Provides a [GliaWidgetsException] describing the error.
+     */
+    @JvmStatic
+    fun getQueues(
+        onSuccess: OnSuccess<Collection<Queue>?>,
+        onError: OnError
+    ) {
+        glia().getQueues(
+            onSuccess = { queues ->
+                onSuccess.onSuccess(queues.toWidgetsType())
+            },
+            onError = {
+                onError.onError(from(it))
+            }
+        )
     }
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
@@ -1,12 +1,12 @@
 package com.glia.widgets.call
 
 import android.os.Bundle
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.widgets.R
 import com.glia.widgets.base.FadeTransitionActivity
 import com.glia.widgets.call.CallView.OnNavigateToChatListener
 import com.glia.widgets.call.CallView.OnNavigateToWebBrowserListener
 import com.glia.widgets.chat.Intention
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.ExtraKeys
 import com.glia.widgets.helper.Logger

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallContract.kt
@@ -1,10 +1,10 @@
 package com.glia.widgets.call
 
-import com.glia.androidsdk.Engagement
 import com.glia.widgets.base.BaseController
 import com.glia.widgets.base.BaseView
 import com.glia.widgets.core.dialog.model.ConfirmationDialogLinks
 import com.glia.widgets.core.dialog.model.Link
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.locale.LocaleString
 
 internal interface CallContract {
@@ -20,7 +20,7 @@ internal interface CallContract {
         fun muteButtonClicked()
         fun videoButtonClicked()
         fun flipVideoButtonClicked()
-        fun startCall(mediaType: Engagement.MediaType?, upgradeToCall: Boolean)
+        fun startCall(mediaType: MediaType?, upgradeToCall: Boolean)
 
         fun onResume()
         fun onPause()

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.call
 
 import android.text.format.DateUtils
-import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.comms.Audio
 import com.glia.androidsdk.comms.MediaDirection
@@ -20,6 +19,7 @@ import com.glia.widgets.core.dialog.domain.ConfirmationDialogLinksUseCase
 import com.glia.widgets.core.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
 import com.glia.widgets.core.dialog.model.ConfirmationDialogLinks
 import com.glia.widgets.core.dialog.model.Link
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.engagement.domain.ConfirmationDialogUseCase
 import com.glia.widgets.core.engagement.domain.ShouldShowMediaEngagementViewUseCase
 import com.glia.widgets.core.notification.domain.CallNotificationUseCase
@@ -179,12 +179,12 @@ internal class CallController(
         emitViewState(callState.engagementStarted())
     }
 
-    override fun startCall(mediaType: Engagement.MediaType?, upgradeToCall: Boolean) {
+    override fun startCall(mediaType: MediaType?, upgradeToCall: Boolean) {
         if (upgradeToCall || mediaType == null) {
             initCall(mediaType)
             return
         }
-        handleCallPermissionsUseCase.invoke(mediaType) { isPermissionsGranted: Boolean ->
+        handleCallPermissionsUseCase(mediaType) { isPermissionsGranted: Boolean ->
             if (isPermissionsGranted) {
                 initCall(mediaType)
             } else {
@@ -193,7 +193,7 @@ internal class CallController(
         }
     }
 
-    private fun initCall(mediaType: Engagement.MediaType?) {
+    private fun initCall(mediaType: MediaType?) {
         if (isShowOverlayPermissionRequestDialogUseCase()) {
             dialogController.showOverlayPermissionsDialog()
         } else {
@@ -361,10 +361,10 @@ internal class CallController(
 
     private fun handleMediaUpgradeAcceptResult(it: MediaUpgradeOffer) {
         d(TAG, "upgradeOfferChoiceSubmitSuccess")
-        val mediaType: Engagement.MediaType = if (it.video != null && it.video != MediaDirection.NONE) {
-            Engagement.MediaType.VIDEO
+        val mediaType: MediaType = if (it.video != null && it.video != MediaDirection.NONE) {
+            MediaType.VIDEO
         } else {
-            Engagement.MediaType.AUDIO
+            MediaType.AUDIO
         }
         emitViewState(callState.changeRequestedMediaType(mediaType))
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallState.java
@@ -7,6 +7,7 @@ import com.glia.androidsdk.Engagement;
 import com.glia.androidsdk.comms.Media;
 import com.glia.androidsdk.comms.MediaState;
 import com.glia.androidsdk.comms.Video;
+import com.glia.widgets.core.engagement.MediaType;
 import com.glia.widgets.helper.Logger;
 import com.glia.widgets.view.floatingvisitorvideoview.FloatingVisitorVideoContract.FlipButtonState;
 
@@ -23,7 +24,7 @@ class CallState {
     public final boolean isMuted;
     public final boolean hasVideo;
     @Nullable
-    public final Engagement.MediaType requestedMediaType;
+    public final MediaType requestedMediaType;
     public final boolean isSpeakerOn;
     public final boolean isOnHold;
     //    Need this to not update all views when only time is changed.
@@ -141,7 +142,7 @@ class CallState {
     public Boolean isCurrentCallVideo() {
         if (requestedMediaType == null && callStatus.getOperatorMediaState() == null) return null;
 
-        return callStatus.getOperatorMediaState() == null ? requestedMediaType == Engagement.MediaType.VIDEO : callStatus.getOperatorMediaState().getVideo() != null;
+        return callStatus.getOperatorMediaState() == null ? requestedMediaType == MediaType.VIDEO : callStatus.getOperatorMediaState().getVideo() != null;
     }
 
     @NonNull
@@ -181,7 +182,7 @@ class CallState {
             .createCallState();
     }
 
-    public CallState changeRequestedMediaType(Engagement.MediaType requestedMediaType) {
+    public CallState changeRequestedMediaType(MediaType requestedMediaType) {
         return new Builder()
             .copyFrom(this)
             .setRequestedMediaType(requestedMediaType)
@@ -472,7 +473,7 @@ class CallState {
             visitorMediaState.getAudio().getStatus() != Media.Status.PLAYING;
     }
 
-    public CallState initCall(@Nullable Engagement.MediaType requestedMediaType) {
+    public CallState initCall(@Nullable MediaType requestedMediaType) {
         return new Builder()
             .copyFrom(this)
             .setIntegratorCallStarted(true)
@@ -494,7 +495,7 @@ class CallState {
         private boolean landscapeLayoutControlsVisible;
         private boolean isMuted;
         private boolean hasVideo;
-        private Engagement.MediaType requestedMediaType;
+        private MediaType requestedMediaType;
         private boolean isSpeakerOn;
         private boolean isOnHold;
         //Maybe helpful when converting to Kotlin, as an android studio makes fields nullable.
@@ -538,7 +539,7 @@ class CallState {
             return this;
         }
 
-        public Builder setRequestedMediaType(Engagement.MediaType requestedMediaType) {
+        public Builder setRequestedMediaType(MediaType requestedMediaType) {
             this.requestedMediaType = requestedMediaType;
             return this;
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -19,7 +19,6 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.transition.TransitionManager
 import androidx.transition.TransitionSet
-import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.comms.MediaState
 import com.glia.androidsdk.comms.VideoView
 import com.glia.widgets.Constants
@@ -29,6 +28,7 @@ import com.glia.widgets.UiTheme.UiThemeBuilder
 import com.glia.widgets.call.CallState.ViewState
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.dialog.model.DialogState
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.databinding.CallButtonsLayoutBinding
 import com.glia.widgets.databinding.CallViewBinding
 import com.glia.widgets.di.Dependencies
@@ -173,7 +173,7 @@ internal class CallView(
         }
     }
 
-    fun startCall(isUpgradeToCall: Boolean, mediaType: Engagement.MediaType?) {
+    fun startCall(isUpgradeToCall: Boolean, mediaType: MediaType?) {
         callController?.startCall(mediaType, isUpgradeToCall)
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/call/domain/HandleCallPermissionsUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/domain/HandleCallPermissionsUseCase.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.call.domain
 
-import com.glia.androidsdk.Engagement
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.permissions.PermissionManager
 import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
 import com.glia.widgets.permissions.PermissionsGrantedCallback
@@ -9,7 +9,7 @@ internal class HandleCallPermissionsUseCase(
     private val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase,
     private val permissionManager: PermissionManager
 ) {
-    operator fun invoke(mediaType: Engagement.MediaType, callback: PermissionsGrantedCallback) {
+    operator fun invoke(mediaType: MediaType, callback: PermissionsGrantedCallback) {
         val permissions = permissionManager.getPermissionsForEngagementMediaType(
             mediaType,
             isCurrentEngagementCallVisualizerUseCase()

--- a/widgetssdk/src/main/java/com/glia/widgets/core/engagement/MediaType.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/engagement/MediaType.kt
@@ -1,0 +1,17 @@
+package com.glia.widgets.core.engagement
+
+/**
+ * Defines different media types supported by Glia.
+ */
+enum class MediaType {
+    TEXT,
+    AUDIO,
+    PHONE,
+    VIDEO,
+    MESSAGING,
+
+    /**
+     * Default value, could be received if value returned by server is not supported by current version of SDK
+     */
+    UNKNOWN
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/permissions/PermissionManager.kt
@@ -7,9 +7,9 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
 import androidx.annotation.VisibleForTesting
-import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.comms.MediaDirection
 import com.glia.androidsdk.comms.MediaUpgradeOffer
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.permissions.Permissions
@@ -56,14 +56,14 @@ internal class PermissionManager(
     }
 
     @SuppressLint("InlinedApi")
-    fun getPermissionsForEngagementMediaType(mediaType: Engagement.MediaType, isCallVisualizer: Boolean): Permissions {
+    fun getPermissionsForEngagementMediaType(mediaType: MediaType, isCallVisualizer: Boolean): Permissions {
         val requiredPermissions = mutableListOf<String>()
         val additionalPermissions = mutableListOf<String>()
-        if (mediaType == Engagement.MediaType.VIDEO) {
+        if (mediaType == MediaType.VIDEO) {
             requiredPermissions.add(Manifest.permission.CAMERA)
         }
         if (!isCallVisualizer) {
-            if (mediaType == Engagement.MediaType.AUDIO || mediaType == Engagement.MediaType.VIDEO) {
+            if (mediaType == MediaType.AUDIO || mediaType == MediaType.VIDEO) {
                 requiredPermissions.add(Manifest.permission.RECORD_AUDIO)
             }
             if (sdkInt > Build.VERSION_CODES.R) {

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/Queue.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/Queue.kt
@@ -1,19 +1,55 @@
 package com.glia.widgets.core.queue
 
-import com.glia.androidsdk.Engagement
-import com.glia.androidsdk.queuing.QueueState
+import com.glia.androidsdk.Engagement.MediaType as CoreSdkMediaType
+import com.glia.androidsdk.queuing.QueueState.Status as CoreSdkQueueState
+import com.glia.androidsdk.queuing.Queue as CoreSdkQueue
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.view.unifiedui.Mergeable
 import com.glia.widgets.view.unifiedui.merge
-import com.glia.androidsdk.queuing.Queue as CoreSdkQueue
 
-internal data class Queue(
+/**
+ * Contains information about Queue.
+ *
+ * @see [com.glia.widgets.GliaWidgets.getQueues]
+ */
+data class Queue(
     val id: String,
     val name: String,
     val isDefault: Boolean?,
     val lastUpdatedMillis: Long,
-    val medias: List<Engagement.MediaType>,
-    val status: QueueState.Status
+    val medias: List<MediaType>,
+    val status: Status
 ) : Mergeable<Queue> {
+    /**
+     * Defines possible Queue state types.
+     */
+    enum class Status {
+        /**
+         * Visitor can enqueue
+         */
+        OPEN,
+
+        /**
+         * Visitor cannot enqueue because the Queue is closed
+         */
+        CLOSED,
+
+        /**
+         * Visitor cannot enqueue because the Queue reached its max capacity
+         */
+        FULL,
+
+        /**
+         * Visitor cannot enqueue because the Queue is unstaffed
+         */
+        UNSTAFFED,
+
+        /**
+         * Visitor should not enqueue because the Queue state is not supported by current version of SDK
+         */
+        UNKNOWN
+    }
+
     override fun merge(other: Queue): Queue = Queue(
         id = id merge other.id,
         name = name merge other.name,
@@ -24,11 +60,43 @@ internal data class Queue(
     )
 }
 
-internal fun CoreSdkQueue.asLocalQueue(): Queue = Queue(
+internal fun CoreSdkQueue.toWidgetsType(): Queue = Queue(
     id = id,
     name = name,
     isDefault = isDefault,
     lastUpdatedMillis = lastUpdatedMillis,
-    medias = state.medias.asList(),
-    status = state.status
+    medias = state.medias.map { it.toWidgetsType() },
+    status = state.status.toWidgetsType()
 )
+
+internal fun Array<CoreSdkQueue>.toWidgetsType(): Collection<Queue> =
+    map { it.toWidgetsType() }
+
+internal fun CoreSdkMediaType.toWidgetsType(): MediaType =
+    when (this) {
+        CoreSdkMediaType.TEXT -> MediaType.TEXT
+        CoreSdkMediaType.AUDIO -> MediaType.AUDIO
+        CoreSdkMediaType.PHONE -> MediaType.PHONE
+        CoreSdkMediaType.VIDEO -> MediaType.VIDEO
+        CoreSdkMediaType.MESSAGING -> MediaType.MESSAGING
+        else -> MediaType.UNKNOWN
+    }
+
+internal fun CoreSdkQueueState.toWidgetsType(): Queue.Status =
+    when (this) {
+        CoreSdkQueueState.OPEN -> Queue.Status.OPEN
+        CoreSdkQueueState.CLOSED -> Queue.Status.CLOSED
+        CoreSdkQueueState.FULL -> Queue.Status.FULL
+        CoreSdkQueueState.UNSTAFFED -> Queue.Status.UNSTAFFED
+        else -> Queue.Status.UNKNOWN
+    }
+
+internal fun MediaType.toCoreType(): CoreSdkMediaType =
+    when (this) {
+        MediaType.TEXT -> CoreSdkMediaType.TEXT
+        MediaType.AUDIO -> CoreSdkMediaType.AUDIO
+        MediaType.PHONE -> CoreSdkMediaType.PHONE
+        MediaType.VIDEO -> CoreSdkMediaType.VIDEO
+        MediaType.MESSAGING -> CoreSdkMediaType.MESSAGING
+        else -> CoreSdkMediaType.UNKNOWN
+    }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/queue/QueueRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/queue/QueueRepository.kt
@@ -97,7 +97,7 @@ internal class QueueRepositoryImpl(
     }
 
     private fun siteQueuesReceived(queues: Array<CoreSdkQueue>) {
-        siteQueues.onNext(queues.map { it.asLocalQueue() })
+        siteQueues.onNext(queues.map { it.toWidgetsType() })
         subscribeToQueues()
         subscribeToQueueUpdates()
     }
@@ -168,7 +168,7 @@ internal class QueueRepositoryImpl(
             return
         }
 
-        currentQueues[index] = currentQueue merge coreSdkQueue.asLocalQueue()
+        currentQueues[index] = currentQueue merge coreSdkQueue.toWidgetsType()
 
         _queuesState.onNext(QueuesState.Queues(currentQueues.toList()))
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCase.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.core.secureconversations.domain
 
-import com.glia.androidsdk.Engagement.MediaType
-import com.glia.androidsdk.queuing.QueueState
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.queue.QueuesState
@@ -23,7 +22,7 @@ internal class IsMessagingAvailableUseCase(private val queueRepository: QueueRep
     }
 
     private fun isMessagingAvailable(queues: List<Queue>): Boolean = queues.asSequence()
-        .filterNot { it.status == QueueState.Status.CLOSED }
-        .filterNot { it.status == QueueState.Status.UNKNOWN }
+        .filterNot { it.status == Queue.Status.CLOSED }
+        .filterNot { it.status == Queue.Status.UNKNOWN }
         .any { it.medias.contains(MediaType.MESSAGING) } // Support messaging
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SecureConversationTopBannerVisibilityUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/core/secureconversations/domain/SecureConversationTopBannerVisibilityUseCase.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.core.secureconversations.domain
 
-import com.glia.androidsdk.Engagement.MediaType
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.queue.QueuesState

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -21,6 +21,7 @@ import com.glia.androidsdk.visitor.Authentication
 import com.glia.androidsdk.visitor.VisitorInfo
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest
 import com.glia.widgets.core.authentication.AuthenticationManager
+import com.glia.widgets.core.engagement.MediaType
 import java.io.InputStream
 import java.util.Optional
 import java.util.function.Consumer
@@ -46,7 +47,7 @@ internal interface GliaCore {
 
     fun queueForEngagement(
         queueIds: List<String>,
-        mediaType: Engagement.MediaType,
+        mediaType: MediaType,
         visitorContextAssetId: String?,
         engagementOptions: EngagementOptions?,
         mediaPermissionRequestCode: Int,

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -22,6 +22,8 @@ import com.glia.androidsdk.visitor.Authentication
 import com.glia.androidsdk.visitor.VisitorInfo
 import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest
 import com.glia.widgets.core.authentication.AuthenticationManager
+import com.glia.widgets.core.engagement.MediaType
+import com.glia.widgets.core.queue.toCoreType
 import java.io.InputStream
 import java.util.Optional
 import java.util.function.Consumer
@@ -92,7 +94,7 @@ internal class GliaCoreImpl : GliaCore {
 
     override fun queueForEngagement(
         queueIds: List<String>,
-        mediaType: Engagement.MediaType,
+        mediaType: MediaType,
         visitorContextAssetId: String?,
         engagementOptions: EngagementOptions?,
         mediaPermissionRequestCode: Int,
@@ -101,7 +103,7 @@ internal class GliaCoreImpl : GliaCore {
     ) {
         Glia.queueForEngagement(
             queueIds.toTypedArray(),
-            mediaType,
+            mediaType.toCoreType(),
             visitorContextAssetId,
             engagementOptions,
             mediaPermissionRequestCode,

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepository.kt
@@ -2,7 +2,6 @@ package com.glia.widgets.engagement
 
 import android.app.Activity
 import android.content.Intent
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.EngagementRequest.Outcome
 import com.glia.androidsdk.IncomingEngagementRequest
 import com.glia.androidsdk.Operator
@@ -10,6 +9,7 @@ import com.glia.androidsdk.comms.CameraDevice
 import com.glia.androidsdk.comms.MediaState
 import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.androidsdk.screensharing.ScreenSharing.Mode
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.helper.Data
 import io.reactivex.rxjava3.core.Flowable
 

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -5,7 +5,6 @@ import android.app.Activity
 import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import com.glia.androidsdk.Engagement
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.EngagementRequest
 import com.glia.androidsdk.EngagementRequest.Outcome
 import com.glia.androidsdk.Glia
@@ -31,6 +30,7 @@ import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.androidsdk.screensharing.ScreenSharingRequest
 import com.glia.androidsdk.screensharing.VisitorScreenSharingState
 import com.glia.widgets.core.engagement.GliaOperatorRepository
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.Data

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
@@ -1,10 +1,10 @@
 package com.glia.widgets.engagement
 
 import com.glia.androidsdk.Engagement.ActionOnEnd
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.engagement.EngagementState
 import com.glia.androidsdk.engagement.Survey
+import com.glia.widgets.core.engagement.MediaType
 
 internal sealed interface State {
     data object NoEngagement : State

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EngagementTypeUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EngagementTypeUseCase.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.engagement.domain
 
-import com.glia.androidsdk.Engagement.MediaType
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.helper.hasAudio
 import com.glia.widgets.helper.hasVideo
 import io.reactivex.rxjava3.core.Flowable

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EnqueueForEngagementUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EnqueueForEngagementUseCase.kt
@@ -1,18 +1,18 @@
 package com.glia.widgets.engagement.domain
 
-import com.glia.androidsdk.Engagement
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
 import com.glia.widgets.engagement.EngagementRepository
 
 internal interface EnqueueForEngagementUseCase {
-    operator fun invoke(mediaType: Engagement.MediaType = Engagement.MediaType.TEXT)
+    operator fun invoke(mediaType: MediaType = MediaType.TEXT)
 }
 
 internal class EnqueueForEngagementUseCaseImpl(
     private val engagementRepository: EngagementRepository,
     private val secureConversationsRepository: SecureConversationsRepository
 ) : EnqueueForEngagementUseCase {
-    override fun invoke(mediaType: Engagement.MediaType) {
+    override fun invoke(mediaType: MediaType) {
         val replaceExisting = secureConversationsRepository.hasPendingSecureConversations || engagementRepository.isTransferredSecureConversation
         engagementRepository.queueForEngagement(mediaType, replaceExisting)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -2,9 +2,9 @@ package com.glia.widgets.entrywidget
 
 import android.app.Activity
 import androidx.annotation.VisibleForTesting
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.widgets.chat.Intention
 import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.queue.QueuesState

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -13,7 +13,6 @@ import androidx.annotation.ColorInt
 import androidx.core.graphics.drawable.DrawableCompat
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Engagement.ActionOnEnd
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.chat.AttachmentFile
@@ -24,8 +23,8 @@ import com.glia.androidsdk.comms.MediaDirection
 import com.glia.androidsdk.comms.MediaState
 import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.androidsdk.omnibrowse.OmnibrowseEngagement
-import com.glia.androidsdk.queuing.QueueState
 import com.glia.widgets.UiTheme
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Completable
@@ -46,9 +45,9 @@ internal fun ColorStateList?.colorForState(state: IntArray): Int? = this?.getCol
 internal fun String.separateStringWithSymbol(symbol: String): String = asSequence().joinToString(symbol)
 
 internal fun Queue.supportedMediaTypes(): List<MediaType>? = when {
-    status == QueueState.Status.OPEN -> medias.filterNot { it == MediaType.PHONE || it == MediaType.UNKNOWN }.takeIf { it.isNotEmpty() }
-    status == QueueState.Status.FULL && medias.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
-    status == QueueState.Status.UNSTAFFED && medias.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
+    status == Queue.Status.OPEN -> medias.filterNot { it == MediaType.PHONE || it == MediaType.UNKNOWN }.takeIf { it.isNotEmpty() }
+    status == Queue.Status.FULL && medias.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
+    status == Queue.Status.UNSTAFFED && medias.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
     else -> null
 }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/call/domain/HandleCallPermissionsUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/call/domain/HandleCallPermissionsUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.call.domain
 
-import com.glia.androidsdk.Engagement
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.permissions.PermissionManager
 import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
 import com.glia.widgets.permissions.Permissions
@@ -28,7 +28,7 @@ class HandleCallPermissionsUseCaseTest {
 
     @Test
     fun `invoke gets permissions from permission manager with MediaType VIDEO, and is call visualizer`() {
-        val mediaType = Engagement.MediaType.VIDEO
+        val mediaType = MediaType.VIDEO
         val isCallVisualizer = true
         whenever(isCurrentEngagementCallVisualizer.invoke()).thenReturn(isCallVisualizer)
         whenever(permissionManager.getPermissionsForEngagementMediaType(any(), any())).thenReturn(mock())
@@ -40,7 +40,7 @@ class HandleCallPermissionsUseCaseTest {
 
     @Test
     fun `invoke gets permissions from permission manager with MediaType AUDIO, and is not call visualizer`() {
-        val mediaType = Engagement.MediaType.AUDIO
+        val mediaType = MediaType.AUDIO
         val isCallVisualizer = false
         whenever(isCurrentEngagementCallVisualizer.invoke()).thenReturn(isCallVisualizer)
         whenever(permissionManager.getPermissionsForEngagementMediaType(any(), any())).thenReturn(mock())
@@ -59,7 +59,7 @@ class HandleCallPermissionsUseCaseTest {
         whenever(permissionManager.getPermissionsForEngagementMediaType(any(), any())).thenReturn(permissions)
         val callback = mock<PermissionsGrantedCallback>()
 
-        useCase.invoke(Engagement.MediaType.TEXT, callback)
+        useCase.invoke(MediaType.TEXT, callback)
 
         verify(permissionManager).handlePermissions(
             necessaryPermissions,

--- a/widgetssdk/src/test/java/com/glia/widgets/core/permissions/PermissionManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/permissions/PermissionManagerTest.kt
@@ -5,10 +5,10 @@ import android.content.Context
 import android.content.pm.PackageManager.PERMISSION_DENIED
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
-import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.comms.MediaDirection
 import com.glia.androidsdk.comms.MediaUpgradeOffer
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.permissions.Permissions
 import com.glia.widgets.permissions.PermissionsGrantedCallback
@@ -63,7 +63,7 @@ class PermissionManagerTest {
 
     @Test
     fun `getPermissionsForEngagementMediaType returns empty lists of permissions when mediaType is TEXT`() {
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.TEXT, false)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.TEXT, false)
 
         assertEquals(
             Permissions(
@@ -76,7 +76,7 @@ class PermissionManagerTest {
 
     @Test
     fun `getPermissionsForEngagementMediaType returns empty lists of permissions when mediaType is AUDIO`() {
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.AUDIO, false)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.AUDIO, false)
 
         assertEquals(
             Permissions(
@@ -89,7 +89,7 @@ class PermissionManagerTest {
 
     @Test
     fun `getPermissionsForEngagementMediaType returns empty lists of permissions when mediaType is VIDEO`() {
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.VIDEO, false)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.VIDEO, false)
 
         assertEquals(
             Permissions(
@@ -102,7 +102,7 @@ class PermissionManagerTest {
 
     @Test
     fun `getPermissionsForEngagementMediaType returns empty lists of permissions when mediaType is AUDIO, isCallVisualizer`() {
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.AUDIO, true)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.AUDIO, true)
 
         assertEquals(
             Permissions(
@@ -115,7 +115,7 @@ class PermissionManagerTest {
 
     @Test
     fun `getPermissionsForEngagementMediaType returns empty lists of permissions when mediaType is VIDEO, isCallVisualizer`() {
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.VIDEO, true)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.VIDEO, true)
 
         assertEquals(
             Permissions(
@@ -134,7 +134,7 @@ class PermissionManagerTest {
             permissionsRequestRepository,
             Build.VERSION_CODES.S
         )
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.TEXT, false)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.TEXT, false)
         assertEquals(
             Permissions(
                 emptyList(),
@@ -153,7 +153,7 @@ class PermissionManagerTest {
             Build.VERSION_CODES.S
         )
 
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.AUDIO, false)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.AUDIO, false)
 
         assertEquals(
             Permissions(
@@ -173,7 +173,7 @@ class PermissionManagerTest {
             Build.VERSION_CODES.S
         )
 
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.VIDEO, false)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.VIDEO, false)
 
         assertEquals(
             Permissions(
@@ -193,7 +193,7 @@ class PermissionManagerTest {
             Build.VERSION_CODES.S
         )
 
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.AUDIO, true)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.AUDIO, true)
 
         assertEquals(
             Permissions(
@@ -213,7 +213,7 @@ class PermissionManagerTest {
             Build.VERSION_CODES.S
         )
 
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.VIDEO, true)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.VIDEO, true)
 
         assertEquals(
             Permissions(
@@ -735,7 +735,7 @@ class PermissionManagerTest {
             Build.VERSION_CODES.TIRAMISU
         )
 
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.AUDIO, true)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.AUDIO, true)
 
         assertTrue(result.additionalPermissions.contains(Manifest.permission.POST_NOTIFICATIONS))
     }
@@ -749,7 +749,7 @@ class PermissionManagerTest {
             Build.VERSION_CODES.S_V2
         )
 
-        val result = permissionManager.getPermissionsForEngagementMediaType(Engagement.MediaType.VIDEO, false)
+        val result = permissionManager.getPermissionsForEngagementMediaType(MediaType.VIDEO, false)
 
         assertFalse(result.additionalPermissions.contains(Manifest.permission.POST_NOTIFICATIONS))
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/queue/QueueRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/queue/QueueRepositoryTest.kt
@@ -237,7 +237,7 @@ class QueueRepositoryTest {
         verify { configurationManager.queueIdsObservable }
 
         queueRepository.queuesState.test()
-            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.asLocalQueue())))
+            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.toWidgetsType())))
 
         queueRepository.relevantQueueIds.test().assertValue(listOf(defaultQueue.id))
         verify { gliaCore.subscribeToQueueStateUpdates(eq(listOf(defaultQueueId)), any(), any()) }
@@ -271,7 +271,7 @@ class QueueRepositoryTest {
         verify { configurationManager.queueIdsObservable }
 
         queueRepository.queuesState.test()
-            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.asLocalQueue())))
+            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.toWidgetsType())))
         queueRepository.relevantQueueIds.test().assertValue(listOf(defaultQueue.id))
         verify { gliaCore.subscribeToQueueStateUpdates(eq(listOf(defaultQueueId)), any(), any()) }
     }
@@ -305,7 +305,7 @@ class QueueRepositoryTest {
         verify { configurationManager.queueIdsObservable }
 
         queueRepository.queuesState.test()
-            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.asLocalQueue(), nonDefaultQueue.asLocalQueue())))
+            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.toWidgetsType(), nonDefaultQueue.toWidgetsType())))
         queueRepository.relevantQueueIds.test()
             .assertValue(listOf(defaultQueue.id, nonDefaultQueue.id))
         verify {
@@ -334,7 +334,7 @@ class QueueRepositoryTest {
         verify { configurationManager.queueIdsObservable }
 
         queueRepository.queuesState.test()
-            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.asLocalQueue(), nonDefaultQueue.asLocalQueue())))
+            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.toWidgetsType(), nonDefaultQueue.toWidgetsType())))
         queueRepository.relevantQueueIds.test()
             .assertValue(listOf(defaultQueue.id, nonDefaultQueue.id))
 
@@ -356,7 +356,7 @@ class QueueRepositoryTest {
         }
 
         queueRepository.queuesState.test()
-            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.asLocalQueue(), nonDefaultQueue.asLocalQueue())))
+            .assertCurrentValue(QueuesState.Queues(listOf(defaultQueue.toWidgetsType(), nonDefaultQueue.toWidgetsType())))
         queueRepository.relevantQueueIds.test()
             .assertValue(listOf(defaultQueue.id, nonDefaultQueue.id))
 
@@ -366,7 +366,7 @@ class QueueRepositoryTest {
         subscribeToQueueUpdatesCallbackSlot.captured.accept(updatedDefaultQueue)
 
         queueRepository.queuesState.test()
-            .assertCurrentValue(QueuesState.Queues(listOf(updatedDefaultQueue.asLocalQueue().copy(isDefault = true), nonDefaultQueue.asLocalQueue())))
+            .assertCurrentValue(QueuesState.Queues(listOf(updatedDefaultQueue.toWidgetsType().copy(isDefault = true), nonDefaultQueue.toWidgetsType())))
         queueRepository.relevantQueueIds.test()
             .assertValue(listOf(defaultQueue.id, nonDefaultQueue.id))
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/HasOngoingSecureConversationUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/HasOngoingSecureConversationUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.core.secureconversations.domain
 
-import com.glia.androidsdk.Engagement
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.secureconversations.SecureConversationsRepository
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -105,7 +105,7 @@ class HasOngoingSecureConversationUseCaseTest {
 
     @Test
     fun `invoke returns false when enqueueing`() {
-        mockInitialState(engagementState = State.PreQueuing(Engagement.MediaType.AUDIO), unreadMessagesCount = 10)
+        mockInitialState(engagementState = State.PreQueuing(MediaType.AUDIO), unreadMessagesCount = 10)
 
         val result = useCase().blockingLast()
         assertEquals(false, result)

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/IsMessagingAvailableUseCaseTest.kt
@@ -1,8 +1,7 @@
 package com.glia.widgets.core.secureconversations.domain
 
 import android.COMMON_EXTENSIONS_CLASS_PATH
-import com.glia.androidsdk.Engagement
-import com.glia.androidsdk.queuing.QueueState
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.queue.QueuesState
@@ -39,7 +38,7 @@ class IsMessagingAvailableUseCaseTest {
 
     @Test
     fun `invoke returns true when transferred SC`() {
-        val nonMessagingQueue = createQueueWithStatus(QueueState.Status.OPEN, false)
+        val nonMessagingQueue = createQueueWithStatus(Queue.Status.OPEN, false)
         val queuesState = QueuesState.Queues(listOf(nonMessagingQueue))
         every { queueRepository.queuesState } returns Flowable.just(queuesState)
         every { engagementRepository.engagementState } returns Flowable.just(State.TransferredToSecureConversation)
@@ -52,7 +51,7 @@ class IsMessagingAvailableUseCaseTest {
 
     @Test
     fun `invoke returns true when queue with messaging exists`() {
-        val messagingQueue = createQueueWithStatus(QueueState.Status.OPEN, true)
+        val messagingQueue = createQueueWithStatus(Queue.Status.OPEN, true)
         val queuesState = QueuesState.Queues(listOf(messagingQueue))
         every { queueRepository.queuesState } returns Flowable.just(queuesState)
         every { engagementRepository.engagementState } returns Flowable.just(State.NoEngagement)
@@ -65,7 +64,7 @@ class IsMessagingAvailableUseCaseTest {
 
     @Test
     fun `invoke returns false when no queue with messaging exists`() {
-        val nonMessagingQueue = createQueueWithStatus(QueueState.Status.OPEN, false)
+        val nonMessagingQueue = createQueueWithStatus(Queue.Status.OPEN, false)
         val queuesState = QueuesState.Queues(listOf(nonMessagingQueue))
         every { queueRepository.queuesState } returns Flowable.just(queuesState)
         every { engagementRepository.engagementState } returns Flowable.just(State.NoEngagement)
@@ -78,7 +77,7 @@ class IsMessagingAvailableUseCaseTest {
 
     @Test
     fun `invoke returns false when queue state is closed`() {
-        val closedQueue = createQueueWithStatus(QueueState.Status.CLOSED, true)
+        val closedQueue = createQueueWithStatus(Queue.Status.CLOSED, true)
         val queuesState = QueuesState.Queues(listOf(closedQueue))
         every { queueRepository.queuesState } returns Flowable.just(queuesState)
         every { engagementRepository.engagementState } returns Flowable.just(State.NoEngagement)
@@ -91,7 +90,7 @@ class IsMessagingAvailableUseCaseTest {
 
     @Test
     fun `invoke returns false when queue state is unknown`() {
-        val unknownQueue = createQueueWithStatus(QueueState.Status.UNKNOWN, true)
+        val unknownQueue = createQueueWithStatus(Queue.Status.UNKNOWN, true)
         val queuesState = QueuesState.Queues(listOf(unknownQueue))
         every { queueRepository.queuesState } returns Flowable.just(queuesState)
         every { engagementRepository.engagementState } returns Flowable.just(State.NoEngagement)
@@ -114,12 +113,12 @@ class IsMessagingAvailableUseCaseTest {
         testSubscriber.assertValue { !it }
     }
 
-    private fun createQueueWithStatus(status: QueueState.Status, supportsMessaging: Boolean): Queue {
+    private fun createQueueWithStatus(status: Queue.Status, supportsMessaging: Boolean): Queue {
         val queue = mockk<Queue>()
         every { queue.status } returns status
-        every { queue.medias } returns if (supportsMessaging) listOf(Engagement.MediaType.MESSAGING) else listOf(
-            Engagement.MediaType.TEXT,
-            Engagement.MediaType.AUDIO
+        every { queue.medias } returns if (supportsMessaging) listOf(MediaType.MESSAGING) else listOf(
+            MediaType.TEXT,
+            MediaType.AUDIO
         )
         return queue
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/SecureConversationTopBannerVisibilityUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/core/secureconversations/domain/SecureConversationTopBannerVisibilityUseCaseTest.kt
@@ -1,8 +1,7 @@
 package com.glia.widgets.core.secureconversations.domain
 
 import android.assertCurrentValue
-import com.glia.androidsdk.Engagement
-import com.glia.androidsdk.queuing.QueueState
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.queue.QueuesState
@@ -71,12 +70,12 @@ class SecureConversationTopBannerVisibilityUseCaseTest {
     fun `returns false when queue list has no live media in open queue`() {
         scheduleIncomingQueues(
             newQueue(
-                status = QueueState.Status.OPEN,
-                media = listOf(Engagement.MediaType.MESSAGING)
+                status = Queue.Status.OPEN,
+                media = listOf(MediaType.MESSAGING)
             ),
             newQueue(
-                status = QueueState.Status.OPEN,
-                media = listOf(Engagement.MediaType.UNKNOWN)
+                status = Queue.Status.OPEN,
+                media = listOf(MediaType.UNKNOWN)
             )
         )
 
@@ -90,16 +89,16 @@ class SecureConversationTopBannerVisibilityUseCaseTest {
     fun `returns false when queue list has no open queue`() {
         scheduleIncomingQueues(
             newQueue(
-                status = QueueState.Status.UNSTAFFED,
-                media = listOf(Engagement.MediaType.TEXT)
+                status = Queue.Status.UNSTAFFED,
+                media = listOf(MediaType.TEXT)
             ),
             newQueue(
-                status = QueueState.Status.CLOSED,
-                media = listOf(Engagement.MediaType.TEXT)
+                status = Queue.Status.CLOSED,
+                media = listOf(MediaType.TEXT)
             ),
             newQueue(
-                status = QueueState.Status.FULL,
-                media = listOf(Engagement.MediaType.TEXT)
+                status = Queue.Status.FULL,
+                media = listOf(MediaType.TEXT)
             )
         )
 
@@ -113,8 +112,8 @@ class SecureConversationTopBannerVisibilityUseCaseTest {
     fun `returns true when queue has open queue with text media`() {
         scheduleIncomingQueues(
             newQueue(
-                status = QueueState.Status.OPEN,
-                media = listOf(Engagement.MediaType.TEXT)
+                status = Queue.Status.OPEN,
+                media = listOf(MediaType.TEXT)
             )
         )
 
@@ -128,8 +127,8 @@ class SecureConversationTopBannerVisibilityUseCaseTest {
     fun `returns true when queue has open queue with audio media`() {
         scheduleIncomingQueues(
             newQueue(
-                status = QueueState.Status.OPEN,
-                media = listOf(Engagement.MediaType.AUDIO)
+                status = Queue.Status.OPEN,
+                media = listOf(MediaType.AUDIO)
             )
         )
 
@@ -143,8 +142,8 @@ class SecureConversationTopBannerVisibilityUseCaseTest {
     fun `returns true when queue has open queue with video media`() {
         scheduleIncomingQueues(
             newQueue(
-                status = QueueState.Status.OPEN,
-                media = listOf(Engagement.MediaType.VIDEO)
+                status = Queue.Status.OPEN,
+                media = listOf(MediaType.VIDEO)
             )
         )
 
@@ -159,7 +158,7 @@ class SecureConversationTopBannerVisibilityUseCaseTest {
         whenever(queueRepository.queuesState) doReturn Flowable.just(QueuesState.Queues(queueList.toList()))
     }
 
-    private fun newQueue(status: QueueState.Status, media: List<Engagement.MediaType>): Queue {
+    private fun newQueue(status: Queue.Status, media: List<MediaType>): Queue {
         return Queue("id", "name", false, System.currentTimeMillis(), media, status)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
@@ -4,7 +4,6 @@ import android.LOGGER_PATH
 import android.app.Activity
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Engagement.ActionOnEnd
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.EngagementRequest
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaException
@@ -31,6 +30,7 @@ import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.androidsdk.screensharing.ScreenSharingRequest
 import com.glia.androidsdk.screensharing.VisitorScreenSharingState
 import com.glia.widgets.core.engagement.GliaOperatorRepository
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.Data

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementDomainTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementDomainTest.kt
@@ -5,7 +5,6 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.comms.Media
 import com.glia.androidsdk.comms.MediaState
@@ -15,6 +14,7 @@ import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.core.dialog.DialogContract
 import com.glia.widgets.core.fileupload.FileAttachmentRepository
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.notification.domain.CallNotificationUseCase
 import com.glia.widgets.core.permissions.PermissionManager
 import com.glia.widgets.core.screensharing.MEDIA_PROJECTION_SERVICE_ACTION_START
@@ -328,7 +328,7 @@ class EngagementDomainTest {
         val secureConversationsRepository: SecureConversationsRepository = mockk(relaxUnitFun = true) {
             every { hasPendingSecureConversations } returns false
         }
-        val mediaType: Engagement.MediaType = mockk(relaxUnitFun = true)
+        val mediaType: MediaType = mockk(relaxUnitFun = true)
 
         val useCase: EnqueueForEngagementUseCase = EnqueueForEngagementUseCaseImpl(
             engagementRepository = engagementRepository,
@@ -350,7 +350,7 @@ class EngagementDomainTest {
         val secureConversationsRepository: SecureConversationsRepository = mockk(relaxUnitFun = true) {
             every { hasPendingSecureConversations } returns false
         }
-        val mediaType: Engagement.MediaType = mockk(relaxUnitFun = true)
+        val mediaType: MediaType = mockk(relaxUnitFun = true)
 
         val useCase: EnqueueForEngagementUseCase = EnqueueForEngagementUseCaseImpl(
             engagementRepository = engagementRepository,
@@ -372,7 +372,7 @@ class EngagementDomainTest {
         val secureConversationsRepository: SecureConversationsRepository = mockk(relaxUnitFun = true) {
             every { hasPendingSecureConversations } returns true
         }
-        val mediaType: Engagement.MediaType = mockk(relaxUnitFun = true)
+        val mediaType: MediaType = mockk(relaxUnitFun = true)
 
         val useCase: EnqueueForEngagementUseCase = EnqueueForEngagementUseCaseImpl(
             engagementRepository = engagementRepository,

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementTypeUseCaseImplTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/domain/EngagementTypeUseCaseImplTest.kt
@@ -1,9 +1,9 @@
 package com.glia.widgets.engagement.domain
 
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.comms.Audio
 import com.glia.androidsdk.comms.MediaState
 import com.glia.androidsdk.comms.Video
+import com.glia.widgets.core.engagement.MediaType
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK

--- a/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/entrywidget/EntryWidgetControllerTest.kt
@@ -3,9 +3,9 @@ package com.glia.widgets.entrywidget
 import android.COMMON_EXTENSIONS_CLASS_PATH
 import android.app.Activity
 import com.glia.androidsdk.Engagement
-import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.engagement.EngagementState
 import com.glia.widgets.chat.domain.IsAuthenticatedUseCase
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import com.glia.widgets.core.queue.QueueRepository
 import com.glia.widgets.core.queue.QueuesState

--- a/widgetssdk/src/test/java/com/glia/widgets/helper/SupportedMediaTypesTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/helper/SupportedMediaTypesTest.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.helper
 
-import com.glia.androidsdk.Engagement
-import com.glia.androidsdk.queuing.QueueState
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.core.queue.Queue
 import io.mockk.every
 import io.mockk.mockk
@@ -15,21 +14,21 @@ class SupportedMediaTypesTest {
     @Test
     fun `supportedMediaTypes returns MESSAGING when queue is FULL and contains MESSAGING`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.FULL
-            every { medias } returns listOf(Engagement.MediaType.TEXT, Engagement.MediaType.MESSAGING)
+            every { status } returns Queue.Status.FULL
+            every { medias } returns listOf(MediaType.TEXT, MediaType.MESSAGING)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
 
         assertEquals(1, supportedMediaTypes?.size)
-        assertTrue(supportedMediaTypes!!.contains(Engagement.MediaType.MESSAGING))
+        assertTrue(supportedMediaTypes!!.contains(MediaType.MESSAGING))
     }
 
     @Test
     fun `supportedMediaTypes returns null when queue is FULL and does not contain MESSAGING`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.FULL
-            every { medias } returns listOf(Engagement.MediaType.TEXT, Engagement.MediaType.AUDIO)
+            every { status } returns Queue.Status.FULL
+            every { medias } returns listOf(MediaType.TEXT, MediaType.AUDIO)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -40,21 +39,21 @@ class SupportedMediaTypesTest {
     @Test
     fun `supportedMediaTypes returns MESSAGING when queue is UNSTAFFED and contains MESSAGING`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.UNSTAFFED
-            every { medias } returns listOf(Engagement.MediaType.TEXT, Engagement.MediaType.MESSAGING)
+            every { status } returns Queue.Status.UNSTAFFED
+            every { medias } returns listOf(MediaType.TEXT, MediaType.MESSAGING)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
 
         assertEquals(1, supportedMediaTypes?.size)
-        assertTrue(supportedMediaTypes!!.contains(Engagement.MediaType.MESSAGING))
+        assertTrue(supportedMediaTypes!!.contains(MediaType.MESSAGING))
     }
 
     @Test
     fun `supportedMediaTypes returns MESSAGING when queue is UNSTAFFED and does not contain MESSAGING`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.UNSTAFFED
-            every { medias } returns listOf(Engagement.MediaType.TEXT, Engagement.MediaType.VIDEO)
+            every { status } returns Queue.Status.UNSTAFFED
+            every { medias } returns listOf(MediaType.TEXT, MediaType.VIDEO)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -65,8 +64,8 @@ class SupportedMediaTypesTest {
     @Test
     fun `supportedMediaTypes filters out Phone and UNKNOWN when queue is OPEN`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.OPEN
-            every { medias } returns listOf(Engagement.MediaType.PHONE, Engagement.MediaType.UNKNOWN)
+            every { status } returns Queue.Status.OPEN
+            every { medias } returns listOf(MediaType.PHONE, MediaType.UNKNOWN)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -77,31 +76,31 @@ class SupportedMediaTypesTest {
     @Test
     fun `supportedMediaTypes filters returns all types except Phone and UNKNOWN when queue is OPEN`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.OPEN
+            every { status } returns Queue.Status.OPEN
             every { medias } returns listOf(
-                Engagement.MediaType.TEXT,
-                Engagement.MediaType.AUDIO,
-                Engagement.MediaType.VIDEO,
-                Engagement.MediaType.MESSAGING,
-                Engagement.MediaType.PHONE,
-                Engagement.MediaType.UNKNOWN
+                MediaType.TEXT,
+                MediaType.AUDIO,
+                MediaType.VIDEO,
+                MediaType.MESSAGING,
+                MediaType.PHONE,
+                MediaType.UNKNOWN
             )
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
 
         assertEquals(4, supportedMediaTypes?.size)
-        assertTrue(supportedMediaTypes!!.contains(Engagement.MediaType.TEXT))
-        assertTrue(supportedMediaTypes.contains(Engagement.MediaType.AUDIO))
-        assertTrue(supportedMediaTypes.contains(Engagement.MediaType.VIDEO))
-        assertTrue(supportedMediaTypes.contains(Engagement.MediaType.MESSAGING))
+        assertTrue(supportedMediaTypes!!.contains(MediaType.TEXT))
+        assertTrue(supportedMediaTypes.contains(MediaType.AUDIO))
+        assertTrue(supportedMediaTypes.contains(MediaType.VIDEO))
+        assertTrue(supportedMediaTypes.contains(MediaType.MESSAGING))
     }
 
     @Test
     fun `supportedMediaTypes returns null when queue is CLOSED`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.CLOSED
-            every { medias } returns listOf(Engagement.MediaType.TEXT, Engagement.MediaType.UNKNOWN)
+            every { status } returns Queue.Status.CLOSED
+            every { medias } returns listOf(MediaType.TEXT, MediaType.UNKNOWN)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -112,8 +111,8 @@ class SupportedMediaTypesTest {
     @Test
     fun `supportedMediaTypes returns null when queue status is UNKNOWN`() {
         val queue: Queue = mockk {
-            every { status } returns QueueState.Status.UNKNOWN
-            every { medias } returns listOf(Engagement.MediaType.TEXT, Engagement.MediaType.UNKNOWN)
+            every { status } returns Queue.Status.UNKNOWN
+            every { medias } returns listOf(MediaType.TEXT, MediaType.UNKNOWN)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()

--- a/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
@@ -7,6 +7,7 @@ import com.glia.androidsdk.Engagement
 import com.glia.widgets.chat.ChatView
 import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.engagement.EndedBy
 import com.glia.widgets.engagement.ScreenSharingState
 import com.glia.widgets.engagement.State
@@ -143,7 +144,7 @@ internal class ActivityWatcherForChatHeadTest {
     fun `bubble will be updated when PreQueuing`() {
         mockShouldShowChatHead()
 
-        engagementStateFlowable.onNext(State.PreQueuing(Engagement.MediaType.TEXT))
+        engagementStateFlowable.onNext(State.PreQueuing(MediaType.TEXT))
         verifyBubbleIsShowed(times = 2)
     }
 
@@ -151,7 +152,7 @@ internal class ActivityWatcherForChatHeadTest {
     fun `bubble will be updated when Queueing is started`() {
         mockShouldShowChatHead()
 
-        engagementStateFlowable.onNext(State.Queuing("", Engagement.MediaType.TEXT))
+        engagementStateFlowable.onNext(State.Queuing("", MediaType.TEXT))
         verifyBubbleIsShowed(times = 2)
     }
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/call/CallViewVideoSnapshotTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/call/CallViewVideoSnapshotTest.kt
@@ -2,7 +2,7 @@ package com.glia.widgets.call
 
 import android.graphics.Color
 import com.android.ide.common.rendering.api.SessionParams
-import com.glia.androidsdk.Engagement
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.SnapshotTest
 import org.junit.Test
 
@@ -12,7 +12,7 @@ internal class CallViewVideoSnapshotTest : SnapshotTest(
 
     // MARK: Init call
 
-    private fun initCallState() = callState().initCall(requestedMediaType = Engagement.MediaType.VIDEO)
+    private fun initCallState() = callState().initCall(requestedMediaType = MediaType.VIDEO)
 
     @Test
     fun initCall() {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/call/SnapshotCallView.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/call/SnapshotCallView.kt
@@ -4,7 +4,6 @@ import android.graphics.Color
 import android.view.Gravity
 import android.view.View
 import android.widget.TextView
-import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.comms.Audio
 import com.glia.androidsdk.comms.Media
 import com.glia.androidsdk.comms.OperatorMediaState
@@ -12,6 +11,7 @@ import com.glia.androidsdk.comms.Video
 import com.glia.androidsdk.comms.VideoView
 import com.glia.androidsdk.comms.VisitorMediaState
 import com.glia.widgets.R
+import com.glia.widgets.core.engagement.MediaType
 import com.glia.widgets.databinding.CallActivityBinding
 import com.glia.widgets.di.ControllerFactory
 import com.glia.widgets.di.Dependencies
@@ -186,7 +186,7 @@ internal interface SnapshotCallView : SnapshotContent, SnapshotTheme, SnapshotAc
 
     fun CallState.initCall(
         companyName: String = "Snapshot tests",
-        requestedMediaType: Engagement.MediaType = Engagement.MediaType.AUDIO,
+        requestedMediaType: MediaType = MediaType.AUDIO,
         visitorMediaState: VisitorMediaState? = null,
         showFlipVisitorCameraButton: Boolean = false,
         isOnHold: Boolean = false


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4205

**What was solved?**
Add `getQueues()` to Android Widgets SDK.
Use Widgets MediaType and Status wrappers in the SDK.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
