### PR TITLE
Update push notification channel names

### DIFF
--- a/widgetssdk/src/main/res/values/donottranslate.xml
+++ b/widgetssdk/src/main/res/values/donottranslate.xml
@@ -5,7 +5,7 @@
 
     <string name="android_notification_audio_call_channel_name" translatable="false">@string/glia_notification_call_channel_name</string>
     <string name="android_notification_screen_sharing_channel_name" translatable="false">@string/glia_notification_screen_sharing_channel_name</string>
-    <string name="android_notification_secure_messaging_channel_name" translatable="false">Messaging notification channel</string>
+    <string name="android_notification_secure_messaging_channel_name" translatable="false">New secure messages</string>
 
     <!-- Survey -->
     <string name="glia_survey_scale_item_1" translatable="false">1</string>

--- a/widgetssdk/src/main/res/values/strings.xml
+++ b/widgetssdk/src/main/res/values/strings.xml
@@ -180,8 +180,8 @@
     <string name="glia_dialog_leave_queue_no">@string/glia_dialog_no</string>
     <string name="glia_notification_screen_sharing_title">Screen Sharing Started</string>
     <string name="glia_notification_screen_sharing_message">You are currently sharing your screen.\nSelect \'End Sharing\' to stop.</string>
-    <string name="glia_notification_screen_sharing_channel_name">Screen sharing notification channel</string>
-    <string name="glia_notification_call_channel_name">Call notification channel</string>
+    <string name="glia_notification_screen_sharing_channel_name">Screen sharing sessions</string>
+    <string name="glia_notification_call_channel_name">Incoming calls</string>
     <string name="glia_notification_audio_call_title">Audio Call Started</string>
     <string name="glia_notification_audio_call_message">Your microphone is now on, and the operator can hear you.</string>
     <string name="glia_notification_two_way_video_call_title">Two-Way Video Started</string>


### PR DESCRIPTION
**Jira issue:**


**What was solved?**
After discussing this topic during a meeting, we agreed that channels should not have the  words 'notification' or 'channel' in them since it is already clear from context, and that it should be in the plural form

Last screenshot from the discussion:
<img width="807" alt="Screenshot 2025-05-23 at 12 03 39" src="https://github.com/user-attachments/assets/9f423017-12ed-4e6b-9aa6-3b9c5133cf23" />

How it looks now:
![Screenshot_20250528_111306](https://github.com/user-attachments/assets/3e5ec7c9-174a-4e63-8994-6268c71df2f7)


