### PR TITLE
Replace RequestCallback with Widgets callbacks in Secure Conversation interfaces

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsException.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsException.kt
@@ -54,7 +54,7 @@ internal fun GliaCoreException?.toWidgetsType(
 ): GliaWidgetsException =
     this?.toWidgetsType() ?: let {
         val exception = GliaWidgetsException(defaultMessage, defaultCause)
-        Logger.e("GliaWidgetsException", "The Core GliaException is null, using the default message and cause.", exception)
+        Logger.e("GliaWidgetsException", "The Core GliaException is null, using the default error message and cause.", exception)
         return@let exception
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/secureconversations/SecureConversations.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/secureconversations/SecureConversations.kt
@@ -1,7 +1,10 @@
 package com.glia.widgets.secureconversations
 
-import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.GliaWidgetsException
+import com.glia.widgets.callbacks.OnError
+import com.glia.widgets.callbacks.OnSuccess
+import com.glia.widgets.toWidgetsType
 
 /**
  * Secure Conversations offers the ability to asynchronously and securely communications for authenticated visitors.
@@ -15,24 +18,40 @@ interface SecureConversations {
      * This number will increase with each message sent by the operator
      * that the visitor has not yet marked as read.
      *
-     * @param callback a callback that returns [RequestCallback] with the number of unread
-     * secure messages on success, or [GliaException] on failure.
+     * @param onSuccess [OnSuccess] a callback that returns the number of unread
+     * secure messages on success.
+     * @param onError [OnError] a callback that returns [GliaWidgetsException] on failure.
      *
      * Exception may have one of the following causes:
-     * [GliaException.Cause.AUTHENTICATION_ERROR] -when a visitor is not authenticated
-     * [GliaException.Cause.INVALID_INPUT] - when SDK is not initialized
+     * [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] -when a visitor is not authenticated
+     * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized
      */
-    fun getUnreadMessageCount(callback: RequestCallback<Int?>)
+    fun getUnreadMessageCount(onSuccess: OnSuccess<Int>, onError: OnError? = null)
 
     /**
-     * The same as [SecureConversations.getUnreadMessageCount] but with the ability to subscribe to updates.
+     * Subscribes to updates of the unread message count.
+     *
+     * This method allows you to receive updates whenever the unread message count changes.
+     * The provided callback will be triggered with the updated count.
+     *
+     * @param callback [OnSuccess] A callback that will be invoked with the updated unread message count.
+     *
+     * Note: Ensure to unsubscribe using [unSubscribeFromUnreadMessageCount] when updates are no longer needed
+     * to avoid memory leaks or unnecessary updates.
      */
-    fun subscribeToUnreadMessageCount(callback: RequestCallback<Int?>)
+    fun subscribeToUnreadMessageCount(callback: OnSuccess<Int>)
 
     /**
-     * Unsubscribe from updates of the unread message count.
+     * Unsubscribes from updates of the unread message count.
+     *
+     * This method stops receiving updates for the unread message count for the provided callback.
+     *
+     * @param callback [OnSuccess] A callback that was previously subscribed to receive updates.
+     *
+     * Note: Ensure that the callback passed to this method is the same instance that was used
+     * during subscription to successfully unsubscribe.
      */
-    fun unSubscribeFromUnreadMessageCount(callback: RequestCallback<Int?>)
+    fun unSubscribeFromUnreadMessageCount(callback: OnSuccess<Int>)
 }
 
 /**
@@ -42,16 +61,34 @@ class SecureConversationsImpl(
     private val secureConversations: com.glia.androidsdk.secureconversations.SecureConversations
 ) : SecureConversations {
 
-    override fun getUnreadMessageCount(callback: RequestCallback<Int?>) {
-        secureConversations.getUnreadMessageCount(callback)
+    internal val subscribedCallbacks: MutableMap<Int, RequestCallback<Int>> = mutableMapOf()
+
+    override fun getUnreadMessageCount(onSuccess: OnSuccess<Int>, onError: OnError?) {
+        secureConversations.getUnreadMessageCount { count, gliaException ->
+            if (gliaException != null || count == null) {
+                onError?.onError(gliaException.toWidgetsType("Failed to get unread message count"))
+            } else {
+                onSuccess.onSuccess(count)
+            }
+        }
     }
 
-    override fun subscribeToUnreadMessageCount(callback: RequestCallback<Int?>) {
-        secureConversations.subscribeToUnreadMessageCount(callback)
+    override fun subscribeToUnreadMessageCount(callback: OnSuccess<Int>) {
+        if (subscribedCallbacks.containsKey(callback.hashCode())) {
+            // Already subscribed
+            return
+        }
+        val requestCallback: RequestCallback<Int> = RequestCallback { count, gliaException ->
+                if (gliaException == null && count != null) {
+                    callback.onSuccess(count)
+                }
+            }
+        subscribedCallbacks[callback.hashCode()] = requestCallback
+        secureConversations.subscribeToUnreadMessageCount(requestCallback)
     }
 
-    override fun unSubscribeFromUnreadMessageCount(callback: RequestCallback<Int?>) {
-        secureConversations.unSubscribeFromUnreadMessageCount(callback)
+    override fun unSubscribeFromUnreadMessageCount(callback: OnSuccess<Int>) {
+        subscribedCallbacks[callback.hashCode()]?.let { secureConversations.unSubscribeFromUnreadMessageCount(it) }
+        subscribedCallbacks.remove(callback.hashCode())
     }
 }
-

--- a/widgetssdk/src/test/java/com/glia/widgets/secureconversations/SecureConversationsImplTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/secureconversations/SecureConversationsImplTest.kt
@@ -1,0 +1,101 @@
+package com.glia.widgets.secureconversations
+
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.GliaWidgetsException
+import com.glia.widgets.callbacks.OnError
+import com.glia.widgets.callbacks.OnSuccess
+import com.glia.widgets.toWidgetsType
+import io.mockk.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class SecureConversationsImplTest {
+
+    private lateinit var secureConversationsCore: com.glia.androidsdk.secureconversations.SecureConversations
+    private lateinit var secureConversationsWidgets: SecureConversationsImpl
+
+    @Before
+    fun setUp() {
+        secureConversationsCore = mockk(relaxed = true)
+        secureConversationsWidgets = SecureConversationsImpl(secureConversationsCore)
+    }
+
+    @Test
+    fun `getUnreadMessageCount calls SDK and invokes onSuccess`() {
+        val onSuccess: OnSuccess<Int> = mockk(relaxed = true)
+        val onError: OnError = mockk(relaxed = true)
+        val unreadCount = 5
+        every { secureConversationsCore.getUnreadMessageCount(any()) } answers {
+            firstArg<RequestCallback<Int>>().onResult(unreadCount, null)
+        }
+
+        secureConversationsWidgets.getUnreadMessageCount(onSuccess, onError)
+
+        verify { onSuccess.onSuccess(unreadCount) }
+        verify(exactly = 0) { onError.onError(any()) }
+    }
+
+    @Test
+    fun `getUnreadMessageCount calls SDK and invokes onError on failure`() {
+        val onSuccess: OnSuccess<Int> = mockk(relaxed = true)
+        val onError: OnError = mockk(relaxed = true)
+        val exception = mock<GliaException>()
+        val widgetsException = GliaWidgetsException("Error", GliaWidgetsException.Cause.AUTHENTICATION_ERROR)
+        mockkStatic("com.glia.widgets.GliaWidgetsExceptionKt")
+        every { exception.toWidgetsType() } returns widgetsException
+        every { secureConversationsCore.getUnreadMessageCount(any()) } answers {
+            firstArg<RequestCallback<Int>>().onResult(null, exception)
+        }
+
+        secureConversationsWidgets.getUnreadMessageCount(onSuccess, onError)
+
+        verify { onError.onError(widgetsException) }
+        verify(exactly = 0) { onSuccess.onSuccess(any()) }
+    }
+
+    @Test
+    fun `subscribeToUnreadMessageCount adds callback and calls SDK`() {
+        val callback: OnSuccess<Int> = mockk(relaxed = true)
+        val requestCallbackSlot = slot<RequestCallback<Int>>()
+        val unreadCount = 10
+        every { secureConversationsCore.subscribeToUnreadMessageCount(capture(requestCallbackSlot)) } just Runs
+
+        secureConversationsWidgets.subscribeToUnreadMessageCount(callback)
+
+        verify { secureConversationsCore.subscribeToUnreadMessageCount(any()) }
+        assert(secureConversationsWidgets.subscribedCallbacks.containsKey(callback.hashCode()))
+        requestCallbackSlot.captured.onResult(unreadCount, null)
+        verify { callback.onSuccess(unreadCount) }
+    }
+
+    @Test
+    fun `subscribeToUnreadMessageCount does not subscribe the same callback twice`() {
+        val callback: OnSuccess<Int> = mockk(relaxed = true)
+        val requestCallbackSlot = slot<RequestCallback<Int>>()
+        every { secureConversationsCore.subscribeToUnreadMessageCount(capture(requestCallbackSlot)) } just Runs
+
+        // Subscribe the same callback twice
+        secureConversationsWidgets.subscribeToUnreadMessageCount(callback)
+        secureConversationsWidgets.subscribeToUnreadMessageCount(callback)
+
+        // Verify that the SDK's subscribeToUnreadMessageCount is called only once
+        verify(exactly = 1) { secureConversationsCore.subscribeToUnreadMessageCount(any()) }
+        // Verify that the callback is stored only once in subscribedCallbacks
+        assert(secureConversationsWidgets.subscribedCallbacks.size == 1)
+        assert(secureConversationsWidgets.subscribedCallbacks.containsKey(callback.hashCode()))
+    }
+
+    @Test
+    fun `unSubscribeFromUnreadMessageCount removes callback and calls SDK`() {
+        val callback: OnSuccess<Int> = mockk(relaxed = true)
+        val requestCallback: RequestCallback<Int> = mockk(relaxed = true)
+        secureConversationsWidgets.subscribedCallbacks[callback.hashCode()] = requestCallback
+
+        secureConversationsWidgets.unSubscribeFromUnreadMessageCount(callback)
+
+        verify { secureConversationsCore.unSubscribeFromUnreadMessageCount(requestCallback) }
+        assert(!secureConversationsWidgets.subscribedCallbacks.containsKey(callback.hashCode()))
+    }
+}


### PR DESCRIPTION
**Jira issue:**
[MOB-4346](https://glia.atlassian.net/browse/MOB-4346)

**What was solved?**
- Replace RequestCallback with Widgets callbacks in Secure Conversation interfaces

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-4346]: https://glia.atlassian.net/browse/MOB-4346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ