### PR TITLE
Use the UnifiedTheme whiteLabel for the EntryWidget

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidget.kt
@@ -49,13 +49,14 @@ internal class EntryWidgetImpl(
     }
 
     override fun getView(context: Context): View {
-        val entryWidgetTheme = themeManager.theme?.entryWidgetTheme
-        val adapter = EntryWidgetAdapter(EntryWidgetContract.ViewType.EMBEDDED_VIEW, entryWidgetTheme)
+        val unifiedTheme = themeManager.theme
+        val adapter = EntryWidgetAdapter(EntryWidgetContract.ViewType.EMBEDDED_VIEW, unifiedTheme?.entryWidgetTheme)
 
         //Wrapping with Glia theme to make the Theme available for embedded view
         return EntryWidgetView(context.wrapWithTheme()).apply {
+            unifiedThemeWhiteLabel = unifiedTheme?.isWhiteLabel
             setAdapter(adapter)
-            setEntryWidgetTheme(entryWidgetTheme)
+            setEntryWidgetTheme(unifiedTheme?.entryWidgetTheme)
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetFragment.kt
@@ -16,7 +16,7 @@ import com.glia.widgets.di.Dependencies
 import com.glia.widgets.entrywidget.adapter.EntryWidgetAdapter
 import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
 import com.glia.widgets.view.unifiedui.applyLayerTheme
-import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
+import com.glia.widgets.view.unifiedui.theme.UnifiedTheme
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -38,12 +38,12 @@ internal class EntryWidgetFragment : BottomSheetDialogFragment() {
     ): View {
         val layoutInflater = LayoutInflater.from(requireContext().wrapWithMaterialThemeOverlay())
         val binding = EntryWidgetFragmentBinding.inflate(layoutInflater, container, false)
-        val entryWidgetsTheme = Dependencies.gliaThemeManager.theme?.entryWidgetTheme
+        val unifiedTheme = Dependencies.gliaThemeManager.theme
 
         setupView(
             requireContext(),
             binding,
-            entryWidgetsTheme
+            unifiedTheme
         )
 
         return binding.root
@@ -53,23 +53,24 @@ internal class EntryWidgetFragment : BottomSheetDialogFragment() {
     fun setupView(
         context: Context,
         binding: EntryWidgetFragmentBinding,
-        entryWidgetsTheme: EntryWidgetTheme?
+        unifiedTheme: UnifiedTheme?
     ) {
         val entryWidgetAdapter = EntryWidgetAdapter(
             EntryWidgetContract.ViewType.BOTTOM_SHEET,
-            entryWidgetsTheme
+            unifiedTheme?.entryWidgetTheme
         )
 
         EntryWidgetView(context).apply {
+            unifiedThemeWhiteLabel = unifiedTheme?.isWhiteLabel
             setAdapter(entryWidgetAdapter)
-            setEntryWidgetTheme(entryWidgetsTheme)
+            setEntryWidgetTheme(unifiedTheme?.entryWidgetTheme)
             binding.container.addView(this)
             onDismissListener = {
                 this@EntryWidgetFragment.dismiss()
             }
         }
 
-        entryWidgetsTheme?.background?.let {
+        unifiedTheme?.entryWidgetTheme?.background?.let {
             binding.root.applyLayerTheme(it)
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetView.kt
@@ -16,6 +16,7 @@ import com.glia.widgets.helper.getDrawableCompat
 import com.glia.widgets.helper.requireActivity
 import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
 import com.glia.widgets.view.unifiedui.applyLayerTheme
+import com.glia.widgets.view.unifiedui.nullSafeMerge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.entrywidget.EntryWidgetTheme
@@ -35,11 +36,17 @@ internal class EntryWidgetView : RecyclerView, EntryWidgetContract.View {
         get() = _viewAdapter ?: throw IllegalStateException("Make sure adapter is set up before attempting to show any items")
     private var dividerView: EntryWidgetItemDivider? = null
 
-    override val whiteLabel by lazy {
+    private val uiThemeWhiteLabel by lazy {
         TypedValue().run {
             context.theme.resolveAttribute(R.attr.whiteLabel, this, true)
             data != 0
         }
+    }
+
+    var unifiedThemeWhiteLabel: Boolean? = null
+
+    override val whiteLabel by lazy {
+        uiThemeWhiteLabel nullSafeMerge unifiedThemeWhiteLabel
     }
 
     init {

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetBottomSheetTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/entrywidget/EntryWidgetBottomSheetTest.kt
@@ -19,7 +19,7 @@ internal class EntryWidgetBottomSheetTest : EntryWidgetEmbeddedViewTest() {
         entryWidgetFragment.setupView(
             context,
             binding,
-            unifiedTheme?.entryWidgetTheme
+            unifiedTheme
         )
 
         binding.container.allViews.forEach {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4377

**What was solved?**
Use the UnifiedTheme whiteLabel for the EntryWidget

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
