### PR TITLE
Show an error Toast in VisitorInfoFragment from UI thread to avoid a crash

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
@@ -125,7 +125,11 @@ class VisitorInfoFragment : Fragment() {
             }
         }
 
-        val onError = OnError { exception -> showError(exception) }
+        val onError = OnError { exception ->
+            activity?.runOnUiThread {
+                showError(exception)
+            }
+        }
 
         GliaWidgets.getVisitorInfo(onResult, onError)
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -358,7 +358,12 @@ object GliaWidgets {
                     onResult.onResult(VisitorInfo(visitorInfo))
                 }
             }
-        gliaCore().getVisitorInfo(callback)
+
+        try {
+            gliaCore().getVisitorInfo(callback)
+        } catch (gliaException: GliaException) {
+            throw gliaException.toWidgetsType()
+        }
     }
 
     /**


### PR DESCRIPTION
**Jira issue:**
[Avoid receiving crash reports for non SDK issues in Sentry](https://glia.atlassian.net/browse/MOB-4406

**What was solved?**
- Show an error Toast in VisitorInfoFragment from UI thread to avoid a crash: java.lang.NullPointerException: Can't toast on a thread that has not called Looper.prepare()
- [Just an improvement] Surround the gliaCore().getVisitorInfo(callback) call in GliaWidgets with try-catch similar to the other calls

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

