### PR TITLE
Remove getUnreadMessageCount() from SecureConversations

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -116,31 +116,31 @@ class MainFragment : Fragment() {
         val visitorContextAssetId = getContextAssetIdFromPrefs(sharedPreferences)
         view.findViewById<View>(R.id.chat_activity_button)
             .setOnClickListener {
-                visitorContextAssetId?.runCatching {
-                    engagementLauncher.startChat(requireActivity(), this)
-                }?.onFailure { error -> showToast("Error: ${error.message}") }
-                    ?: engagementLauncher.startChat(requireActivity())
+                runCatching {
+                    visitorContextAssetId?.run { engagementLauncher.startChat(requireActivity(), this) }
+                        ?: engagementLauncher.startChat(requireActivity())
+                }.onFailure { error -> showToast("Error: ${error.message}") }
             }
         view.findViewById<View>(R.id.audio_call_button)
             .setOnClickListener {
-                visitorContextAssetId?.runCatching {
-                    engagementLauncher.startAudioCall(requireActivity(), this)
-                }?.onFailure { error -> showToast("Error: ${error.message}") }
-                    ?: engagementLauncher.startAudioCall(requireActivity())
+                runCatching {
+                    visitorContextAssetId?.run { engagementLauncher.startAudioCall(requireActivity(), this) }
+                        ?: engagementLauncher.startAudioCall(requireActivity())
+                }.onFailure { error -> showToast("Error: ${error.message}") }
             }
         view.findViewById<View>(R.id.video_call_button)
             .setOnClickListener {
-                visitorContextAssetId?.runCatching {
-                    engagementLauncher.startVideoCall(requireActivity(), this)
-                }?.onFailure { error -> showToast("Error: ${error.message}") }
-                    ?: engagementLauncher.startVideoCall(requireActivity())
+                runCatching {
+                    visitorContextAssetId?.run { engagementLauncher.startVideoCall(requireActivity(), this) }
+                        ?: engagementLauncher.startVideoCall(requireActivity())
+                }.onFailure { error -> showToast("Error: ${error.message}") }
             }
         view.findViewById<View>(R.id.message_center_activity_button)
             .setOnClickListener {
-                visitorContextAssetId?.runCatching {
-                    engagementLauncher.startSecureMessaging(requireActivity(), this)
-                }?.onFailure { error -> showToast("Error: ${error.message}") }
-                    ?: engagementLauncher.startSecureMessaging(requireActivity())
+                runCatching {
+                    visitorContextAssetId?.run { engagementLauncher.startSecureMessaging(requireActivity(), this) }
+                        ?: engagementLauncher.startSecureMessaging(requireActivity())
+                }.onFailure { error -> showToast("Error: ${error.message}") }
             }
         view.findViewById<View>(R.id.end_engagement_button)
             .setOnClickListener { GliaWidgets.endEngagement() }
@@ -529,7 +529,7 @@ class MainFragment : Fragment() {
             createDefaultConfig(
                 context = requireActivity().applicationContext,
 //                uiJsonRemoteConfig = UnifiedUiConfigurationLoader.fetchLocalConfigSample(requireContext()),
-//                region = "us"
+//                region = "beta"
             ),
             onComplete = {
                 prepareAuthentication()

--- a/widgetssdk/src/main/java/com/glia/widgets/secureconversations/SecureConversations.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/secureconversations/SecureConversations.kt
@@ -1,10 +1,7 @@
 package com.glia.widgets.secureconversations
 
 import com.glia.androidsdk.RequestCallback
-import com.glia.widgets.GliaWidgetsException
-import com.glia.widgets.callbacks.OnError
 import com.glia.widgets.callbacks.OnResult
-import com.glia.widgets.toWidgetsType
 
 /**
  * Secure Conversations offers the ability to asynchronously and securely communications for authenticated visitors.
@@ -14,24 +11,10 @@ import com.glia.widgets.toWidgetsType
  */
 interface SecureConversations {
     /**
-     * Returns the number of unread messages for the secure conversations.
-     * This number will increase with each message sent by the operator
-     * that the visitor has not yet marked as read.
-     *
-     * @param onResult [OnResult] a callback that returns the number of unread
-     * secure messages on success.
-     * @param onError [OnError] a callback that returns [GliaWidgetsException] on failure.
-     *
-     * Exception may have one of the following causes:
-     * [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] -when a visitor is not authenticated
-     * [GliaWidgetsException.Cause.INVALID_INPUT] - when SDK is not initialized
-     */
-    fun getUnreadMessageCount(onResult: OnResult<Int>, onError: OnError? = null)
-
-    /**
      * Subscribes to updates of the unread message count.
      *
-     * This method allows you to receive updates whenever the unread message count changes.
+     * This method allows you to receive updates whenever the unread message count for
+     * the secure conversations changes. It doesn't count the live chat messages.
      * The provided callback will be triggered with the updated count.
      *
      * @param callback [OnResult] A callback that will be invoked with the updated unread message count.
@@ -62,16 +45,6 @@ class SecureConversationsImpl(
 ) : SecureConversations {
 
     internal val subscribedCallbacks: MutableMap<Int, RequestCallback<Int>> = mutableMapOf()
-
-    override fun getUnreadMessageCount(onResult: OnResult<Int>, onError: OnError?) {
-        secureConversations.getUnreadMessageCount { count, gliaException ->
-            if (gliaException != null || count == null) {
-                onError?.onError(gliaException.toWidgetsType("Failed to get unread message count"))
-            } else {
-                onResult.onResult(count)
-            }
-        }
-    }
 
     override fun subscribeToUnreadMessageCount(callback: OnResult<Int>) {
         if (subscribedCallbacks.containsKey(callback.hashCode())) {

--- a/widgetssdk/src/test/java/com/glia/widgets/secureconversations/SecureConversationsImplTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/secureconversations/SecureConversationsImplTest.kt
@@ -23,39 +23,6 @@ class SecureConversationsImplTest {
     }
 
     @Test
-    fun `getUnreadMessageCount calls SDK and invokes onResult`() {
-        val onResult: OnResult<Int> = mockk(relaxed = true)
-        val onError: OnError = mockk(relaxed = true)
-        val unreadCount = 5
-        every { secureConversationsCore.getUnreadMessageCount(any()) } answers {
-            firstArg<RequestCallback<Int>>().onResult(unreadCount, null)
-        }
-
-        secureConversationsWidgets.getUnreadMessageCount(onResult, onError)
-
-        verify { onResult.onResult(unreadCount) }
-        verify(exactly = 0) { onError.onError(any()) }
-    }
-
-    @Test
-    fun `getUnreadMessageCount calls SDK and invokes onError on failure`() {
-        val onResult: OnResult<Int> = mockk(relaxed = true)
-        val onError: OnError = mockk(relaxed = true)
-        val exception = mock<GliaException>()
-        val widgetsException = GliaWidgetsException("Error", GliaWidgetsException.Cause.AUTHENTICATION_ERROR)
-        mockkStatic("com.glia.widgets.GliaWidgetsExceptionKt")
-        every { exception.toWidgetsType() } returns widgetsException
-        every { secureConversationsCore.getUnreadMessageCount(any()) } answers {
-            firstArg<RequestCallback<Int>>().onResult(null, exception)
-        }
-
-        secureConversationsWidgets.getUnreadMessageCount(onResult, onError)
-
-        verify { onError.onError(widgetsException) }
-        verify(exactly = 0) { onResult.onResult(any()) }
-    }
-
-    @Test
     fun `subscribeToUnreadMessageCount adds callback and calls SDK`() {
         val callback: OnResult<Int> = mockk(relaxed = true)
         val requestCallbackSlot = slot<RequestCallback<Int>>()


### PR DESCRIPTION
**Jira issue:**
[MOB-4373](https://glia.atlassian.net/browse/MOB-4373)

**What was solved?**
1. Remove `getUnreadMessageCount()` from `SecureConversations`, see [this message](https://salemove.slack.com/archives/C08H43U2DAB/p1747749067843349).
2. Explain that SecureConversations.getUnreadMessageCount() counts only SC messages and doesn't count unread live chat messages
3. Handle the SDK not initialized case in the example app for the case when EngagementLauncher is called without visitor context

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.



[MOB-4373]: https://glia.atlassian.net/browse/MOB-4373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ