### PR TITLE
Introduce a separate isInitialized Boolean to GliaWidgets instead of glia().isInitialized

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -24,7 +24,7 @@ import com.glia.widgets.di.Dependencies.destroyControllersAndResetEngagementData
 import com.glia.widgets.di.Dependencies.engagementLauncher
 import com.glia.widgets.di.Dependencies.entryWidget
 import com.glia.widgets.di.Dependencies.getAuthenticationManager
-import com.glia.widgets.di.Dependencies.glia
+import com.glia.widgets.di.Dependencies.gliaCore
 import com.glia.widgets.di.Dependencies.gliaThemeManager
 import com.glia.widgets.di.Dependencies.liveObservation
 import com.glia.widgets.di.Dependencies.onSdkInit
@@ -66,6 +66,8 @@ object GliaWidgets {
     @JvmStatic
     val widgetsCoreSdkVersion: String
         get() = BuildConfig.GLIA_CORE_SDK_VERSION
+
+    private var isInitialized = false
 
     private var _customCardAdapter: CustomCardAdapter? = WebViewCardAdapter()
 
@@ -142,7 +144,7 @@ object GliaWidgets {
             onSdkInit(gliaWidgetsConfig)
             setupLoggingMetadata(gliaWidgetsConfig)
             gliaThemeManager.applyJsonConfig(gliaWidgetsConfig.uiJsonRemoteConfig)
-            glia().isInitialized = true
+            isInitialized = true
         } catch (gliaException: GliaException) {
             val gliaWidgetsException = gliaException.toWidgetsType()
             throw gliaWidgetsException
@@ -166,7 +168,7 @@ object GliaWidgets {
             val callback: RequestCallback<Boolean?> =
                 RequestCallback { _, exception ->
                     if (exception == null) {
-                        glia().isInitialized = true
+                        isInitialized = true
                         onComplete.onComplete()
                     } else {
                         Logger.i(TAG, "Glia Widgets SDK initialization failed")
@@ -207,7 +209,7 @@ object GliaWidgets {
      */
     @JvmStatic
     fun isInitialized(): Boolean {
-        return glia().isInitialized
+        return isInitialized
     }
 
     /**
@@ -223,7 +225,7 @@ object GliaWidgets {
         onResult: OnResult<Collection<Queue>>,
         onError: OnError? = null
     ) {
-        glia().getQueues(
+        gliaCore().getQueues(
             onResult = { queues ->
                 onResult.onResult(queues.toWidgetsType())
             },
@@ -264,7 +266,7 @@ object GliaWidgets {
     @Synchronized
     @JvmStatic
     fun getEntryWidget(queueIds: List<String>): EntryWidget {
-        if (!glia().isInitialized) {
+        if (!gliaCore().isInitialized) {
             Logger.e(TAG, "Attempt to get EntryWidget before SDK initialization")
         }
 
@@ -301,7 +303,7 @@ object GliaWidgets {
     ) {
         Logger.d(TAG, "onRequestPermissionsResult")
         try {
-            glia().onRequestPermissionsResult(requestCode, permissions, grantResults)
+            gliaCore().onRequestPermissionsResult(requestCode, permissions, grantResults)
         } catch (gliaException: GliaException) {
             throw gliaException.toWidgetsType()
         }
@@ -356,7 +358,7 @@ object GliaWidgets {
                     onResult.onResult(VisitorInfo(visitorInfo))
                 }
             }
-        glia().getVisitorInfo(callback)
+        gliaCore().getVisitorInfo(callback)
     }
 
     /**
@@ -381,7 +383,7 @@ object GliaWidgets {
                     onError.onError(error.toWidgetsType())
                 }
             }
-        glia().updateVisitorInfo(visitorInfoUpdateRequest.toCoreType(), updateCallback)
+        gliaCore().updateVisitorInfo(visitorInfoUpdateRequest.toCoreType(), updateCallback)
     }
 
     /**
@@ -399,7 +401,7 @@ object GliaWidgets {
             //and we don't need secure conversations data for un-authenticated visitors.
             repositoryFactory.secureConversationsRepository.unsubscribeAndResetData()
 
-            glia().clearVisitorSession()
+            gliaCore().clearVisitorSession()
         } catch (gliaException: GliaException) {
             throw gliaException.toWidgetsType()
         }
@@ -502,7 +504,7 @@ object GliaWidgets {
     }
 
     private fun setupQueueIds(queueIds: List<String>) {
-        glia().ensureInitialized()
+        gliaCore().ensureInitialized()
 
         configurationManager.setQueueIds(queueIds)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt
@@ -5,9 +5,9 @@ import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
-import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaConfig
 import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.GliaWidgets
 import com.glia.widgets.GliaWidgetsConfig
 import com.glia.widgets.authentication.Authentication
 import com.glia.widgets.callvisualizer.CallVisualizerActivityWatcher
@@ -289,7 +289,7 @@ internal object Dependencies {
     }
 
     @JvmStatic
-    fun glia(): GliaCore {
+    fun gliaCore(): GliaCore {
         return gliaCore
     }
 
@@ -308,7 +308,7 @@ internal object Dependencies {
                 Lifecycle.Event.ON_PAUSE -> {
                     // Moved to on pause due to "IllegalStateException: Not allowed to start service app is in background"
                     // Related bug ticket MOB-4011
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && Glia.isInitialized()) {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && GliaWidgets.isInitialized()) {
                         notificationManager.startNotificationRemovalService()
                     }
                 }

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCore.kt
@@ -26,7 +26,7 @@ import java.util.Optional
 import java.util.function.Consumer
 
 internal interface GliaCore {
-    var isInitialized: Boolean
+    val isInitialized: Boolean
     val pushNotifications: PushNotifications
     val currentEngagement: Optional<Engagement>
     val callVisualizer: Omnibrowse

--- a/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/GliaCoreImpl.kt
@@ -28,7 +28,11 @@ import java.util.Optional
 import java.util.function.Consumer
 
 internal class GliaCoreImpl : GliaCore {
-    override var isInitialized: Boolean = false
+    // GliaWidgets initialization process: The Core SDK is initialized first, followed by GliaWidgets.
+    // The `isInitialized` property represents the initialization state of the Core SDK (via `Glia.isInitialized()`).
+    // It is not connected to the Widgets-specific `GliaWidgets.isInitialized()` Boolean.
+    override val isInitialized: Boolean
+        get() = Glia.isInitialized()
 
     override val pushNotifications: PushNotifications
         get() = Glia.getPushNotifications()

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -30,7 +30,7 @@ internal class EntryWidgetController @JvmOverloads constructor(
     private val hasOngoingSecureConversationUseCase: HasOngoingSecureConversationUseCase,
     private val engagementStateUseCase: EngagementStateUseCase,
     private val engagementTypeUseCase: EngagementTypeUseCase,
-    private val core: GliaCore,
+    private val gliaCore: GliaCore,
     private val engagementLauncher: EngagementLauncher,
     private val activityLauncher: ActivityLauncher,
     private val compositeDisposable: CompositeDisposable = CompositeDisposable()
@@ -76,7 +76,7 @@ internal class EntryWidgetController @JvmOverloads constructor(
     override fun setView(view: EntryWidgetContract.View, type: EntryWidgetContract.ViewType) {
         this.view = view
 
-        if (!core.isInitialized) {
+        if (!gliaCore.isInitialized) {
             showSdkNotInitializedState(type == EntryWidgetContract.ViewType.MESSAGING_LIVE_SUPPORT)
         }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
@@ -1,6 +1,6 @@
 package com.glia.widgets.view.head.controller
 
-import com.glia.androidsdk.Glia
+import com.glia.widgets.GliaWidgets
 import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.engagement.ScreenSharingState
@@ -88,7 +88,7 @@ internal class ActivityWatcherForChatHeadController(
 
         val viewName: String = gliaOrRootView?.javaClass?.simpleName.orEmpty()
         applicationChatHeadController.onResume(viewName)
-        if (Glia.isInitialized() && shouldShowAppBubble(viewName)) {
+        if (GliaWidgets.isInitialized() && shouldShowAppBubble(viewName)) {
             watcher.addChatHeadLayoutIfAbsent()
         }
     }


### PR DESCRIPTION
**Jira issue:**
[MOB-4359](https://glia.atlassian.net/browse/MOB-4359)

**One of the affected scenarios:**

1. Open the app, don’t initialize the SDK yet
2. Show embedded Entry Widget, error state is shown
3. Initialize the SDK 
**Expected result:** Entry Widget switches to the loading state and after queues are loaded, shows available types.
**Actual result:** error state is still shown

**The reason:**
`fun init(gliaWidgetsConfig: GliaWidgetsConfig)` calls `onSdkInit(gliaWidgetsConfig)` and after that sets `glia().isInitialized` to `true`. However, `onSdkInit` calls `repositoryFactory.initialize()` which initializes `QueueRepository`. `QueueRepository` has `forceFetchQueues()` function that relies on `gliaCore.isInitializedvalue`. So, the sequence of actions is broken.

**What was solved?**

- Introduce a separate `isInitialized` `Boolean` to `GliaWidgets`. It's value will be exposed to integrators.
- Separated the Core `isInitialized` from Widgets `isInitialized`. Made it internally available only.
- Used Core `isInitialized` for most of the places inside Widgets SDK
- Used Widgets `isInitialized` for some the places of Widgets SDK where it makes sense to wait for Widgets initialization completion

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.


[MOB-4359]: https://glia.atlassian.net/browse/MOB-4359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ