### PR TITLE
Deprecate onAppCreate method

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!--    "network_security_config" is added to support GVA images for testing app-->
     <application
@@ -56,6 +57,11 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_notification" />
+
+        <provider
+            android:name="com.glia.widgets.InitializationProvider"
+            android:authorities="${applicationId}.InitializationProvider"
+            tools:node="remove"/> <!-- Used the custom provider from the testing Application -->
 
         <provider
             android:name=".InitializationProvider"

--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -112,5 +112,10 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_provider" />
         </provider>
+
+        <provider
+            android:name=".InitializationProvider"
+            android:authorities="${applicationId}.InitializationProvider"
+            android:exported="false" />
     </application>
 </manifest>

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -108,11 +108,14 @@ object GliaWidgets {
     }
 
     /**
-     * Should be called when the application is starting in [Application].onCreate()
+     * This method is obsolete and no longer required.
+     * It is safe to remove calls to this method.
      *
      * @param application the application where it is initialized
      * @throws GliaWidgetsException with [GliaWidgetsException.Cause]
      */
+    @Deprecated("No longer required to call this method")
+    @JvmStatic
     @Synchronized
     fun onAppCreate(application: Application) {
         try {
@@ -515,7 +518,13 @@ object GliaWidgets {
 
     // More info about global Rx error handler:
     // https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling
-    private fun setupRxErrorHandler() {
+    internal fun setupRxErrorHandler() {
+        // Check if RxJava error handler is already set
+        if (RxJavaPlugins.getErrorHandler() != null) {
+            // RxJava error handler is already set by the application
+            return
+        }
+
         RxJavaPlugins.setErrorHandler { throwable: Throwable ->
             val error = (throwable as? UndeliverableException)?.cause ?: throwable
             when (error) {

--- a/widgetssdk/src/main/java/com/glia/widgets/InitializationProvider.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/InitializationProvider.kt
@@ -5,13 +5,17 @@ import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
+import com.glia.widgets.di.Dependencies
 
 /**
  * @hide
  */
 open class InitializationProvider : ContentProvider() {
     override fun onCreate(): Boolean {
-        (context as? Application)?.let { GliaWidgets.onAppCreate(it) }
+        (context as? Application)?.let {
+            Dependencies.onAppCreate(it)
+            GliaWidgets.setupRxErrorHandler()
+        }
         return true
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4363

**What was solved?**
- Add the InitializationProvider to the SDK manifest.
- Check if RxJava error handler is already set.

**What was solved? (Ignore Release notes)**
- Make onAppCreate as JvmStatic.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
