### PR TITLE
Fix Authentication interfaces

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -39,6 +39,7 @@ import com.glia.widgets.fcm.PushNotifications
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.Logger.SITE_ID_KEY
 import com.glia.widgets.helper.Logger.addGlobalMetadata
+import com.glia.widgets.internal.authentication.toCoreType
 import com.glia.widgets.internal.authentication.toWidgetsType
 import com.glia.widgets.launcher.EngagementLauncher
 import io.reactivex.rxjava3.exceptions.UndeliverableException
@@ -425,15 +426,15 @@ object GliaWidgets {
      * Creates `Authentication` instance for a given JWT token.
      *
      * @param behavior authentication behavior
-     * @return `Authentication` object or throws [GliaWidgetsException] if error happened.
+     * @return `com.glia.androidsdk.visitor.Authentication` object or throws [GliaWidgetsException] if error happened.
      * Exception may have the following cause:
      * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized
      */
     @Deprecated("Please use getAuthentication(behavior: com.glia.widgets.authentication.Authentication.Behavior)")
     @JvmStatic
-    fun getAuthentication(behavior: com.glia.androidsdk.visitor.Authentication.Behavior): Authentication {
+    fun getAuthentication(behavior: com.glia.androidsdk.visitor.Authentication.Behavior): com.glia.androidsdk.visitor.Authentication {
         try {
-            return getAuthenticationManager(behavior.toWidgetsType())
+            return getAuthenticationManager(behavior.toWidgetsType()).toCoreType()
         } catch (gliaException: GliaException) {
             throw mapCoreExceptionToWidgets(gliaException)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
@@ -2,7 +2,6 @@ package com.glia.widgets.authentication
 
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
-import com.glia.androidsdk.visitor.Authentication
 
 /**
  * Interface for managing authentication and de-authentication.
@@ -17,7 +16,7 @@ interface Authentication {
      * @param behavior authentication behavior
      * @throws GliaException [GliaException.Cause.INVALID_INPUT] - in case behavior is null.
      */
-    fun setBehavior(behavior: Authentication.Behavior)
+    fun setBehavior(behavior: Behavior)
 
     /**
      * Authenticates the visitor.

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
@@ -1,11 +1,109 @@
 package com.glia.widgets.internal.authentication
 
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.authentication.Authentication
 import junit.framework.TestCase.assertEquals
-import org.junit.Assert
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
 
 class AuthenticationManagerTest {
+    @Test
+    fun toCoreType_setBehavior_returnsCoreAuthenticationWithCorrectBehavior() {
+        val widgetAuthentication = mock<Authentication>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val behavior = com.glia.androidsdk.visitor.Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT
+        coreAuthentication.setBehavior(behavior)
+
+        verify(widgetAuthentication).setBehavior(behavior.toWidgetsType())
+    }
+
+    @Test
+    fun toCoreType_authenticateWithValidJwtToken_callsAuthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<Authentication>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.authenticate(jwtToken, externalAccessToken, callback)
+
+        verify(widgetAuthentication).authenticate(jwtToken, externalAccessToken, callback)
+    }
+
+    @Test
+    fun toCoreType_authenticateWithNullJwtToken_callsAuthCallbackWithInvalidInputError() {
+        val widgetAuthentication = mock<Authentication>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.authenticate(null, "externalToken", callback)
+
+        verify(callback).onResult(
+            eq(null),
+            argThat { this.cause == GliaException.Cause.INVALID_INPUT }
+        )
+    }
+
+    @Test
+    fun toCoreType_deauthenticate_callsDeauthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<Authentication>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.deauthenticate(callback)
+
+        verify(widgetAuthentication).deauthenticate(callback)
+    }
+
+    @Test
+    fun toCoreType_isAuthenticated_returnsCorrectValue() {
+        val widgetAuthentication = mock<Authentication>()
+        whenever(widgetAuthentication.isAuthenticated).thenReturn(true)
+
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        assertTrue(coreAuthentication.isAuthenticated())
+    }
+
+    @Test
+    fun toCoreType_refreshWithValidJwtToken_callsRefreshOnWidgetAuthentication() {
+        val widgetAuthentication = mock<Authentication>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.refresh(jwtToken, externalAccessToken, callback)
+
+        verify(widgetAuthentication).refresh(jwtToken, externalAccessToken, callback)
+    }
+
+    @Test
+    fun toCoreType_refreshWithNullJwtToken_callsAuthCallbackWithInvalidInputError() {
+        val widgetAuthentication = mock<Authentication>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.refresh(null, "externalToken", callback)
+
+        verify(callback).onResult(
+            eq(null),
+            argThat { this is GliaException && this.cause == GliaException.Cause.INVALID_INPUT }
+        )
+    }
 
     @Test
     fun testWidgetsAuthenticationBehaviorsCorrespondToCoreAuthenticationBehaviors() {
@@ -16,8 +114,8 @@ class AuthenticationManagerTest {
         allWidgetsAuthBehaviors.forEachIndexed { index, item ->
             val coreBehavior = item.toCoreType()
 
-            Assert.assertNotNull(coreBehavior)
-            Assert.assertEquals(coreBehavior.name, allWidgetsAuthBehaviors[index].name)
+            assertNotNull(coreBehavior)
+            assertEquals(coreBehavior.name, allWidgetsAuthBehaviors[index].name)
         }
     }
 
@@ -30,8 +128,8 @@ class AuthenticationManagerTest {
         allCoreAuthBehaviors.forEachIndexed { index, item ->
             val widgetsBehavior = item.toWidgetsType()
 
-            Assert.assertNotNull(widgetsBehavior)
-            Assert.assertEquals(widgetsBehavior.name, allCoreAuthBehaviors[index].name)
+            assertNotNull(widgetsBehavior)
+            assertEquals(widgetsBehavior.name, allCoreAuthBehaviors[index].name)
         }
     }
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4331

**What was solved?**
Use the Widgets type of `Authentication.Behavior` for the Widgets `Authentication.setBehavior()`.
Returns the Core type of `Authentication` for the deprecated `GliaWidgets.getAuthentication.getAuthentication()` method.

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
