### PR TITLE
Remove handleOnMainActivityCreate from Widgets

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/fcm/PushNotifications.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/fcm/PushNotifications.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.fcm
 
 import android.content.Context
-import android.os.Bundle
 import com.google.firebase.messaging.RemoteMessage
 
 /**
@@ -73,29 +72,6 @@ interface PushNotifications {
      * @param message - New FCM message
      */
     fun onNewMessage(message: RemoteMessage)
-
-    /**
-     * Should be called when the main activity is created.
-     *
-     * **Usage example:**
-     * ```kotlin
-     * override fun onCreate(savedInstanceState: Bundle?) {
-     *    super.onCreate(savedInstanceState)
-     *
-     *    ...
-     *
-     *    val pushMessage = GliaWidgets.getPushNotifications().handleOnMainActivityCreate(intent.extras)
-     *
-     *    if (pushMessage?.type == GliaPushMessage.PushType.CHAT_MESSAGE) {
-     *        // handle the opening of the push notification
-     *    }
-     * }
-     * ```
-     *
-     * @param bundle - Bundle passed to the main activity
-     * @return GliaPushMessage if the main activity is opened by clicking on the notification or {@code null} if not.
-     */
-    fun handleOnMainActivityCreate(bundle: Bundle?): GliaPushMessage?
 }
 
 internal class PushNotificationsImpl(
@@ -119,10 +95,5 @@ internal class PushNotificationsImpl(
 
     override fun onNewMessage(message: RemoteMessage) {
         pushNotifications.onNewMessage(message)
-    }
-
-    override fun handleOnMainActivityCreate(bundle: Bundle?): GliaPushMessage? {
-        val pushMessage = pushNotifications.handleOnMainActivityCreate(bundle)
-        return pushMessage?.let { GliaPushMessageImpl(it) }
     }
 }


### PR DESCRIPTION
**What was solved?**
It no longer needs to call the `GliaWidgets.getPushNotifications().handleOnMainActivityCreate(bundle)`. Handling will be implemented on the `ActivityWatcher`.
The method will not be introduced for integrators to simplify SDK usage.

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
