### PR TITLE
Use corresponding widgets method inside authentication converter

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/internal/authentication/AuthenticationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/authentication/AuthenticationManager.kt
@@ -109,7 +109,7 @@ internal fun AuthenticationManager.toCoreType(): CoreAuthentication = this.let {
         }
 
         override fun deauthenticate(authCallback: RequestCallback<Void>?) {
-            deauthenticate(true, authCallback)
+            widgetAuthentication.deauthenticate(authCallback.toOnComplete(), authCallback.toOnError())
         }
 
         override val isAuthenticated: Boolean


### PR DESCRIPTION
**What was solved?**
Used the corresponding function from the Widgets authentication inside converter to keep consistency between methods.

🙇‍♂️ thanks @andrews-moc for finding

**Release notes:**

 - [x] Feature(PN)
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
