### PR TITLE
Deprecate Screen Sharing

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgetsConfig.kt
@@ -218,9 +218,13 @@ class GliaWidgetsConfig private constructor(builder: Builder) {
         }
 
         /**
+         * Screen sharing is deprecated. Please use Live Observation instead:
+         * https://docs.glia.com/glia-mobile/docs/android-live-observation
+         *
          * @param screenSharingMode - Screen sharing mode, either UNBOUND(default) or APP_BOUND
          * @return Builder instance
          */
+        @Deprecated("Please use Live Observation instead")
         fun setScreenSharingMode(screenSharingMode: ScreenSharing.Mode?): Builder {
             this.screenSharingMode = screenSharingMode
             return this


### PR DESCRIPTION
**What was solved?**
Deprecate Screen Sharing.
Mark the GliaWidgetsConfig.Builder.setScreenSharingMode() as deprecated.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
