### PR TITLE
Improve OnSuccess, OnError and GliaWidgetsException

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Intent
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
-import com.glia.widgets.GliaWidgetsException.Companion.from
 import com.glia.widgets.authentication.Authentication
 import com.glia.widgets.callbacks.OnComplete
 import com.glia.widgets.callbacks.OnError
@@ -119,7 +118,7 @@ object GliaWidgets {
         try {
             Dependencies.onAppCreate(application)
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
         setupRxErrorHandler()
         Logger.d(TAG, "onAppCreate")
@@ -142,7 +141,7 @@ object GliaWidgets {
             gliaThemeManager.applyJsonConfig(gliaWidgetsConfig.uiJsonRemoteConfig)
             glia().isInitialized = true
         } catch (gliaException: GliaException) {
-            val gliaWidgetsException = mapCoreExceptionToWidgets(gliaException)
+            val gliaWidgetsException = gliaException.toWidgetsType()
             throw gliaWidgetsException
         }
     }
@@ -181,11 +180,9 @@ object GliaWidgets {
             gliaThemeManager.applyJsonConfig(gliaWidgetsConfig.uiJsonRemoteConfig)
         } catch (exception: Exception) {
             if (exception is GliaException) {
-                val mappedException = mapCoreExceptionToWidgets(exception)
-                if (mappedException is GliaWidgetsException) {
-                    onError?.onError(mappedException)
-                    return
-                }
+                val mappedException = exception.toWidgetsType()
+                onError?.onError(mappedException)
+                return
             }
 
             Logger.e(TAG, "Glia Widgets SDK initialization failed")
@@ -228,7 +225,7 @@ object GliaWidgets {
                 onSuccess.onSuccess(queues.toWidgetsType())
             },
             onError = {
-                onError.onError(from(it))
+                onError.onError(it.toWidgetsType("Failed to get queues"))
             }
         )
     }
@@ -249,7 +246,7 @@ object GliaWidgets {
             setupQueueIds(queueIds)
             return engagementLauncher
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -272,7 +269,7 @@ object GliaWidgets {
             configurationManager.setQueueIds(queueIds)
             return entryWidget
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -303,7 +300,7 @@ object GliaWidgets {
         try {
             glia().onRequestPermissionsResult(requestCode, permissions, grantResults)
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -330,7 +327,7 @@ object GliaWidgets {
         try {
             repositoryFactory.engagementRepository.onActivityResult(requestCode, resultCode, data)
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -351,7 +348,7 @@ object GliaWidgets {
             RequestCallback { visitorInfo: com.glia.androidsdk.visitor.VisitorInfo?,
                               error: GliaException? ->
                 if (error != null || visitorInfo == null) {
-                    onError.onError(from(error))
+                    onError.onError(error.toWidgetsType("Failed to get visitor info"))
                 } else {
                     onSuccess.onSuccess(VisitorInfo(visitorInfo))
                 }
@@ -378,7 +375,7 @@ object GliaWidgets {
                 if (error == null) {
                     onComplete.onComplete()
                 } else {
-                    onError.onError(from(error))
+                    onError.onError(error.toWidgetsType())
                 }
             }
         glia().updateVisitorInfo(visitorInfoUpdateRequest.toCoreType(), updateCallback)
@@ -401,7 +398,7 @@ object GliaWidgets {
 
             glia().clearVisitorSession()
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -418,7 +415,7 @@ object GliaWidgets {
         try {
             useCaseFactory.endEngagementUseCase.invoke(EndedBy.CLEAR_STATE)
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -436,7 +433,7 @@ object GliaWidgets {
         try {
             return getAuthenticationManager(behavior.toWidgetsType()).toCoreType()
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -453,7 +450,7 @@ object GliaWidgets {
         try {
             return getAuthenticationManager(behavior)
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -470,7 +467,7 @@ object GliaWidgets {
         try {
             return secureConversations
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -487,7 +484,7 @@ object GliaWidgets {
         try {
             return liveObservation
         } catch (gliaException: GliaException) {
-            throw mapCoreExceptionToWidgets(gliaException)
+            throw gliaException.toWidgetsType()
         }
     }
 
@@ -556,10 +553,5 @@ object GliaWidgets {
             "RxErrorHandler",
             "Undeliverable exception received, not sure what to do. $message"
         )
-    }
-
-    private fun mapCoreExceptionToWidgets(gliaException: GliaException): RuntimeException {
-        val widgetsException = from(gliaException)
-        return widgetsException ?: gliaException
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsException.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsException.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets
 
+import com.glia.widgets.GliaWidgetsException.Cause
+import com.glia.widgets.helper.Logger
 import com.glia.androidsdk.GliaException as GliaCoreException
 
 /**
@@ -7,8 +9,8 @@ import com.glia.androidsdk.GliaException as GliaCoreException
  * a {@link Cause} enum value for handling some of the errors programmatically.
  */
 class GliaWidgetsException internal constructor(
-    val debugMessage: String?,
-    val gliaCause: Cause?
+    val debugMessage: String,
+    val gliaCause: Cause
 ) : RuntimeException(
     debugMessage
 ) {
@@ -37,24 +39,40 @@ class GliaWidgetsException internal constructor(
     override fun toString(): String {
         return "GliaWidgetsException: " + this.debugMessage + ", cause: " + gliaCause.toString()
     }
-
-    internal companion object {
-        @JvmStatic
-        fun from(gliaException: GliaCoreException?): GliaWidgetsException? {
-            return gliaException?.let {
-                GliaWidgetsException(
-                    it.debugMessage,
-                    it.cause?.toWidgetsCause()
-                )
-            }
-        }
-
-        private fun GliaCoreException.Cause.toWidgetsCause(): Cause? {
-            return try {
-                GliaWidgetsException.Cause.valueOf(this.name)
-            } catch (e: IllegalArgumentException) {
-                null
-            }
-        }
-    }
 }
+
+internal fun GliaCoreException.toWidgetsType(): GliaWidgetsException = this.let {
+    GliaWidgetsException(
+        it.debugMessage,
+        it.cause.toWidgetsType()
+    )
+}
+
+internal fun GliaCoreException?.toWidgetsType(
+    defaultMessage: String,
+    defaultCause: Cause = Cause.INTERNAL_ERROR
+): GliaWidgetsException =
+    this?.toWidgetsType() ?: let {
+        val exception = GliaWidgetsException(defaultMessage, defaultCause)
+        Logger.e("GliaWidgetsException", "The Core GliaException is null, using the default message and cause.", exception)
+        return@let exception
+    }
+
+private fun GliaCoreException.Cause.toWidgetsType(): Cause =
+    when(this) {
+        GliaCoreException.Cause.INVALID_INPUT -> Cause.INVALID_INPUT
+        GliaCoreException.Cause.INVALID_LOCALE -> Cause.INVALID_LOCALE
+        GliaCoreException.Cause.NETWORK_TIMEOUT -> Cause.NETWORK_TIMEOUT
+        GliaCoreException.Cause.INTERNAL_ERROR -> Cause.INTERNAL_ERROR
+        GliaCoreException.Cause.AUTHENTICATION_ERROR -> Cause.AUTHENTICATION_ERROR
+        GliaCoreException.Cause.PERMISSIONS_DENIED -> Cause.PERMISSIONS_DENIED
+        GliaCoreException.Cause.ALREADY_QUEUED -> Cause.ALREADY_QUEUED
+        GliaCoreException.Cause.FORBIDDEN -> Cause.FORBIDDEN
+        GliaCoreException.Cause.NOT_MAIN_THREAD -> Cause.NOT_MAIN_THREAD
+        GliaCoreException.Cause.FILE_FORMAT_UNSUPPORTED -> Cause.FILE_FORMAT_UNSUPPORTED
+        GliaCoreException.Cause.FILE_TOO_LARGE -> Cause.FILE_TOO_LARGE
+        GliaCoreException.Cause.FILE_UNAVAILABLE -> Cause.FILE_UNAVAILABLE
+        GliaCoreException.Cause.FILE_UPLOAD_FORBIDDEN -> Cause.FILE_UPLOAD_FORBIDDEN
+        GliaCoreException.Cause.QUEUE_CLOSED -> Cause.QUEUE_CLOSED
+        GliaCoreException.Cause.QUEUE_FULL -> Cause.QUEUE_FULL
+    }

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsException.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsException.kt
@@ -76,3 +76,29 @@ private fun GliaCoreException.Cause.toWidgetsType(): Cause =
         GliaCoreException.Cause.QUEUE_CLOSED -> Cause.QUEUE_CLOSED
         GliaCoreException.Cause.QUEUE_FULL -> Cause.QUEUE_FULL
     }
+
+internal fun GliaWidgetsException.toCoreType(): GliaCoreException = this.let {
+    GliaCoreException(
+        it.debugMessage,
+        it.gliaCause.toCoreType()
+    )
+}
+
+private fun Cause.toCoreType(): GliaCoreException.Cause =
+    when(this) {
+        Cause.INVALID_INPUT -> GliaCoreException.Cause.INVALID_INPUT
+        Cause.INVALID_LOCALE -> GliaCoreException.Cause.INVALID_LOCALE
+        Cause.NETWORK_TIMEOUT -> GliaCoreException.Cause.NETWORK_TIMEOUT
+        Cause.INTERNAL_ERROR -> GliaCoreException.Cause.INTERNAL_ERROR
+        Cause.AUTHENTICATION_ERROR -> GliaCoreException.Cause.AUTHENTICATION_ERROR
+        Cause.PERMISSIONS_DENIED -> GliaCoreException.Cause.PERMISSIONS_DENIED
+        Cause.ALREADY_QUEUED -> GliaCoreException.Cause.ALREADY_QUEUED
+        Cause.FORBIDDEN -> GliaCoreException.Cause.FORBIDDEN
+        Cause.NOT_MAIN_THREAD -> GliaCoreException.Cause.NOT_MAIN_THREAD
+        Cause.FILE_FORMAT_UNSUPPORTED -> GliaCoreException.Cause.FILE_FORMAT_UNSUPPORTED
+        Cause.FILE_TOO_LARGE -> GliaCoreException.Cause.FILE_TOO_LARGE
+        Cause.FILE_UNAVAILABLE -> GliaCoreException.Cause.FILE_UNAVAILABLE
+        Cause.FILE_UPLOAD_FORBIDDEN -> GliaCoreException.Cause.FILE_UPLOAD_FORBIDDEN
+        Cause.QUEUE_CLOSED -> GliaCoreException.Cause.QUEUE_CLOSED
+        Cause.QUEUE_FULL -> GliaCoreException.Cause.QUEUE_FULL
+    }

--- a/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
@@ -1,7 +1,8 @@
 package com.glia.widgets.authentication
 
-import com.glia.androidsdk.GliaException
-import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.GliaWidgetsException
+import com.glia.widgets.callbacks.OnComplete
+import com.glia.widgets.callbacks.OnError
 
 /**
  * Interface for managing authentication and de-authentication.
@@ -14,7 +15,7 @@ interface Authentication {
      * Sets the specified behavior.
      *
      * @param behavior authentication behavior
-     * @throws GliaException [GliaException.Cause.INVALID_INPUT] - in case behavior is null.
+     * @throws GliaWidgetsException [GliaWidgetsException.Cause.INVALID_INPUT] - in case behavior is null.
      */
     fun setBehavior(behavior: Behavior)
 
@@ -24,30 +25,36 @@ interface Authentication {
      * @param jwtToken                JWT token (Direct ID token) for visitor authentication.
      * @param externalAccessToken     An access token that can be used to make authenticated requests
      * to other systems on behalf of the authenticated visitor.
-     * @param authCallback callback to receive execution result
-     * (null for success or GliaException for error).
+     * @param onComplete Callback invoked when the update operation is successfully completed.
+     * @param onError Callback invoked when an error occurs during the update operation.
+     *                Provides a [GliaWidgetsException] describing the error.
      * Exception may have one of following causes:
-     * <br></br> [GliaException.Cause.NETWORK_TIMEOUT] - when request times out due to connection issues
-     * <br></br> [GliaException.Cause.INTERNAL_ERROR] - when internal error occurs
-     * <br></br> [GliaException.Cause.AUTHENTICATION_ERROR] - when authentication fails
+     * <br></br> [GliaWidgetsException.Cause.NETWORK_TIMEOUT] - when request times out due to connection issues
+     * <br></br> [GliaWidgetsException.Cause.INTERNAL_ERROR] - when internal error occurs
+     * <br></br> [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] - when authentication fails
      */
     fun authenticate(
         jwtToken: String,
         externalAccessToken: String?,
-        authCallback: RequestCallback<Void>?
+        onComplete: OnComplete?,
+        onError: OnError?
     )
 
     /**
      * De-authenticates the visitor.
      *
-     * @param authCallback callback to receive execution result
-     * (null for success or GliaException for error).
+     * @param onComplete Callback invoked when the update operation is successfully completed.
+     * @param onError Callback invoked when an error occurs during the update operation.
+     *                Provides a [GliaWidgetsException] describing the error.
      * Exception may have one of following causes:
-     * <br></br> [GliaException.Cause.NETWORK_TIMEOUT] - when request times out due to connection issues
-     * <br></br> [GliaException.Cause.INTERNAL_ERROR] - when internal error occurs
-     * <br></br> [GliaException.Cause.AUTHENTICATION_ERROR] - when authentication fails
+     * <br></br> [GliaWidgetsException.Cause.NETWORK_TIMEOUT] - when request times out due to connection issues
+     * <br></br> [GliaWidgetsException.Cause.INTERNAL_ERROR] - when internal error occurs
+     * <br></br> [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] - when authentication fails
      */
-    fun deauthenticate(authCallback: RequestCallback<Void>?)
+    fun deauthenticate(
+        onComplete: OnComplete?,
+        onError: OnError?
+    )
 
     /**
      * Check if Visitor is authenticated in Glia using the external authentication.
@@ -63,17 +70,19 @@ interface Authentication {
      * @param jwtToken                JWT token (Direct ID token) for visitor authentication.
      * @param externalAccessToken     An access token that can be used to make authenticated requests
      * to other systems on behalf of the authenticated visitor.
-     * @param authCallback callback to receive execution result
-     * (null for success or GliaException for error).
+     * @param onComplete Callback invoked when the update operation is successfully completed.
+     * @param onError Callback invoked when an error occurs during the update operation.
+     *                Provides a [GliaWidgetsException] describing the error.
      * Exception may have one of following causes:
-     * <br></br> [GliaException.Cause.NETWORK_TIMEOUT] - when request times out due to connection issues
-     * <br></br> [GliaException.Cause.INTERNAL_ERROR] - when internal error occurs
-     * <br></br> [GliaException.Cause.AUTHENTICATION_ERROR] - when authentication fails
+     * <br></br> [GliaWidgetsException.Cause.NETWORK_TIMEOUT] - when request times out due to connection issues
+     * <br></br> [GliaWidgetsException.Cause.INTERNAL_ERROR] - when internal error occurs
+     * <br></br> [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] - when authentication fails
      */
     fun refresh(
         jwtToken: String,
         externalAccessToken: String?,
-        authCallback: RequestCallback<Void>?
+        onComplete: OnComplete?,
+        onError: OnError?
     )
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnComplete.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnComplete.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.callbacks
 
+import com.glia.androidsdk.RequestCallback
+
 /**
  * Callback used in some requests to Glia Widgets SDK.
  *
@@ -9,4 +11,8 @@ fun interface OnComplete {
      * Function that is fired if request completes
      */
     fun onComplete()
+}
+
+internal fun RequestCallback<Void>.toOnComplete(): OnComplete {
+    return OnComplete { onResult(null, null) }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnError.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnError.kt
@@ -1,6 +1,8 @@
 package com.glia.widgets.callbacks
 
+import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.GliaWidgetsException
+import com.glia.widgets.toCoreType
 
 /**
  * Error callback used in some requests to Glia Widgets SDK.
@@ -12,4 +14,8 @@ fun interface OnError {
      * @param exception GliaWidgetsException returned if the request failed
      */
     fun onError(exception: GliaWidgetsException)
+}
+
+internal fun RequestCallback<Void>.toOnError(): OnError {
+    return OnError { onResult(null, it.toCoreType()) }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnError.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnError.kt
@@ -11,5 +11,5 @@ fun interface OnError {
      *
      * @param exception GliaWidgetsException returned if the request failed
      */
-    fun onError(exception: GliaWidgetsException?)
+    fun onError(exception: GliaWidgetsException)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnSuccess.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnSuccess.kt
@@ -11,5 +11,5 @@ fun interface OnSuccess<T> {
      *
      * @param result result returned if the request succeeded
      */
-    fun onSuccess(result: T?)
+    fun onSuccess(result: T)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnSuccess.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnSuccess.kt
@@ -1,5 +1,7 @@
 package com.glia.widgets.callbacks
 
+import com.glia.androidsdk.RequestCallback
+
 /**
  * Callback used in some requests to Glia Widgets SDK.
  *
@@ -12,4 +14,8 @@ fun interface OnSuccess<T> {
      * @param result result returned if the request succeeded
      */
     fun onSuccess(result: T)
+}
+
+internal fun <T> RequestCallback<T>.toOnSuccess(): OnSuccess<T> {
+    return OnSuccess { onResult(it, null) }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsExceptionTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsExceptionTest.kt
@@ -1,14 +1,18 @@
 package com.glia.widgets
 
 import com.glia.androidsdk.GliaException
-import io.mockk.every
-import io.mockk.mockk
+import com.glia.widgets.helper.Logger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 
 class GliaWidgetsExceptionTest {
+
+    @Before
+    fun setUp() {
+        Logger.setIsDebug(false)
+    }
 
     @Test
     fun testFrom_withAllValidGliaException_returnsGliaWidgetsException() {
@@ -20,30 +24,19 @@ class GliaWidgetsExceptionTest {
 
         assertEquals(allCoreCauses.size, allWidgetsCauses.size)
         gliaCoreExceptions.forEachIndexed { index, item ->
-            val widgetsException = GliaWidgetsException.from(item)
+            val widgetsException = item.toWidgetsType()
 
             assertNotNull(widgetsException)
-            assertEquals("Test message", widgetsException?.debugMessage)
-            assertEquals(widgetsException?.gliaCause, gliaWidgetsExceptions[index].gliaCause)
+            assertEquals("Test message", widgetsException.debugMessage)
+            assertEquals(widgetsException.gliaCause, gliaWidgetsExceptions[index].gliaCause)
         }
     }
 
     @Test
-    fun testFrom_withNullGliaException_returnsNull() {
-        val widgetsException = GliaWidgetsException.from(null)
-        assertNull(widgetsException)
-    }
-
-    @Test
-    fun testFrom_withUnknownCause_returnsGliaWidgetsExceptionWithNullCause() {
-        val unknownCause = mockk<GliaException.Cause>()
-        every { unknownCause.name } returns "UNKNOWN_CAUSE"
-
-        val coreException = GliaException("Test message", unknownCause)
-        val widgetsException = GliaWidgetsException.from(coreException)
-
-        assertNotNull(widgetsException)
-        assertEquals("Test message", widgetsException?.debugMessage)
-        assertNull(widgetsException?.gliaCause)
+    fun testFrom_withNullGliaException_returnsDefinedGliaWidgetsException() {
+        val nothing: GliaException? = null
+        val widgetsException = nothing.toWidgetsType("Test message", GliaWidgetsException.Cause.INVALID_INPUT)
+        assertEquals("Test message", widgetsException.debugMessage)
+        assertEquals(widgetsException.gliaCause, GliaWidgetsException.Cause.INVALID_INPUT)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsExceptionTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsExceptionTest.kt
@@ -15,7 +15,7 @@ class GliaWidgetsExceptionTest {
     }
 
     @Test
-    fun testFrom_withAllValidGliaException_returnsGliaWidgetsException() {
+    fun toWidgetsType_withAllValidGliaException_returnsGliaWidgetsException() {
         val allCoreCauses: List<GliaException.Cause> = GliaException.Cause.entries
         val gliaCoreExceptions = allCoreCauses.map { GliaException("Test message", it) }
 
@@ -33,10 +33,28 @@ class GliaWidgetsExceptionTest {
     }
 
     @Test
-    fun testFrom_withNullGliaException_returnsDefinedGliaWidgetsException() {
+    fun toWidgetsType_withNullGliaException_returnsDefinedGliaWidgetsException() {
         val nothing: GliaException? = null
         val widgetsException = nothing.toWidgetsType("Test message", GliaWidgetsException.Cause.INVALID_INPUT)
         assertEquals("Test message", widgetsException.debugMessage)
         assertEquals(widgetsException.gliaCause, GliaWidgetsException.Cause.INVALID_INPUT)
+    }
+
+    @Test
+    fun toCoreType_withAllValidGliaWidgetsException_returnsGliaException() {
+        val allWidgetsCauses: List<GliaWidgetsException.Cause> = GliaWidgetsException.Cause.entries
+        val gliaWidgetsExceptions = allWidgetsCauses.map { GliaWidgetsException("Test message", it) }
+
+        val allCoreCauses: List<GliaException.Cause> = GliaException.Cause.entries
+        val gliaCoreExceptions = allCoreCauses.map { GliaException("Test message", it) }
+
+        assertEquals(allCoreCauses.size, allWidgetsCauses.size)
+        gliaWidgetsExceptions.forEachIndexed { index, item ->
+            val coreException = item.toCoreType()
+
+            assertNotNull(coreException)
+            assertEquals("Test message", coreException.debugMessage)
+            assertEquals(coreException.cause, gliaCoreExceptions[index].cause)
+        }
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
@@ -7,6 +7,7 @@ import junit.framework.TestCase.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.Mockito.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.argThat
@@ -16,7 +17,7 @@ import org.mockito.kotlin.whenever
 class AuthenticationManagerTest {
     @Test
     fun toCoreType_setBehavior_returnsCoreAuthenticationWithCorrectBehavior() {
-        val widgetAuthentication = mock<Authentication>()
+        val widgetAuthentication = mock<AuthenticationManager>()
         val coreAuthentication = widgetAuthentication.toCoreType()
 
         val behavior = com.glia.androidsdk.visitor.Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT
@@ -27,7 +28,7 @@ class AuthenticationManagerTest {
 
     @Test
     fun toCoreType_authenticateWithValidJwtToken_callsAuthenticateOnWidgetAuthentication() {
-        val widgetAuthentication = mock<Authentication>()
+        val widgetAuthentication = mock<AuthenticationManager>()
         val coreAuthentication = widgetAuthentication.toCoreType()
 
         val jwtToken = "validToken"
@@ -36,12 +37,12 @@ class AuthenticationManagerTest {
 
         coreAuthentication.authenticate(jwtToken, externalAccessToken, callback)
 
-        verify(widgetAuthentication).authenticate(jwtToken, externalAccessToken, callback)
+        verify(widgetAuthentication).authenticate(eq(jwtToken), eq(externalAccessToken), any(), any())
     }
 
     @Test
     fun toCoreType_authenticateWithNullJwtToken_callsAuthCallbackWithInvalidInputError() {
-        val widgetAuthentication = mock<Authentication>()
+        val widgetAuthentication = mock<AuthenticationManager>()
         val coreAuthentication = widgetAuthentication.toCoreType()
 
         val callback = mock<RequestCallback<Void>>()
@@ -56,19 +57,19 @@ class AuthenticationManagerTest {
 
     @Test
     fun toCoreType_deauthenticate_callsDeauthenticateOnWidgetAuthentication() {
-        val widgetAuthentication = mock<Authentication>()
+        val widgetAuthentication = mock<AuthenticationManager>()
         val coreAuthentication = widgetAuthentication.toCoreType()
 
         val callback = mock<RequestCallback<Void>>()
 
         coreAuthentication.deauthenticate(callback)
 
-        verify(widgetAuthentication).deauthenticate(callback)
+        verify(widgetAuthentication).deauthenticate(any(), any())
     }
 
     @Test
     fun toCoreType_isAuthenticated_returnsCorrectValue() {
-        val widgetAuthentication = mock<Authentication>()
+        val widgetAuthentication = mock<AuthenticationManager>()
         whenever(widgetAuthentication.isAuthenticated).thenReturn(true)
 
         val coreAuthentication = widgetAuthentication.toCoreType()
@@ -78,7 +79,7 @@ class AuthenticationManagerTest {
 
     @Test
     fun toCoreType_refreshWithValidJwtToken_callsRefreshOnWidgetAuthentication() {
-        val widgetAuthentication = mock<Authentication>()
+        val widgetAuthentication = mock<AuthenticationManager>()
         val coreAuthentication = widgetAuthentication.toCoreType()
 
         val jwtToken = "validToken"
@@ -87,12 +88,12 @@ class AuthenticationManagerTest {
 
         coreAuthentication.refresh(jwtToken, externalAccessToken, callback)
 
-        verify(widgetAuthentication).refresh(jwtToken, externalAccessToken, callback)
+        verify(widgetAuthentication).refresh(eq(jwtToken), eq(externalAccessToken), any(), any())
     }
 
     @Test
     fun toCoreType_refreshWithNullJwtToken_callsAuthCallbackWithInvalidInputError() {
-        val widgetAuthentication = mock<Authentication>()
+        val widgetAuthentication = mock<AuthenticationManager>()
         val coreAuthentication = widgetAuthentication.toCoreType()
 
         val callback = mock<RequestCallback<Void>>()


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4344

**What was solved?**
Made `OnSuccess`, `OnError` and `GliaWidgetsException` not optional.
Result always returns value.

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
