### PR TITLE
Add public class for SiteApiKey to Android Widgets SDK

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets
 
 import android.content.Context
-import com.glia.androidsdk.SiteApiKey
 import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
@@ -176,7 +175,18 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
             return this
         }
 
-        fun setSiteApiKey(siteApiKey: SiteApiKey?): Builder {
+        @Deprecated(
+            "Use {@link #setSiteApiKey(SiteApiKey)}",
+            ReplaceWith(
+                "setSiteApiKey(SiteApiKey(id, secret))",
+                "com.glia.widgets.SiteApiKey"
+            )
+        )
+        fun setSiteApiKey(siteApiKey: com.glia.androidsdk.SiteApiKey?): Builder {
+            return siteApiKey?.toWidgetType()?.let { setSiteApiKey(it) } ?: this
+        }
+
+        fun setSiteApiKey(siteApiKey: SiteApiKey): Builder {
             this.siteApiKey = siteApiKey
             return this
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/SiteApiKey.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/SiteApiKey.kt
@@ -1,0 +1,19 @@
+package com.glia.widgets
+
+/**
+ * Configurations used for configuring the Glia SDK with site API Key ID and secret
+ *
+ * @param id     The site API Key ID
+ * @param secret The site API Key secret
+ *
+ * @see GliaWidgetsConfig
+ */
+data class SiteApiKey(val id: String, val secret: String)
+
+internal fun SiteApiKey.toCoreType(): com.glia.androidsdk.SiteApiKey {
+    return com.glia.androidsdk.SiteApiKey(id, secret)
+}
+
+internal fun com.glia.androidsdk.SiteApiKey.toWidgetType(): SiteApiKey {
+    return SiteApiKey(id, secret)
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -47,6 +47,7 @@ import com.glia.widgets.launcher.EngagementLauncherImpl
 import com.glia.widgets.locale.LocaleProvider
 import com.glia.widgets.operator.OperatorRequestActivityWatcher
 import com.glia.widgets.permissions.ActivityWatcherForPermissionsRequest
+import com.glia.widgets.toCoreType
 import com.glia.widgets.view.head.ActivityWatcherForChatHead
 import com.glia.widgets.view.head.ChatHeadContract
 import com.glia.widgets.view.snackbar.ActivityWatcherForSnackbar
@@ -264,7 +265,7 @@ internal object Dependencies {
     private fun createGliaConfig(gliaWidgetsConfig: GliaWidgetsConfig): GliaConfig {
         val builder = GliaConfig.Builder()
         gliaWidgetsConfig.siteApiKey?.let {
-            builder.setSiteApiKey(it)
+            builder.setSiteApiKey(it.toCoreType())
         } ?: throw RuntimeException("Site key or app token is missing")
         return builder
             .setSiteId(gliaWidgetsConfig.siteId)

--- a/widgetssdk/src/test/java/com/glia/widgets/SiteApiKeyTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/SiteApiKeyTest.kt
@@ -1,0 +1,30 @@
+package com.glia.widgets
+
+import com.glia.androidsdk.SiteApiKey as CoreSiteApiKey
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SiteApiKeyTest {
+
+    @Test
+    fun toCoreType_convertsToCoreSiteApiKey() {
+        val widgetsApiKey = SiteApiKey(id = "testId", secret = "testSecret")
+
+        val coreApiKey = widgetsApiKey.toCoreType()
+
+        assertEquals(CoreSiteApiKey::class.java, coreApiKey::class.java)
+        assertEquals(widgetsApiKey.id, coreApiKey.id)
+        assertEquals(widgetsApiKey.secret, coreApiKey.secret)
+    }
+
+    @Test
+    fun toWidgetType_convertsToWidgetsSiteApiKey() {
+        val coreApiKey = CoreSiteApiKey("testId", "testSecret")
+
+        val widgetsApiKey = coreApiKey.toWidgetType()
+
+        assertEquals(SiteApiKey::class.java, widgetsApiKey::class.java)
+        assertEquals(coreApiKey.id, widgetsApiKey.id)
+        assertEquals(coreApiKey.secret, widgetsApiKey.secret)
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4212

**What was solved?**
Add public class for SiteApiKey to Android Widgets SDK

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
