### PR TITLE
Rename OnSuccess callback to OnResult

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
@@ -16,7 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.glia.widgets.GliaWidgets
 import com.glia.widgets.GliaWidgetsException
 import com.glia.widgets.callbacks.OnError
-import com.glia.widgets.callbacks.OnSuccess
+import com.glia.widgets.callbacks.OnResult
 import com.glia.widgets.callbacks.OnComplete
 import com.glia.widgets.visitor.VisitorInfo
 import com.glia.widgets.visitor.VisitorInfoUpdateRequest
@@ -118,16 +118,16 @@ class VisitorInfoFragment : Fragment() {
 
     private fun getVisitorInfo() {
         saveButton.text = getString(R.string.visitor_info_loading)
-        val onSuccess: OnSuccess<VisitorInfo?> = OnSuccess { result ->
+        val onResult: OnResult<VisitorInfo?> = OnResult { result ->
             view?.post {
                 saveButton.text = getString(R.string.visitor_info_save)
                 result?.let { showVisitorInfo(it) }
             }
         }
 
-        val onError = OnError { exception -> exception?.let { showError(it) } }
+        val onError = OnError { exception -> showError(exception) }
 
-        GliaWidgets.getVisitorInfo(onSuccess, onError)
+        GliaWidgets.getVisitorInfo(onResult, onError)
     }
 
     private fun saveVisitorInfo(visitorInfo: VisitorInfoUpdateRequest) {
@@ -142,7 +142,7 @@ class VisitorInfoFragment : Fragment() {
 
         val onError = OnError { exception ->
             saveButton.text = getString(R.string.visitor_info_save)
-            exception?.let { showError(it) }
+            showError(exception)
         }
         GliaWidgets.updateVisitorInfo(visitorInfo, onComplete, onError)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -7,7 +7,7 @@ import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.authentication.Authentication
 import com.glia.widgets.callbacks.OnComplete
 import com.glia.widgets.callbacks.OnError
-import com.glia.widgets.callbacks.OnSuccess
+import com.glia.widgets.callbacks.OnResult
 import com.glia.widgets.chat.adapter.CustomCardAdapter
 import com.glia.widgets.chat.adapter.WebViewCardAdapter
 import com.glia.widgets.callvisualizer.CallVisualizer
@@ -210,19 +210,19 @@ object GliaWidgets {
     /**
      * Fetches all queues and their information for the current site.
      *
-     * @param onSuccess Callback invoked when the queues are successfully retrieved.
+     * @param onResult Callback invoked when the queues are successfully retrieved.
      *                  Provides a collection of [Queue] objects or `null` if no queues are available.
      * @param onError Callback invoked when an error occurs during the retrieval process.
      *                Provides a [GliaWidgetsException] describing the error.
      */
     @JvmStatic
     fun getQueues(
-        onSuccess: OnSuccess<Collection<Queue>?>,
+        onResult: OnResult<Collection<Queue>?>,
         onError: OnError
     ) {
         glia().getQueues(
-            onSuccess = { queues ->
-                onSuccess.onSuccess(queues.toWidgetsType())
+            onResult = { queues ->
+                onResult.onResult(queues.toWidgetsType())
             },
             onError = {
                 onError.onError(it.toWidgetsType("Failed to get queues"))
@@ -334,14 +334,14 @@ object GliaWidgets {
     /**
      * Fetches the visitor's information
      *
-     * @param onSuccess Callback invoked when the visitor information is successfully retrieved.
+     * @param onResult Callback invoked when the visitor information is successfully retrieved.
      *                  Provides the retrieved [VisitorInfo] or `null` if no information is available.
      * @param onError Callback invoked when an error occurs during the retrieval process.
      *                Provides a [GliaWidgetsException] describing the error.
      */
     @JvmStatic
     fun getVisitorInfo(
-        onSuccess: OnSuccess<VisitorInfo?>,
+        onResult: OnResult<VisitorInfo?>,
         onError: OnError
     ) {
         val callback =
@@ -350,7 +350,7 @@ object GliaWidgets {
                 if (error != null || visitorInfo == null) {
                     onError.onError(error.toWidgetsType("Failed to get visitor info"))
                 } else {
-                    onSuccess.onSuccess(VisitorInfo(visitorInfo))
+                    onResult.onResult(VisitorInfo(visitorInfo))
                 }
             }
         glia().getVisitorInfo(callback)

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnResult.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnResult.kt
@@ -7,15 +7,15 @@ import com.glia.androidsdk.RequestCallback
  *
  * @param <T> object expected to be returned by the request
 </T> */
-fun interface OnSuccess<T> {
+fun interface OnResult<T> {
     /**
      * Function that is fired if request succeeds with a result
      *
      * @param result result returned if the request succeeded
      */
-    fun onSuccess(result: T)
+    fun onResult(result: T)
 }
 
-internal fun <T> RequestCallback<T>.toOnSuccess(): OnSuccess<T> {
-    return OnSuccess { onResult(it, null) }
+internal fun <T> RequestCallback<T>.toOnResult(): OnResult<T> {
+    return OnResult { onResult(it, null) }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -42,7 +42,7 @@ internal interface GliaCore {
     fun <T> off(event: OmnicoreEvent<T>)
     fun fetchFile(attachmentFile: AttachmentFile, callback: RequestCallback<InputStream?>)
     fun getChatHistory(callback: RequestCallback<List<ChatMessage>?>)
-    fun getQueues(onSuccess: (Array<Queue>) -> Unit, onError: (GliaException?) -> Unit)
+    fun getQueues(onResult: (Array<Queue>) -> Unit, onError: (GliaException?) -> Unit)
 
     fun queueForEngagement(
         queueIds: List<String>,

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -85,9 +85,9 @@ internal class GliaCoreImpl : GliaCore {
         Glia.getChatHistory { messages, exception -> callback.onResult(messages?.toList(), exception) }
     }
 
-    override fun getQueues(onSuccess: (Array<Queue>) -> Unit, onError: (GliaException?) -> Unit) {
+    override fun getQueues(onResult: (Array<Queue>) -> Unit, onError: (GliaException?) -> Unit) {
         Glia.getQueues { queues, gliaException ->
-            queues?.also { onSuccess(it) } ?: onError(gliaException)
+            queues?.also { onResult(it) } ?: onError(gliaException)
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt
@@ -46,7 +46,7 @@ internal enum class EndedBy {
     VISITOR
 }
 
-internal typealias FetchSurveyCallback = (onSuccess: (Survey) -> Unit, onError: () -> Unit) -> Unit
+internal typealias FetchSurveyCallback = (onResult: (Survey) -> Unit, onError: () -> Unit) -> Unit
 
 internal sealed interface EngagementUpdateState {
     data object Transferring : EngagementUpdateState

--- a/widgetssdk/src/main/java/com/glia/widgets/secureconversations/SecureConversations.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/secureconversations/SecureConversations.kt
@@ -3,7 +3,7 @@ package com.glia.widgets.secureconversations
 import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.GliaWidgetsException
 import com.glia.widgets.callbacks.OnError
-import com.glia.widgets.callbacks.OnSuccess
+import com.glia.widgets.callbacks.OnResult
 import com.glia.widgets.toWidgetsType
 
 /**
@@ -18,7 +18,7 @@ interface SecureConversations {
      * This number will increase with each message sent by the operator
      * that the visitor has not yet marked as read.
      *
-     * @param onSuccess [OnSuccess] a callback that returns the number of unread
+     * @param onResult [OnResult] a callback that returns the number of unread
      * secure messages on success.
      * @param onError [OnError] a callback that returns [GliaWidgetsException] on failure.
      *
@@ -26,7 +26,7 @@ interface SecureConversations {
      * [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] -when a visitor is not authenticated
      * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized
      */
-    fun getUnreadMessageCount(onSuccess: OnSuccess<Int>, onError: OnError? = null)
+    fun getUnreadMessageCount(onResult: OnResult<Int>, onError: OnError? = null)
 
     /**
      * Subscribes to updates of the unread message count.
@@ -34,24 +34,24 @@ interface SecureConversations {
      * This method allows you to receive updates whenever the unread message count changes.
      * The provided callback will be triggered with the updated count.
      *
-     * @param callback [OnSuccess] A callback that will be invoked with the updated unread message count.
+     * @param callback [OnResult] A callback that will be invoked with the updated unread message count.
      *
      * Note: Ensure to unsubscribe using [unSubscribeFromUnreadMessageCount] when updates are no longer needed
      * to avoid memory leaks or unnecessary updates.
      */
-    fun subscribeToUnreadMessageCount(callback: OnSuccess<Int>)
+    fun subscribeToUnreadMessageCount(callback: OnResult<Int>)
 
     /**
      * Unsubscribes from updates of the unread message count.
      *
      * This method stops receiving updates for the unread message count for the provided callback.
      *
-     * @param callback [OnSuccess] A callback that was previously subscribed to receive updates.
+     * @param callback [OnResult] A callback that was previously subscribed to receive updates.
      *
      * Note: Ensure that the callback passed to this method is the same instance that was used
      * during subscription to successfully unsubscribe.
      */
-    fun unSubscribeFromUnreadMessageCount(callback: OnSuccess<Int>)
+    fun unSubscribeFromUnreadMessageCount(callback: OnResult<Int>)
 }
 
 /**
@@ -63,31 +63,31 @@ class SecureConversationsImpl(
 
     internal val subscribedCallbacks: MutableMap<Int, RequestCallback<Int>> = mutableMapOf()
 
-    override fun getUnreadMessageCount(onSuccess: OnSuccess<Int>, onError: OnError?) {
+    override fun getUnreadMessageCount(onResult: OnResult<Int>, onError: OnError?) {
         secureConversations.getUnreadMessageCount { count, gliaException ->
             if (gliaException != null || count == null) {
                 onError?.onError(gliaException.toWidgetsType("Failed to get unread message count"))
             } else {
-                onSuccess.onSuccess(count)
+                onResult.onResult(count)
             }
         }
     }
 
-    override fun subscribeToUnreadMessageCount(callback: OnSuccess<Int>) {
+    override fun subscribeToUnreadMessageCount(callback: OnResult<Int>) {
         if (subscribedCallbacks.containsKey(callback.hashCode())) {
             // Already subscribed
             return
         }
         val requestCallback: RequestCallback<Int> = RequestCallback { count, gliaException ->
                 if (gliaException == null && count != null) {
-                    callback.onSuccess(count)
+                    callback.onResult(count)
                 }
             }
         subscribedCallbacks[callback.hashCode()] = requestCallback
         secureConversations.subscribeToUnreadMessageCount(requestCallback)
     }
 
-    override fun unSubscribeFromUnreadMessageCount(callback: OnSuccess<Int>) {
+    override fun unSubscribeFromUnreadMessageCount(callback: OnResult<Int>) {
         subscribedCallbacks[callback.hashCode()]?.let { secureConversations.unSubscribeFromUnreadMessageCount(it) }
         subscribedCallbacks.remove(callback.hashCode())
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/secureconversations/SecureConversationsImplTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/secureconversations/SecureConversationsImplTest.kt
@@ -4,7 +4,7 @@ import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.GliaWidgetsException
 import com.glia.widgets.callbacks.OnError
-import com.glia.widgets.callbacks.OnSuccess
+import com.glia.widgets.callbacks.OnResult
 import com.glia.widgets.toWidgetsType
 import io.mockk.*
 import org.junit.Before
@@ -23,23 +23,23 @@ class SecureConversationsImplTest {
     }
 
     @Test
-    fun `getUnreadMessageCount calls SDK and invokes onSuccess`() {
-        val onSuccess: OnSuccess<Int> = mockk(relaxed = true)
+    fun `getUnreadMessageCount calls SDK and invokes onResult`() {
+        val onResult: OnResult<Int> = mockk(relaxed = true)
         val onError: OnError = mockk(relaxed = true)
         val unreadCount = 5
         every { secureConversationsCore.getUnreadMessageCount(any()) } answers {
             firstArg<RequestCallback<Int>>().onResult(unreadCount, null)
         }
 
-        secureConversationsWidgets.getUnreadMessageCount(onSuccess, onError)
+        secureConversationsWidgets.getUnreadMessageCount(onResult, onError)
 
-        verify { onSuccess.onSuccess(unreadCount) }
+        verify { onResult.onResult(unreadCount) }
         verify(exactly = 0) { onError.onError(any()) }
     }
 
     @Test
     fun `getUnreadMessageCount calls SDK and invokes onError on failure`() {
-        val onSuccess: OnSuccess<Int> = mockk(relaxed = true)
+        val onResult: OnResult<Int> = mockk(relaxed = true)
         val onError: OnError = mockk(relaxed = true)
         val exception = mock<GliaException>()
         val widgetsException = GliaWidgetsException("Error", GliaWidgetsException.Cause.AUTHENTICATION_ERROR)
@@ -49,15 +49,15 @@ class SecureConversationsImplTest {
             firstArg<RequestCallback<Int>>().onResult(null, exception)
         }
 
-        secureConversationsWidgets.getUnreadMessageCount(onSuccess, onError)
+        secureConversationsWidgets.getUnreadMessageCount(onResult, onError)
 
         verify { onError.onError(widgetsException) }
-        verify(exactly = 0) { onSuccess.onSuccess(any()) }
+        verify(exactly = 0) { onResult.onResult(any()) }
     }
 
     @Test
     fun `subscribeToUnreadMessageCount adds callback and calls SDK`() {
-        val callback: OnSuccess<Int> = mockk(relaxed = true)
+        val callback: OnResult<Int> = mockk(relaxed = true)
         val requestCallbackSlot = slot<RequestCallback<Int>>()
         val unreadCount = 10
         every { secureConversationsCore.subscribeToUnreadMessageCount(capture(requestCallbackSlot)) } just Runs
@@ -67,12 +67,12 @@ class SecureConversationsImplTest {
         verify { secureConversationsCore.subscribeToUnreadMessageCount(any()) }
         assert(secureConversationsWidgets.subscribedCallbacks.containsKey(callback.hashCode()))
         requestCallbackSlot.captured.onResult(unreadCount, null)
-        verify { callback.onSuccess(unreadCount) }
+        verify { callback.onResult(unreadCount) }
     }
 
     @Test
     fun `subscribeToUnreadMessageCount does not subscribe the same callback twice`() {
-        val callback: OnSuccess<Int> = mockk(relaxed = true)
+        val callback: OnResult<Int> = mockk(relaxed = true)
         val requestCallbackSlot = slot<RequestCallback<Int>>()
         every { secureConversationsCore.subscribeToUnreadMessageCount(capture(requestCallbackSlot)) } just Runs
 
@@ -89,7 +89,7 @@ class SecureConversationsImplTest {
 
     @Test
     fun `unSubscribeFromUnreadMessageCount removes callback and calls SDK`() {
-        val callback: OnSuccess<Int> = mockk(relaxed = true)
+        val callback: OnResult<Int> = mockk(relaxed = true)
         val requestCallback: RequestCallback<Int> = mockk(relaxed = true)
         secureConversationsWidgets.subscribedCallbacks[callback.hashCode()] = requestCallback
 


### PR DESCRIPTION
**What was solved?**
[Add public classes for Core SDK GliaException and RequestCallback to Android Widgets SDK](https://glia.atlassian.net/browse/MOB-4213)

It's a result of [this discussion](https://github.com/salemove/android-sdk-widgets/pull/1300#discussion_r2086525822).

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

