### PR TITLE
Rename 'customAttributesMap' to 'customAttributes' in VisitorInfo to align with VisitorInfoUpdateRequest

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
@@ -80,7 +80,7 @@ class VisitorInfoFragment : Fragment() {
         phoneEditText.setText(visitorInfo.phone)
         externalIdEditText.setText(visitorInfo.externalId)
         noteEditText.setText(visitorInfo.note)
-        customAttributesAdapter.setAttributes(visitorInfo.customAttributesMap)
+        customAttributesAdapter.setAttributes(visitorInfo.customAttributes)
     }
 
     private fun showError(exception: GliaWidgetsException) {

--- a/widgetssdk/src/main/java/com/glia/widgets/visitor/VisitorInfo.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/visitor/VisitorInfo.kt
@@ -10,7 +10,7 @@ data class VisitorInfo(
     val email: String? = null,
     val phone: String? = null,
     val note: String? = null,
-    val customAttributesMap: Map<String, String>,
+    val customAttributes: Map<String, String>,
     val generatedName: String? = null,
     val banned: Boolean? = null,
     val href: String? = null,

--- a/widgetssdk/src/main/java/com/glia/widgets/visitor/VisitorInfo.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/visitor/VisitorInfo.kt
@@ -12,7 +12,7 @@ data class VisitorInfo(
     val note: String? = null,
     val customAttributes: Map<String, String>,
     val generatedName: String? = null,
-    val banned: Boolean? = null,
+    val banned: Boolean,
     val href: String? = null,
     val id: String? = null,
     val externalId: String? = null,


### PR DESCRIPTION
**Jira issue:**
[MOB-4169](https://glia.atlassian.net/browse/MOB-4169)

**What was solved?**
- Rename 'customAttributesMap' to 'customAttributes' in VisitorInfo to align with VisitorInfoUpdateRequest

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.


[MOB-4169]: https://glia.atlassian.net/browse/MOB-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ