### PR TITLE
Replace Runnable with OnComplete in CallVisualizer interface

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -332,9 +332,9 @@ class MainFragment : Fragment() {
 
     private fun listenForCallVisualizerEngagements() {
         // If a Visitor Code is displayed as embedded view, then it should be hidden on engagement start
-        GliaWidgets.getCallVisualizer().onEngagementStart {
+        GliaWidgets.getCallVisualizer().onEngagementStart(onComplete = {
             activity?.runOnUiThread { removeVisitorCodeFromDedicatedView() }
-        }
+        })
     }
 
     private fun getQueueIdsFromPrefs(sharedPreferences: SharedPreferences): List<String> {

--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -28,7 +28,6 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.PreferenceManager
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.Glia
-import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.fcm.GliaPushMessage
 import com.glia.androidsdk.omnibrowse.Omnibrowse
 import com.glia.exampleapp.ExampleAppConfigManager.createDefaultConfig
@@ -540,7 +539,7 @@ class MainFragment : Fragment() {
                 view?.post { initMenu() }
             },
             onError = { error ->
-                error?.let { showToast(it.message.toString()) }
+                showToast(error.message.toString())
             }
         )
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizer.kt
@@ -12,7 +12,7 @@ import com.glia.widgets.callbacks.OnComplete
  *
  * For more information, see the [Call Visualizer guide](https://docs.glia.com/glia-mobile/docs/android-widgets-call-visualizer).
  */
-interface CallVisualizer {
+interface CallVisualizer: com.glia.widgets.core.callvisualizer.domain.CallVisualizer {
     /**
      * Creates a VisitorCodeView component that can be integrated into the client application
      *
@@ -22,7 +22,7 @@ interface CallVisualizer {
      * expired. During that time, the code can be used to initiate an engagement. Once the operator
      * has used the visitor code to initiate an engagement, the code will expire immediately.
      */
-    fun createVisitorCodeView(context: Context): View?
+    override fun createVisitorCodeView(context: Context): View?
 
     /**
      * Shows the visitor code in a dialog box on top of the current activity within your application.
@@ -31,14 +31,14 @@ interface CallVisualizer {
      *
      * Otherwise, it behaves the same way as [.createVisitorCodeView].
      */
-    fun showVisitorCodeDialog()
+    override fun showVisitorCodeDialog()
 
     /**
      * Sets visitor context to the upcoming Call Visualizer engagement
      *
-     * @param visitorContextAssetId is a visitor context asset ID
+     * @param visitorCodeContext is a visitor context asset ID
      */
-    fun addVisitorContext(visitorContextAssetId: String)
+    override fun addVisitorContext(visitorCodeContext: String)
 
     /**
      * Sets callback that will be called when Call Visualizer engagement is started.
@@ -56,7 +56,7 @@ interface CallVisualizer {
      * Callback won't be triggered for engagement ended before the callback has been set.
      * Setting new callback will override the old one.
      *
-     * @param onComplete The [OnComplete] callback that will be executed on Call Visualizer engagement end
+     * @param runnable The Runnable that will be executed on engagement end
      */
     fun onEngagementEnd(onComplete: OnComplete)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizer.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/CallVisualizer.kt
@@ -2,21 +2,19 @@ package com.glia.widgets.callvisualizer
 
 import android.content.Context
 import android.view.View
+import com.glia.widgets.callbacks.OnComplete
 
 /**
  * Provides controls related to Call Visualizer module
  *
- *
  * Some interactions between operators and visitors start as regular phone calls with no Glia engagement.
  * Screen sharing and video engagements are available for such calls via Call Visualizer.
  *
- *
  * For more information, see the [Call Visualizer guide](https://docs.glia.com/glia-mobile/docs/android-widgets-call-visualizer).
  */
-interface CallVisualizer: com.glia.widgets.core.callvisualizer.domain.CallVisualizer {
+interface CallVisualizer {
     /**
      * Creates a VisitorCodeView component that can be integrated into the client application
-     *
      *
      * The visitor code is generated on demand and is unique for every visitor on a particular site.
      * The first time this function is called for a visitor, the code is generated and returned.
@@ -24,45 +22,41 @@ interface CallVisualizer: com.glia.widgets.core.callvisualizer.domain.CallVisual
      * expired. During that time, the code can be used to initiate an engagement. Once the operator
      * has used the visitor code to initiate an engagement, the code will expire immediately.
      */
-    override fun createVisitorCodeView(context: Context): View?
+    fun createVisitorCodeView(context: Context): View?
 
     /**
      * Shows the visitor code in a dialog box on top of the current activity within your application.
      *
-     *
      * This dialog will overlay on top of any other dialogs without dismissing them.
-     *
      *
      * Otherwise, it behaves the same way as [.createVisitorCodeView].
      */
-    override fun showVisitorCodeDialog()
+    fun showVisitorCodeDialog()
 
     /**
      * Sets visitor context to the upcoming Call Visualizer engagement
      *
-     * @param visitorCodeContext is a visitor context asset ID
+     * @param visitorContextAssetId is a visitor context asset ID
      */
-    override fun addVisitorContext(visitorCodeContext: String)
+    fun addVisitorContext(visitorContextAssetId: String)
 
     /**
      * Sets callback that will be called when Call Visualizer engagement is started.
      *
-     *
      * Callback won't be triggered for engagement started before the callback has been set or the ongoing engagements.
      * Setting new callback will override the old one.
      *
-     * @param runnable The Runnable that will be executed on engagement start
+     * @param onComplete The [OnComplete] callback that will be executed on Call Visualizer engagement start
      */
-    override fun onEngagementStart(runnable: Runnable)
+    fun onEngagementStart(onComplete: OnComplete)
 
     /**
      * Sets callback that will be called when Call Visualizer engagement is ended.
      *
-     *
      * Callback won't be triggered for engagement ended before the callback has been set.
      * Setting new callback will override the old one.
      *
-     * @param runnable The Runnable that will be executed on engagement end
+     * @param onComplete The [OnComplete] callback that will be executed on Call Visualizer engagement end
      */
-    override fun onEngagementEnd(runnable: Runnable)
+    fun onEngagementEnd(onComplete: OnComplete)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/EndScreenSharingController.kt
@@ -25,7 +25,7 @@ internal class EndScreenSharingController(private val endScreenSharingUseCase: E
     }
 
     override fun onActivityCreate() {
-        GliaWidgets.getCallVisualizer().onEngagementEnd { view?.finish() }
+        GliaWidgets.getCallVisualizer().onEngagementEnd(onComplete = { view?.finish() })
     }
 
     override fun onDestroy() {}

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/callvisualizer/CallVisualizerManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/callvisualizer/CallVisualizerManager.kt
@@ -3,6 +3,7 @@ package com.glia.widgets.internal.callvisualizer
 import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
+import com.glia.widgets.callbacks.OnComplete
 import com.glia.widgets.callvisualizer.controller.CallVisualizerContract
 import com.glia.widgets.callvisualizer.CallVisualizer
 import com.glia.widgets.internal.callvisualizer.domain.VisitorCodeViewBuilderUseCase
@@ -26,12 +27,12 @@ internal class CallVisualizerManager(
     }
 
     @SuppressLint("CheckResult")
-    override fun onEngagementStart(runnable: Runnable) {
-        callVisualizerController.engagementStartFlow.unSafeSubscribe { runnable.run() }
+    override fun onEngagementStart(onComplete: OnComplete) {
+        callVisualizerController.engagementStartFlow.unSafeSubscribe { onComplete.onComplete() }
     }
 
     @SuppressLint("CheckResult")
-    override fun onEngagementEnd(runnable: Runnable) {
-        callVisualizerController.engagementEndFlow.unSafeSubscribe { runnable.run() }
+    override fun onEngagementEnd(onComplete: OnComplete) {
+        callVisualizerController.engagementEndFlow.unSafeSubscribe { onComplete.onComplete() }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/callvisualizer/CallVisualizerManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/callvisualizer/CallVisualizerManager.kt
@@ -31,8 +31,16 @@ internal class CallVisualizerManager(
         callVisualizerController.engagementStartFlow.unSafeSubscribe { onComplete.onComplete() }
     }
 
+    override fun onEngagementStart(runnable: Runnable) {
+        onEngagementStart(onComplete = { runnable.run() })
+    }
+
     @SuppressLint("CheckResult")
     override fun onEngagementEnd(onComplete: OnComplete) {
         callVisualizerController.engagementEndFlow.unSafeSubscribe { onComplete.onComplete() }
+    }
+
+    override fun onEngagementEnd(runnable: Runnable) {
+        onEngagementEnd(onComplete = { runnable.run() })
     }
 }


### PR DESCRIPTION
**Jira issue:**
[Replace Runnable with OnComplete in CallVisualizer interface](https://glia.atlassian.net/browse/MOB-4348)

**What was solved?**
- Replace Runnable with OnComplete in CallVisualizer interface
- Got rid of inheritance from a deprecated com.glia.widgets.core.callvisualizer.domain.CallVisualizer
- Several other minor improvements

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.
