### PR TITLE
Rename medias to media

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -45,9 +45,9 @@ internal fun ColorStateList?.colorForState(state: IntArray): Int? = this?.getCol
 internal fun String.separateStringWithSymbol(symbol: String): String = asSequence().joinToString(symbol)
 
 internal fun Queue.supportedMediaTypes(): List<MediaType>? = when {
-    status == Queue.Status.OPEN -> medias.filterNot { it == MediaType.PHONE || it == MediaType.UNKNOWN }.takeIf { it.isNotEmpty() }
-    status == Queue.Status.FULL && medias.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
-    status == Queue.Status.UNSTAFFED && medias.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
+    status == Queue.Status.OPEN -> media.filterNot { it == MediaType.PHONE || it == MediaType.UNKNOWN }.takeIf { it.isNotEmpty() }
+    status == Queue.Status.FULL && media.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
+    status == Queue.Status.UNSTAFFED && media.contains(MediaType.MESSAGING) -> listOf(MediaType.MESSAGING)
     else -> null
 }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/domain/IsMessagingAvailableUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/domain/IsMessagingAvailableUseCase.kt
@@ -24,5 +24,5 @@ internal class IsMessagingAvailableUseCase(private val queueRepository: QueueRep
     private fun isMessagingAvailable(queues: List<Queue>): Boolean = queues.asSequence()
         .filterNot { it.status == Queue.Status.CLOSED }
         .filterNot { it.status == Queue.Status.UNKNOWN }
-        .any { it.medias.contains(MediaType.MESSAGING) } // Support messaging
+        .any { it.media.contains(MediaType.MESSAGING) } // Support messaging
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/queue/Queue.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/queue/Queue.kt
@@ -17,7 +17,7 @@ data class Queue(
     val name: String,
     val isDefault: Boolean?,
     val lastUpdatedMillis: Long,
-    val medias: List<MediaType>,
+    val media: List<MediaType>,
     val status: Status
 ) : Mergeable<Queue> {
     /**
@@ -55,7 +55,7 @@ data class Queue(
         name = name merge other.name,
         isDefault = isDefault merge other.isDefault,
         lastUpdatedMillis = lastUpdatedMillis merge other.lastUpdatedMillis,
-        medias = medias merge other.medias,
+        media = media merge other.media,
         status = status merge other.status
     )
 }
@@ -65,7 +65,7 @@ internal fun CoreSdkQueue.toWidgetsType(): Queue = Queue(
     name = name,
     isDefault = isDefault,
     lastUpdatedMillis = lastUpdatedMillis,
-    medias = state.medias.map { it.toWidgetsType() },
+    media = state.medias.map { it.toWidgetsType() },
     status = state.status.toWidgetsType()
 )
 

--- a/widgetssdk/src/test/java/com/glia/widgets/helper/SupportedMediaTypesTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/helper/SupportedMediaTypesTest.kt
@@ -15,7 +15,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes returns MESSAGING when queue is FULL and contains MESSAGING`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.FULL
-            every { medias } returns listOf(MediaType.TEXT, MediaType.MESSAGING)
+            every { media } returns listOf(MediaType.TEXT, MediaType.MESSAGING)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -28,7 +28,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes returns null when queue is FULL and does not contain MESSAGING`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.FULL
-            every { medias } returns listOf(MediaType.TEXT, MediaType.AUDIO)
+            every { media } returns listOf(MediaType.TEXT, MediaType.AUDIO)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -40,7 +40,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes returns MESSAGING when queue is UNSTAFFED and contains MESSAGING`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.UNSTAFFED
-            every { medias } returns listOf(MediaType.TEXT, MediaType.MESSAGING)
+            every { media } returns listOf(MediaType.TEXT, MediaType.MESSAGING)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -53,7 +53,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes returns MESSAGING when queue is UNSTAFFED and does not contain MESSAGING`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.UNSTAFFED
-            every { medias } returns listOf(MediaType.TEXT, MediaType.VIDEO)
+            every { media } returns listOf(MediaType.TEXT, MediaType.VIDEO)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -65,7 +65,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes filters out Phone and UNKNOWN when queue is OPEN`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.OPEN
-            every { medias } returns listOf(MediaType.PHONE, MediaType.UNKNOWN)
+            every { media } returns listOf(MediaType.PHONE, MediaType.UNKNOWN)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -77,7 +77,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes filters returns all types except Phone and UNKNOWN when queue is OPEN`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.OPEN
-            every { medias } returns listOf(
+            every { media } returns listOf(
                 MediaType.TEXT,
                 MediaType.AUDIO,
                 MediaType.VIDEO,
@@ -100,7 +100,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes returns null when queue is CLOSED`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.CLOSED
-            every { medias } returns listOf(MediaType.TEXT, MediaType.UNKNOWN)
+            every { media } returns listOf(MediaType.TEXT, MediaType.UNKNOWN)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()
@@ -112,7 +112,7 @@ class SupportedMediaTypesTest {
     fun `supportedMediaTypes returns null when queue status is UNKNOWN`() {
         val queue: Queue = mockk {
             every { status } returns Queue.Status.UNKNOWN
-            every { medias } returns listOf(MediaType.TEXT, MediaType.UNKNOWN)
+            every { media } returns listOf(MediaType.TEXT, MediaType.UNKNOWN)
         }
 
         val supportedMediaTypes = queue.supportedMediaTypes()

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/secureconversations/domain/IsMessagingAvailableUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/secureconversations/domain/IsMessagingAvailableUseCaseTest.kt
@@ -116,7 +116,7 @@ class IsMessagingAvailableUseCaseTest {
     private fun createQueueWithStatus(status: Queue.Status, supportsMessaging: Boolean): Queue {
         val queue = mockk<Queue>()
         every { queue.status } returns status
-        every { queue.medias } returns if (supportsMessaging) listOf(MediaType.MESSAGING) else listOf(
+        every { queue.media } returns if (supportsMessaging) listOf(MediaType.MESSAGING) else listOf(
             MediaType.TEXT,
             MediaType.AUDIO
         )


### PR DESCRIPTION
**What was solved?**
Rename `medias` to `media`.
"Media" is a correct form for plural.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
