### PR TITLE
Improve VisitorInfoUpdateRequest

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/visitor/VisitorInfoUpdateRequest.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/visitor/VisitorInfoUpdateRequest.kt
@@ -9,13 +9,13 @@ import com.glia.androidsdk.visitor.VisitorInfoUpdateRequest
  * @see {@link GliaWidgets#updateVisitorInfo(VisitorInfoUpdateRequest, OnWidgetsSuccess, OnWidgetsError)}
  */
 data class VisitorInfoUpdateRequest(
-    val name: String?,
-    val email: String?,
-    val phone: String?,
-    val note: String?,
-    val noteUpdateMethod: NoteUpdateMethod?,
-    val customAttributes: Map<String, String>?,
-    val customAttrsUpdateMethod: CustomAttributesUpdateMethod?
+    var name: String? = null,
+    var email: String? = null,
+    var phone: String? = null,
+    var note: String? = null,
+    var noteUpdateMethod: NoteUpdateMethod? = null,
+    var customAttributes: Map<String, String>? = null,
+    var customAttrsUpdateMethod: CustomAttributesUpdateMethod? = null
 ) {
 
     internal fun toCoreType(): VisitorInfoUpdateRequest {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4343

**What was solved?**
Add default values,
Make the ability to use setters.

Now it is possible to use it like this:
```java
VisitorInfoUpdateRequest visitorInfoUpdateRequest = new VisitorInfoUpdateRequest();
visitorInfoUpdateRequest.setName("John Smith");
visitorInfoUpdateRequest.setEmail("john.smith@example.com");
```
instead of this:
```java
VisitorInfoUpdateRequest visitorInformation = new VisitorInfoUpdateRequest(
    "John Smith",
    "john.smith@example.com",
    null, // phone
    null, // note
    null, // noteUpdateMethod
    null, // customAttributes
    null // customAttrsUpdateMethod
);
```

For Kotlin, there are also improvements. No need to pass all parameters to the constructor.
```kotlin
val visitorInformation = VisitorInfoUpdateRequest(
    name = "John Smith",
    email = "john.smith@example.com"
)
```

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
