### PR TITLE
Refactor callbacks

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
@@ -118,10 +118,10 @@ class VisitorInfoFragment : Fragment() {
 
     private fun getVisitorInfo() {
         saveButton.text = getString(R.string.visitor_info_loading)
-        val onResult: OnResult<VisitorInfo?> = OnResult { result ->
+        val onResult: OnResult<VisitorInfo> = OnResult { result ->
             view?.post {
                 saveButton.text = getString(R.string.visitor_info_save)
-                result?.let { showVisitorInfo(it) }
+                showVisitorInfo(result)
             }
         }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -156,22 +156,22 @@ object GliaWidgets {
     @JvmStatic
     @Synchronized
     fun init(gliaWidgetsConfig: GliaWidgetsConfig,
-             onComplete: OnComplete? = null,
-             onError: OnError? = null) {
+             onComplete: OnComplete,
+             onError: OnError) {
         Logger.i(TAG, "Initialize Glia Widgets SDK")
         try {
             val callback: RequestCallback<Boolean?> =
                 RequestCallback { _, exception ->
                     if (exception == null) {
                         glia().isInitialized = true
-                        onComplete?.onComplete()
+                        onComplete.onComplete()
                     } else {
                         Logger.i(TAG, "Glia Widgets SDK initialization failed")
                         val invalidInputError = GliaWidgetsException(
                             "Failed to initialise Glia Widgets SDK. Please check credentials.",
                             GliaWidgetsException.Cause.INVALID_INPUT
                         )
-                        onError?.onError(invalidInputError)
+                        onError.onError(invalidInputError)
                     }
                 }
 
@@ -181,7 +181,7 @@ object GliaWidgets {
         } catch (exception: Exception) {
             if (exception is GliaException) {
                 val mappedException = exception.toWidgetsType()
-                onError?.onError(mappedException)
+                onError.onError(mappedException)
                 return
             }
 
@@ -190,7 +190,7 @@ object GliaWidgets {
                 "Internal SDK error",
                 GliaWidgetsException.Cause.INTERNAL_ERROR
             )
-            onError?.onError(internalError)
+            onError.onError(internalError)
         }
     }
 
@@ -217,15 +217,15 @@ object GliaWidgets {
      */
     @JvmStatic
     fun getQueues(
-        onResult: OnResult<Collection<Queue>?>,
-        onError: OnError
+        onResult: OnResult<Collection<Queue>>,
+        onError: OnError? = null
     ) {
         glia().getQueues(
             onResult = { queues ->
                 onResult.onResult(queues.toWidgetsType())
             },
             onError = {
-                onError.onError(it.toWidgetsType("Failed to get queues"))
+                onError?.onError(it.toWidgetsType("Failed to get queues"))
             }
         )
     }
@@ -341,14 +341,14 @@ object GliaWidgets {
      */
     @JvmStatic
     fun getVisitorInfo(
-        onResult: OnResult<VisitorInfo?>,
-        onError: OnError
+        onResult: OnResult<VisitorInfo>,
+        onError: OnError? = null
     ) {
         val callback =
             RequestCallback { visitorInfo: com.glia.androidsdk.visitor.VisitorInfo?,
                               error: GliaException? ->
                 if (error != null || visitorInfo == null) {
-                    onError.onError(error.toWidgetsType("Failed to get visitor info"))
+                    onError?.onError(error.toWidgetsType("Failed to get visitor info"))
                 } else {
                     onResult.onResult(VisitorInfo(visitorInfo))
                 }

--- a/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
@@ -36,8 +36,8 @@ interface Authentication {
     fun authenticate(
         jwtToken: String,
         externalAccessToken: String?,
-        onComplete: OnComplete?,
-        onError: OnError?
+        onComplete: OnComplete,
+        onError: OnError
     )
 
     /**
@@ -52,8 +52,8 @@ interface Authentication {
      * <br></br> [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] - when authentication fails
      */
     fun deauthenticate(
-        onComplete: OnComplete?,
-        onError: OnError?
+        onComplete: OnComplete,
+        onError: OnError
     )
 
     /**
@@ -81,8 +81,8 @@ interface Authentication {
     fun refresh(
         jwtToken: String,
         externalAccessToken: String?,
-        onComplete: OnComplete?,
-        onError: OnError?
+        onComplete: OnComplete,
+        onError: OnError
     )
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnComplete.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnComplete.kt
@@ -13,6 +13,6 @@ fun interface OnComplete {
     fun onComplete()
 }
 
-internal fun RequestCallback<Void>.toOnComplete(): OnComplete {
-    return OnComplete { onResult(null, null) }
+internal fun RequestCallback<Void>?.toOnComplete(): OnComplete {
+    return OnComplete { this?.onResult(null, null) }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnError.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callbacks/OnError.kt
@@ -16,6 +16,6 @@ fun interface OnError {
     fun onError(exception: GliaWidgetsException)
 }
 
-internal fun RequestCallback<Void>.toOnError(): OnError {
-    return OnError { onResult(null, it.toCoreType()) }
+internal fun RequestCallback<Void>?.toOnError(): OnError {
+    return OnError { this?.onResult(null, it.toCoreType()) }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/authentication/AuthenticationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/authentication/AuthenticationManager.kt
@@ -30,8 +30,8 @@ internal class AuthenticationManager(
     override fun authenticate(
         jwtToken: String,
         externalAccessToken: String?,
-        onComplete: OnComplete?,
-        onError: OnError?
+        onComplete: OnComplete,
+        onError: OnError
     ) {
         onAuthenticationRequestedCallback()
         Dependencies.destroyControllersAndResetQueueing()
@@ -39,19 +39,19 @@ internal class AuthenticationManager(
         Logger.i(TAG, "Authenticate. Is external access token used: ${externalAccessToken != null}")
         authentication.authenticate(jwtToken, externalAccessToken) { _, gliaException ->
             if (gliaException != null) {
-                onError?.onError(gliaException.toWidgetsType())
+                onError.onError(gliaException.toWidgetsType())
             }
             //Here we need to subscribe to secure conversations repository to get the data for authenticated visitors
             repositoryFactory.secureConversationsRepository.subscribe()
 
-            onComplete?.onComplete()
+            onComplete.onComplete()
 
         }
     }
 
     override fun deauthenticate(
-        onComplete: OnComplete?,
-        onError: OnError?
+        onComplete: OnComplete,
+        onError: OnError
     ) {
         Logger.i(TAG, "Unauthenticate")
         //Need to end engagement before it's done on the core side to prevent unexpected behavior
@@ -63,9 +63,9 @@ internal class AuthenticationManager(
 
         authentication.deauthenticate { _, gliaException ->
             if (gliaException != null) {
-                onError?.onError(gliaException.toWidgetsType())
+                onError.onError(gliaException.toWidgetsType())
             }
-            onComplete?.onComplete()
+            onComplete.onComplete()
         }
     }
 
@@ -74,16 +74,16 @@ internal class AuthenticationManager(
 
     override fun refresh(jwtToken: String,
                          externalAccessToken: String?,
-                         onComplete: OnComplete?,
-                         onError: OnError?
+                         onComplete: OnComplete,
+                         onError: OnError
     ) {
         Logger.i(TAG, "Refresh authentication")
         authentication.refresh(jwtToken, externalAccessToken) { _, gliaException ->
             if (gliaException != null) {
-                onError?.onError(gliaException.toWidgetsType())
+                onError.onError(gliaException.toWidgetsType())
             }
 
-            onComplete?.onComplete()
+            onComplete.onComplete()
         }
     }
 }
@@ -99,11 +99,11 @@ internal fun AuthenticationManager.toCoreType(): CoreAuthentication = this.let {
                 reportTokenInvalidError(authCallback)
                 return
             }
-            widgetAuthentication.authenticate(jwtToken, externalAccessToken, authCallback?.toOnComplete(), authCallback?.toOnError())
+            widgetAuthentication.authenticate(jwtToken, externalAccessToken, authCallback.toOnComplete(), authCallback.toOnError())
         }
 
         override fun deauthenticate(authCallback: RequestCallback<Void>?) {
-            widgetAuthentication.deauthenticate(authCallback?.toOnComplete(), authCallback?.toOnError())
+            widgetAuthentication.deauthenticate(authCallback.toOnComplete(), authCallback.toOnError())
         }
 
         override fun isAuthenticated(): Boolean {
@@ -115,7 +115,7 @@ internal fun AuthenticationManager.toCoreType(): CoreAuthentication = this.let {
                 reportTokenInvalidError(authCallback)
                 return
             }
-            widgetAuthentication.refresh(jwtToken, externalAccessToken, authCallback?.toOnComplete(), authCallback?.toOnError())
+            widgetAuthentication.refresh(jwtToken, externalAccessToken, authCallback.toOnComplete(), authCallback.toOnError())
         }
 
         private fun reportTokenInvalidError(authCallback: RequestCallback<Void>?) {

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
@@ -22,11 +22,11 @@ import org.junit.ClassRule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.never
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
@@ -7,11 +7,11 @@ import junit.framework.TestCase.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.mockito.Mockito.any
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class AuthenticationManagerTest {
@@ -36,6 +36,19 @@ class AuthenticationManagerTest {
         val callback = mock<RequestCallback<Void>>()
 
         coreAuthentication.authenticate(jwtToken, externalAccessToken, callback)
+
+        verify(widgetAuthentication).authenticate(eq(jwtToken), eq(externalAccessToken), any(), any())
+    }
+
+    @Test
+    fun toCoreType_authenticateWithoutCallback_callsAuthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+
+        coreAuthentication.authenticate(jwtToken, externalAccessToken, null)
 
         verify(widgetAuthentication).authenticate(eq(jwtToken), eq(externalAccessToken), any(), any())
     }
@@ -68,6 +81,16 @@ class AuthenticationManagerTest {
     }
 
     @Test
+    fun toCoreType_deauthenticateWithoutCallback_callsDeauthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        coreAuthentication.deauthenticate(null)
+
+        verify(widgetAuthentication).deauthenticate(any(), any())
+    }
+
+    @Test
     fun toCoreType_isAuthenticated_returnsCorrectValue() {
         val widgetAuthentication = mock<AuthenticationManager>()
         whenever(widgetAuthentication.isAuthenticated).thenReturn(true)
@@ -87,6 +110,19 @@ class AuthenticationManagerTest {
         val callback = mock<RequestCallback<Void>>()
 
         coreAuthentication.refresh(jwtToken, externalAccessToken, callback)
+
+        verify(widgetAuthentication).refresh(eq(jwtToken), eq(externalAccessToken), any(), any())
+    }
+
+    @Test
+    fun toCoreType_refreshWithoutCallback_callsRefreshOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+
+        coreAuthentication.refresh(jwtToken, externalAccessToken, null)
 
         verify(widgetAuthentication).refresh(eq(jwtToken), eq(externalAccessToken), any(), any())
     }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4355

**What was solved?**
The idea is to make the interface more convenient for integrators. Callbacks are divided into 3 types:
- Result callbacks not nullable (OnComplete, OnResult). Integrators will always have result.
- OnError callbacks nullable for getters (getQueues, getVisitorInfo, getUnreadMessageCount, etc). In case integrators need the result, but don't want to handle the errors.
- make the OnError callback not nullable for methods that update something or perform some action (init, updateVisitorInfo, etc). Important actions should always be handled.

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
