### PR TITLE
Deprecate 'whiteLabel' attribute in xml theme

### DIFF
--- a/widgetssdk/src/main/res/values/attrs.xml
+++ b/widgetssdk/src/main/res/values/attrs.xml
@@ -97,7 +97,8 @@
         <attr name="chatStartingCaptionTextColor" format="reference" />
         <attr name="chatStartedHeadingTextColor" format="reference" />
         <attr name="chatStartedCaptionTextColor" format="reference" />
-
+        <!-- @deprecated This attribute is deprecated and will be removed in future.
+             Use Unified Customization instead: https://docs.glia.com/glia-mobile/docs/android-widgets-unified-customization. -->
         <attr name="whiteLabel" />
         <attr name="gliaAlertDialogButtonUseVerticalAlignment" />
     </declare-styleable>


### PR DESCRIPTION
**Jira issue:**
Following up the [Add WhiteLabel property to the UnifiedUI](https://glia.atlassian.net/browse/MOB-4333)

**What was solved?**
- Deprecation notice will be shown in an info pop-up to the `whiteLabel` attribute (see screenshot).

**Release notes:**

 - [x] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img width="741" alt="Screenshot 2025-05-29 at 12 47 42" src="https://github.com/user-attachments/assets/579c7fe0-89d7-42e6-b16c-21f8795e97de" />
