### PR TITLE
Fix engagement end during de-authentication

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/MainFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/MainFragment.kt
@@ -556,11 +556,7 @@ class MainFragment : Fragment() {
         authentication = GliaWidgets.getAuthentication(getAuthenticationBehaviorFromPrefs(sharedPreferences, resources))
     }
 
-    private fun authenticate(
-        jwtInput: EditText,
-        externalTokenInput: EditText,
-        callback: OnAuthCallback?
-    ) {
+    private fun authenticate(jwtInput: EditText, externalTokenInput: EditText, callback: OnAuthCallback?) {
         if (activity == null || containerView == null) return
         prepareAuthentication()
         val jwt = jwtInput.text.toString()

--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -399,6 +399,7 @@ object GliaWidgets {
     fun clearVisitorSession() {
         Logger.i(TAG, "Clear visitor session")
         try {
+            //Need to clear engagement state and unsubscribe from engagement related callbacks before it's done on the core side to prevent unexpected behavior
             destroyControllersAndResetEngagementData()
 
             //Here we reset the secure conversations repository to clear the data,
@@ -406,6 +407,7 @@ object GliaWidgets {
             //and we don't need secure conversations data for un-authenticated visitors.
             repositoryFactory.secureConversationsRepository.unsubscribeAndResetData()
 
+            // This function will end the ongoing engagement itself if it is present
             gliaCore().clearVisitorSession()
         } catch (gliaException: GliaException) {
             throw gliaException.toWidgetsType()

--- a/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/authentication/Authentication.kt
@@ -33,12 +33,7 @@ interface Authentication {
      * <br></br> [GliaWidgetsException.Cause.INTERNAL_ERROR] - when internal error occurs
      * <br></br> [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] - when authentication fails
      */
-    fun authenticate(
-        jwtToken: String,
-        externalAccessToken: String?,
-        onComplete: OnComplete,
-        onError: OnError
-    )
+    fun authenticate(jwtToken: String, externalAccessToken: String?, onComplete: OnComplete, onError: OnError)
 
     /**
      * De-authenticates the visitor.
@@ -53,21 +48,12 @@ interface Authentication {
      * <br></br> [GliaWidgetsException.Cause.INTERNAL_ERROR] - when internal error occurs
      * <br></br> [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] - when authentication fails
      */
-    fun deauthenticate(
-        stopPushNotifications: Boolean,
-        onComplete: OnComplete,
-        onError: OnError
-    )
+    fun deauthenticate(stopPushNotifications: Boolean, onComplete: OnComplete, onError: OnError)
 
     /**
      * Same as [deauthenticate] but with default value `false` for `stopPushNotifications` parameter.
      */
-    fun deauthenticate(
-        onComplete: OnComplete,
-        onError: OnError
-    ) {
-        deauthenticate(false, onComplete, onError)
-    }
+    fun deauthenticate(onComplete: OnComplete, onError: OnError) = deauthenticate(false, onComplete, onError)
 
     /**
      * Check if Visitor is authenticated in Glia using the external authentication.
@@ -91,12 +77,7 @@ interface Authentication {
      * <br></br> [GliaWidgetsException.Cause.INTERNAL_ERROR] - when internal error occurs
      * <br></br> [GliaWidgetsException.Cause.AUTHENTICATION_ERROR] - when authentication fails
      */
-    fun refresh(
-        jwtToken: String,
-        externalAccessToken: String?,
-        onComplete: OnComplete,
-        onError: OnError
-    )
+    fun refresh(jwtToken: String, externalAccessToken: String?, onComplete: OnComplete, onError: OnError)
 
     /**
      * Behavior for authentication and de-authentication.

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -29,8 +29,6 @@ import com.glia.androidsdk.screensharing.LocalScreen
 import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.androidsdk.screensharing.ScreenSharingRequest
 import com.glia.androidsdk.screensharing.VisitorScreenSharingState
-import com.glia.widgets.internal.engagement.GliaOperatorRepository
-import com.glia.widgets.internal.queue.QueueRepository
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.Data
 import com.glia.widgets.helper.Logger
@@ -41,6 +39,8 @@ import com.glia.widgets.helper.isQueueUnavailable
 import com.glia.widgets.helper.isRetain
 import com.glia.widgets.helper.isUnknown
 import com.glia.widgets.helper.unSafeSubscribe
+import com.glia.widgets.internal.engagement.GliaOperatorRepository
+import com.glia.widgets.internal.queue.QueueRepository
 import com.glia.widgets.launcher.ConfigurationManager
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
@@ -220,13 +220,14 @@ internal class EngagementRepositoryImpl(
             unsubscribeFromEvents(it)
             resetState()
 
-            it.end { ex -> ex?.also { Logger.d(TAG, "Ending engagement failed") } }
+            //End the current engagement only when it is ended by the visitor.
+            if (endedBy == EndedBy.VISITOR) {
+                it.end { ex -> ex?.also { Logger.d(TAG, "Ending engagement failed") } }
+            }
 
-            val state = State.EngagementEnded(
-                it.isCallVisualizer,
-                endedBy,
-                it.state.actionOnEnd
-            ) { onSuccess, onError -> fetchSurvey(it, onError, onSuccess) }
+            val state = State.EngagementEnded(it.isCallVisualizer, endedBy, it.state.actionOnEnd) { onSuccess, onError ->
+                fetchSurvey(it, onError, onSuccess)
+            }
 
             _engagementState.onNext(state)
 

--- a/widgetssdk/src/main/java/com/glia/widgets/push/notifications/PushClickHandlerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/push/notifications/PushClickHandlerController.kt
@@ -12,7 +12,7 @@ import com.glia.widgets.view.dialog.UiComponentsDispatcher
 
 internal interface PushClickHandlerController {
     fun handlePushClick(queueId: String?, visitorId: String)
-    fun onAuthenticated()
+    fun onAuthenticationAttempt()
 }
 
 private class PendingPn(val queueId: String?, val visitorId: String)
@@ -43,7 +43,7 @@ internal class PushClickHandlerControllerImpl(
         }
     }
 
-    override fun onAuthenticated() {
+    override fun onAuthenticationAttempt() {
         handlePendingPushNotification(pendingPn ?: return)
         pendingPn = null
     }

--- a/widgetssdk/src/test/java/android/TestExtensions.kt
+++ b/widgetssdk/src/test/java/android/TestExtensions.kt
@@ -1,6 +1,7 @@
 package android
 
 import android.content.Intent
+import com.glia.widgets.di.Dependencies
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.OneTimeEvent
 import io.mockk.Runs
@@ -20,6 +21,7 @@ internal const val COMMON_EXTENSIONS_CLASS_PATH = "com.glia.widgets.helper.Commo
 internal const val CONTEXT_EXTENSIONS_CLASS_PATH = "com.glia.widgets.helper.ContextExtensions"
 internal const val FILE_HELPER_EXTENSIONS_CLASS_PATH = "com.glia.widgets.helper.FileHelper"
 internal const val LOGGER_PATH = "com.glia.widgets.helper.Logger"
+internal const val DEPS_PATH = "com.glia.widgets.di.Dependencies"
 
 fun <T> Class<T>.readRawResource(resName: String): String = classLoader?.getResourceAsStream(resName)?.run {
     bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
@@ -56,6 +58,14 @@ internal fun Logger.mock() {
 //Extension function to unMock the static logger
 internal fun Logger.unMock() {
     unmockkStatic(LOGGER_PATH)
+}
+
+internal fun Dependencies.mock() {
+    mockkStatic(DEPS_PATH)
+}
+
+internal fun Dependencies.unMock() {
+    unmockkStatic(DEPS_PATH)
 }
 
 //Extension function to mock the [OneTimeEvent] class, that is used in multiple places.

--- a/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/engagement/EngagementRepositoryTest.kt
@@ -29,12 +29,12 @@ import com.glia.androidsdk.screensharing.LocalScreen
 import com.glia.androidsdk.screensharing.ScreenSharing
 import com.glia.androidsdk.screensharing.ScreenSharingRequest
 import com.glia.androidsdk.screensharing.VisitorScreenSharingState
-import com.glia.widgets.internal.engagement.GliaOperatorRepository
-import com.glia.widgets.internal.queue.QueueRepository
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.Data
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.formattedName
+import com.glia.widgets.internal.engagement.GliaOperatorRepository
+import com.glia.widgets.internal.queue.QueueRepository
 import com.glia.widgets.launcher.ConfigurationManager
 import io.mockk.CapturingSlot
 import io.mockk.MockKAnnotations
@@ -367,8 +367,10 @@ class EngagementRepositoryTest {
         }
 
         if (ongoingEngagement) {
-            if (endedBy != EndedBy.OPERATOR) {
+            if (endedBy == EndedBy.VISITOR) {
                 verify { engagement.end(any()) }
+            } else {
+                verify(exactly = 0) { engagement.end(any()) }
             }
 
             verifyUnsubscribedFromEngagement()

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerTest.kt
@@ -1,140 +1,264 @@
 package com.glia.widgets.internal.authentication
 
+import android.mock
+import android.unMock
+import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
 import com.glia.widgets.authentication.Authentication
-import junit.framework.TestCase.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
+import com.glia.widgets.callbacks.OnComplete
+import com.glia.widgets.callbacks.OnError
+import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
+import com.glia.widgets.push.notifications.PushClickHandlerController
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import junit.framework.TestCase.assertTrue
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import com.glia.androidsdk.visitor.Authentication as CoreAuthentication
 
-class AuthenticationManagerTest {
-    @Test
-    fun toCoreType_setBehavior_returnsCoreAuthenticationWithCorrectBehavior() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        val coreAuthentication = widgetAuthentication.toCoreType()
+internal class AuthenticationManagerTest {
 
-        val behavior = com.glia.androidsdk.visitor.Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT
-        coreAuthentication.setBehavior(behavior)
+    private lateinit var coreAuthentication: CoreAuthentication
+    private lateinit var onAuthenticationRequestCallback: () -> Unit
 
-        verify(widgetAuthentication).setBehavior(behavior.toWidgetsType())
+    private lateinit var secureConversationsRepository: SecureConversationsRepository
+
+    private lateinit var authenticationManager: AuthenticationManager
+    private lateinit var pushClickHandlerController: PushClickHandlerController
+
+
+    @Before
+    fun setUp() {
+        coreAuthentication = mockk(relaxUnitFun = true)
+        onAuthenticationRequestCallback = mockk<() -> Unit>(relaxed = true)
+        secureConversationsRepository = mockk(relaxUnitFun = true)
+        pushClickHandlerController = mockk(relaxUnitFun = true)
+        Logger.mock()
+        Dependencies.mock()
+
+        every { Dependencies.repositoryFactory.secureConversationsRepository } returns secureConversationsRepository
+        every { Dependencies.controllerFactory.pushClickHandlerController } returns pushClickHandlerController
+
+        authenticationManager = AuthenticationManager(coreAuthentication, onAuthenticationRequestCallback)
+    }
+
+    @After
+    fun tearDown() {
+        Logger.unMock()
+        Dependencies.unMock()
     }
 
     @Test
-    fun toCoreType_authenticateWithValidJwtToken_callsAuthenticateOnWidgetAuthentication() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        val coreAuthentication = widgetAuthentication.toCoreType()
-
-        val jwtToken = "validToken"
-        val externalAccessToken = "externalToken"
-        val callback = mock<RequestCallback<Void>>()
-
-        coreAuthentication.authenticate(jwtToken, externalAccessToken, callback)
-
-        verify(widgetAuthentication).authenticate(eq(jwtToken), eq(externalAccessToken), any(), any())
+    fun `isAuthenticated calls corresponding function from core`() {
+        every { coreAuthentication.isAuthenticated } returns true
+        assertTrue(authenticationManager.isAuthenticated)
+        verify { coreAuthentication.isAuthenticated }
     }
 
     @Test
-    fun toCoreType_authenticateWithoutCallback_callsAuthenticateOnWidgetAuthentication() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        val coreAuthentication = widgetAuthentication.toCoreType()
-
-        val jwtToken = "validToken"
-        val externalAccessToken = "externalToken"
-
-        coreAuthentication.authenticate(jwtToken, externalAccessToken, null)
-
-        verify(widgetAuthentication).authenticate(eq(jwtToken), eq(externalAccessToken), any(), any())
+    fun `setBehavior calls corresponding core function`() {
+        authenticationManager.setBehavior(Authentication.Behavior.ALLOWED_DURING_ENGAGEMENT)
+        verify { coreAuthentication.setBehavior(eq(CoreAuthentication.Behavior.ALLOWED_DURING_ENGAGEMENT)) }
     }
 
     @Test
-    fun toCoreType_deauthenticate_callsDeauthenticateOnWidgetAuthentication() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        val coreAuthentication = widgetAuthentication.toCoreType()
+    fun `authenticate triggers only the success callback when core authentication succeeds`() {
+        every { Dependencies.destroyControllersAndResetQueueing() } just Runs
+        val token = "just token"
+        val externalAccessToken = "external"
+        val onComplete = mockk<OnComplete>(relaxUnitFun = true)
+        val onError = mockk<OnError>(relaxUnitFun = true)
+        val authCallbackSlot = slot<RequestCallback<Void>>()
 
-        val callback = mock<RequestCallback<Void>>()
+        authenticationManager.authenticate(token, externalAccessToken, onComplete, onError)
 
-        coreAuthentication.deauthenticate(callback)
-
-        verify(widgetAuthentication).deauthenticate(any(), any())
-    }
-
-    @Test
-    fun toCoreType_deauthenticateWithoutCallback_callsDeauthenticateOnWidgetAuthentication() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        val coreAuthentication = widgetAuthentication.toCoreType()
-
-        coreAuthentication.deauthenticate(null)
-
-        verify(widgetAuthentication).deauthenticate(any(), any())
-    }
-
-    @Test
-    fun toCoreType_isAuthenticated_returnsCorrectValue() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        whenever(widgetAuthentication.isAuthenticated).thenReturn(true)
-
-        val coreAuthentication = widgetAuthentication.toCoreType()
-
-        assertTrue(coreAuthentication.isAuthenticated)
-    }
-
-    @Test
-    fun toCoreType_refreshWithValidJwtToken_callsRefreshOnWidgetAuthentication() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        val coreAuthentication = widgetAuthentication.toCoreType()
-
-        val jwtToken = "validToken"
-        val externalAccessToken = "externalToken"
-        val callback = mock<RequestCallback<Void>>()
-
-        coreAuthentication.refresh(jwtToken, externalAccessToken, callback)
-
-        verify(widgetAuthentication).refresh(eq(jwtToken), eq(externalAccessToken), any(), any())
-    }
-
-    @Test
-    fun toCoreType_refreshWithoutCallback_callsRefreshOnWidgetAuthentication() {
-        val widgetAuthentication = mock<AuthenticationManager>()
-        val coreAuthentication = widgetAuthentication.toCoreType()
-
-        val jwtToken = "validToken"
-        val externalAccessToken = "externalToken"
-
-        coreAuthentication.refresh(jwtToken, externalAccessToken, null)
-
-        verify(widgetAuthentication).refresh(eq(jwtToken), eq(externalAccessToken), any(), any())
-    }
-
-    @Test
-    fun testWidgetsAuthenticationBehaviorsCorrespondToCoreAuthenticationBehaviors() {
-        val allCoreAuthBehaviors = com.glia.androidsdk.visitor.Authentication.Behavior.entries
-        val allWidgetsAuthBehaviors = Authentication.Behavior.entries
-
-        assertEquals(allCoreAuthBehaviors.size, allWidgetsAuthBehaviors.size)
-        allWidgetsAuthBehaviors.forEachIndexed { index, item ->
-            val coreBehavior = item.toCoreType()
-
-            assertNotNull(coreBehavior)
-            assertEquals(coreBehavior.name, allWidgetsAuthBehaviors[index].name)
+        verify { onAuthenticationRequestCallback() }
+        verify { Logger.i(any(), any()) }
+        verify {
+            coreAuthentication.authenticate(eq(token), eq(externalAccessToken), capture(authCallbackSlot))
         }
+
+        //verify that all the business logic is inside callback
+
+        //success
+        verify(exactly = 0) { pushClickHandlerController.onAuthenticationAttempt() }
+        verify(exactly = 0) { Dependencies.destroyControllersAndResetQueueing() }
+        verify(exactly = 0) { secureConversationsRepository.subscribe() }
+        verify(exactly = 0) { onComplete.onComplete() }
+
+        //error
+        verify(exactly = 0) { onError.onError(any()) }
+
+        authCallbackSlot.captured.onResult(null, null)
+
+        verify { pushClickHandlerController.onAuthenticationAttempt() }
+
+        verify { Dependencies.destroyControllersAndResetQueueing() }
+        verify { secureConversationsRepository.subscribe() }
+        verify { onComplete.onComplete() }
+
+        verify(exactly = 0) { onError.onError(any()) }
     }
 
     @Test
-    fun testCoreAuthenticationBehaviorsCorrespondToWidgetsAuthenticationBehaviors() {
-        val allCoreAuthBehaviors = com.glia.androidsdk.visitor.Authentication.Behavior.entries
-        val allWidgetsAuthBehaviors = Authentication.Behavior.entries
+    fun `authenticate triggers only the error callback when core authentication fails`() {
+        every { Dependencies.destroyControllersAndResetQueueing() } just Runs
+        val token = "just token"
+        val externalAccessToken = "external"
+        val onComplete = mockk<OnComplete>(relaxUnitFun = true)
+        val onError = mockk<OnError>(relaxUnitFun = true)
+        val authCallbackSlot = slot<RequestCallback<Void>>()
 
-        assertEquals(allCoreAuthBehaviors.size, allWidgetsAuthBehaviors.size)
-        allCoreAuthBehaviors.forEachIndexed { index, item ->
-            val widgetsBehavior = item.toWidgetsType()
+        authenticationManager.authenticate(token, externalAccessToken, onComplete, onError)
 
-            assertNotNull(widgetsBehavior)
-            assertEquals(widgetsBehavior.name, allCoreAuthBehaviors[index].name)
+        verify { onAuthenticationRequestCallback() }
+        verify { Logger.i(any(), any()) }
+        verify {
+            coreAuthentication.authenticate(eq(token), eq(externalAccessToken), capture(authCallbackSlot))
         }
+
+        //verify that all the business logic is inside callback
+
+        //success
+        verify(exactly = 0) { pushClickHandlerController.onAuthenticationAttempt() }
+        verify(exactly = 0) { Dependencies.destroyControllersAndResetQueueing() }
+        verify(exactly = 0) { secureConversationsRepository.subscribe() }
+        verify(exactly = 0) { onComplete.onComplete() }
+
+        //error
+        verify(exactly = 0) { onError.onError(any()) }
+
+        authCallbackSlot.captured.onResult(null, GliaException("error", GliaException.Cause.INVALID_INPUT))
+
+        verify(inverse = true) { Dependencies.destroyControllersAndResetQueueing() }
+        verify(exactly = 0) { secureConversationsRepository.subscribe() }
+        verify(exactly = 0) { onComplete.onComplete() }
+
+        verify { pushClickHandlerController.onAuthenticationAttempt() }
+        verify { onError.onError(any()) }
     }
+
+    @Test
+    fun `deauthenticate triggers success callback only when the core deauthentication succeeds`() {
+        val stopPushNotifications = true
+        every { Dependencies.destroyControllersAndResetEngagementData() } just Runs
+
+        val onComplete = mockk<OnComplete>(relaxUnitFun = true)
+        val onError = mockk<OnError>(relaxUnitFun = true)
+        val authCallbackSlot = slot<RequestCallback<Void>>()
+
+        authenticationManager.deauthenticate(stopPushNotifications, onComplete, onError)
+
+        verify { Logger.i(any(), any()) }
+        verify {
+            coreAuthentication.deauthenticate(eq(stopPushNotifications), capture(authCallbackSlot))
+        }
+
+        //verify that all the business logic is inside callback
+        verify(exactly = 0) { Dependencies.destroyControllersAndResetEngagementData() }
+        verify(exactly = 0) { secureConversationsRepository.unsubscribeAndResetData() }
+        verify(exactly = 0) { onComplete.onComplete() }
+        verify(exactly = 0) { onError.onError(any()) }
+
+        authCallbackSlot.captured.onResult(null, null)
+
+        verify { Dependencies.destroyControllersAndResetEngagementData() }
+        verify { secureConversationsRepository.unsubscribeAndResetData() }
+        verify { onComplete.onComplete() }
+
+        verify(exactly = 0) { onError.onError(any()) }
+    }
+
+    @Test
+    fun `deauthenticate triggers error callback only when the core deauthentication fails`() {
+        val stopPushNotifications = true
+        every { Dependencies.destroyControllersAndResetEngagementData() } just Runs
+
+        val onComplete = mockk<OnComplete>(relaxUnitFun = true)
+        val onError = mockk<OnError>(relaxUnitFun = true)
+        val authCallbackSlot = slot<RequestCallback<Void>>()
+
+        authenticationManager.deauthenticate(stopPushNotifications, onComplete, onError)
+
+        verify { Logger.i(any(), any()) }
+        verify {
+            coreAuthentication.deauthenticate(eq(stopPushNotifications), capture(authCallbackSlot))
+        }
+
+        //verify that all the business logic is inside callback
+        verify(exactly = 0) { Dependencies.destroyControllersAndResetEngagementData() }
+        verify(exactly = 0) { secureConversationsRepository.unsubscribeAndResetData() }
+        verify(exactly = 0) { onComplete.onComplete() }
+        verify(exactly = 0) { onError.onError(any()) }
+
+        authCallbackSlot.captured.onResult(null, GliaException("error", GliaException.Cause.INVALID_INPUT))
+
+        verify(inverse = true) { Dependencies.destroyControllersAndResetEngagementData() }
+        verify(exactly = 0) { secureConversationsRepository.unsubscribeAndResetData() }
+        verify(exactly = 0) { onComplete.onComplete() }
+
+        verify(exactly = 1) { onError.onError(any()) }
+    }
+
+    @Test
+    fun `refresh triggers only the success callback when core refresh succeeds`() {
+        every { Dependencies.destroyControllersAndResetQueueing() } just Runs
+        val jwtToken = "just token"
+        val externalAccessToken = "external"
+
+        val onComplete = mockk<OnComplete>(relaxUnitFun = true)
+        val onError = mockk<OnError>(relaxUnitFun = true)
+        val authCallbackSlot = slot<RequestCallback<Void>>()
+
+        authenticationManager.refresh(jwtToken, externalAccessToken, onComplete, onError)
+
+        verify { Logger.i(any(), any()) }
+        verify {
+            coreAuthentication.refresh(eq(jwtToken), eq(externalAccessToken), capture(authCallbackSlot))
+        }
+
+        //verify that all the business logic is inside callback
+        verify(exactly = 0) { onComplete.onComplete() }
+        verify(exactly = 0) { onError.onError(any()) }
+
+        authCallbackSlot.captured.onResult(null, null)
+
+        verify { onComplete.onComplete() }
+        verify(exactly = 0) { onError.onError(any()) }
+    }
+
+    @Test
+    fun `refresh triggers only the error callback when core refresh fails`() {
+        every { Dependencies.destroyControllersAndResetQueueing() } just Runs
+        val jwtToken = "just token"
+        val externalAccessToken = "external"
+
+        val onComplete = mockk<OnComplete>(relaxUnitFun = true)
+        val onError = mockk<OnError>(relaxUnitFun = true)
+        val authCallbackSlot = slot<RequestCallback<Void>>()
+
+        authenticationManager.refresh(jwtToken, externalAccessToken, onComplete, onError)
+
+        verify { Logger.i(any(), any()) }
+        verify {
+            coreAuthentication.refresh(eq(jwtToken), eq(externalAccessToken), capture(authCallbackSlot))
+        }
+
+        //verify that all the business logic is inside callback
+        verify(exactly = 0) { onComplete.onComplete() }
+        verify(exactly = 0) { onError.onError(any()) }
+
+        authCallbackSlot.captured.onResult(null, GliaException("error", GliaException.Cause.INVALID_INPUT))
+
+        verify(exactly = 0) { onComplete.onComplete() }
+        verify(exactly = 1) { onError.onError(any()) }
+    }
+
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerToCoreTypeTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/authentication/AuthenticationManagerToCoreTypeTest.kt
@@ -1,0 +1,140 @@
+package com.glia.widgets.internal.authentication
+
+import com.glia.androidsdk.RequestCallback
+import com.glia.widgets.authentication.Authentication
+import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class AuthenticationManagerToCoreTypeTest {
+    @Test
+    fun toCoreType_setBehavior_returnsCoreAuthenticationWithCorrectBehavior() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val behavior = com.glia.androidsdk.visitor.Authentication.Behavior.FORBIDDEN_DURING_ENGAGEMENT
+        coreAuthentication.setBehavior(behavior)
+
+        verify(widgetAuthentication).setBehavior(behavior.toWidgetsType())
+    }
+
+    @Test
+    fun toCoreType_authenticateWithValidJwtToken_callsAuthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.authenticate(jwtToken, externalAccessToken, callback)
+
+        verify(widgetAuthentication).authenticate(eq(jwtToken), eq(externalAccessToken), any(), any())
+    }
+
+    @Test
+    fun toCoreType_authenticateWithoutCallback_callsAuthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+
+        coreAuthentication.authenticate(jwtToken, externalAccessToken, null)
+
+        verify(widgetAuthentication).authenticate(eq(jwtToken), eq(externalAccessToken), any(), any())
+    }
+
+    @Test
+    fun toCoreType_deauthenticate_callsDeauthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.deauthenticate(callback)
+
+        verify(widgetAuthentication).deauthenticate(any(), any())
+    }
+
+    @Test
+    fun toCoreType_deauthenticateWithoutCallback_callsDeauthenticateOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        coreAuthentication.deauthenticate(null)
+
+        verify(widgetAuthentication).deauthenticate(any(), any())
+    }
+
+    @Test
+    fun toCoreType_isAuthenticated_returnsCorrectValue() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        whenever(widgetAuthentication.isAuthenticated).thenReturn(true)
+
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        assertTrue(coreAuthentication.isAuthenticated)
+    }
+
+    @Test
+    fun toCoreType_refreshWithValidJwtToken_callsRefreshOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+        val callback = mock<RequestCallback<Void>>()
+
+        coreAuthentication.refresh(jwtToken, externalAccessToken, callback)
+
+        verify(widgetAuthentication).refresh(eq(jwtToken), eq(externalAccessToken), any(), any())
+    }
+
+    @Test
+    fun toCoreType_refreshWithoutCallback_callsRefreshOnWidgetAuthentication() {
+        val widgetAuthentication = mock<AuthenticationManager>()
+        val coreAuthentication = widgetAuthentication.toCoreType()
+
+        val jwtToken = "validToken"
+        val externalAccessToken = "externalToken"
+
+        coreAuthentication.refresh(jwtToken, externalAccessToken, null)
+
+        verify(widgetAuthentication).refresh(eq(jwtToken), eq(externalAccessToken), any(), any())
+    }
+
+    @Test
+    fun testWidgetsAuthenticationBehaviorsCorrespondToCoreAuthenticationBehaviors() {
+        val allCoreAuthBehaviors = com.glia.androidsdk.visitor.Authentication.Behavior.entries
+        val allWidgetsAuthBehaviors = Authentication.Behavior.entries
+
+        assertEquals(allCoreAuthBehaviors.size, allWidgetsAuthBehaviors.size)
+        allWidgetsAuthBehaviors.forEachIndexed { index, item ->
+            val coreBehavior = item.toCoreType()
+
+            assertNotNull(coreBehavior)
+            assertEquals(coreBehavior.name, allWidgetsAuthBehaviors[index].name)
+        }
+    }
+
+    @Test
+    fun testCoreAuthenticationBehaviorsCorrespondToWidgetsAuthenticationBehaviors() {
+        val allCoreAuthBehaviors = com.glia.androidsdk.visitor.Authentication.Behavior.entries
+        val allWidgetsAuthBehaviors = Authentication.Behavior.entries
+
+        assertEquals(allCoreAuthBehaviors.size, allWidgetsAuthBehaviors.size)
+        allCoreAuthBehaviors.forEachIndexed { index, item ->
+            val widgetsBehavior = item.toWidgetsType()
+
+            assertNotNull(widgetsBehavior)
+            assertEquals(widgetsBehavior.name, allCoreAuthBehaviors[index].name)
+        }
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/push/notifications/PushClickHandlerControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/push/notifications/PushClickHandlerControllerTest.kt
@@ -131,11 +131,11 @@ class PushClickHandlerControllerTest {
     }
 
     @Test
-    fun `onAuthenticated does nothing when no engagement and not authenticated yet`() {
+    fun `onAuthenticationAttempt does nothing when no engagement and not authenticated yet`() {
         every { isAuthenticatedUseCase() } returns false
         every { isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement } returns false
 
-        pushClickHandlerController.onAuthenticated()
+        pushClickHandlerController.onAuthenticationAttempt()
 
         verify(exactly = 0) { gliaCore.getCurrentVisitor(any()) }
         verify(exactly = 0) { configurationManager.setQueueIds(any()) }
@@ -143,14 +143,14 @@ class PushClickHandlerControllerTest {
     }
 
     @Test
-    fun `onAuthenticated logs when the auth is failed`() {
+    fun `onAuthenticationAttempt logs when the auth is failed`() {
         every { isAuthenticatedUseCase() } returns false
         every { isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement } returns false
         val visitorId = "visitorId"
         val queueId = "queueId"
         mockkGetCurrentVisitorCallback(visitorId, false)
         pushClickHandlerController.handlePushClick(queueId, visitorId)
-        pushClickHandlerController.onAuthenticated()
+        pushClickHandlerController.onAuthenticationAttempt()
 
         verify { gliaCore.getCurrentVisitor(any()) }
 
@@ -161,10 +161,10 @@ class PushClickHandlerControllerTest {
             )
         }
 
-        //call onAuthenticated multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
+        //call onAuthenticationAttempt multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
         verify(exactly = 1) { gliaCore.getCurrentVisitor(any()) }
 
         verify(exactly = 0) { configurationManager.setQueueIds(any()) }
@@ -172,7 +172,7 @@ class PushClickHandlerControllerTest {
     }
 
     @Test
-    fun `onAuthenticated logs when the visitor ids does not match`() {
+    fun `onAuthenticationAttempt logs when the visitor ids does not match`() {
         every { isAuthenticatedUseCase() } returns false
         every { isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement } returns false
         val visitorId = "visitorId"
@@ -180,7 +180,7 @@ class PushClickHandlerControllerTest {
         mockkGetCurrentVisitorCallback(visitorId, true)
 
         pushClickHandlerController.handlePushClick(queueId, "anotherVisitorId")
-        pushClickHandlerController.onAuthenticated()
+        pushClickHandlerController.onAuthenticationAttempt()
 
         verify { gliaCore.getCurrentVisitor( any()) }
 
@@ -191,10 +191,10 @@ class PushClickHandlerControllerTest {
             )
         }
 
-        //call onAuthenticated multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
+        //call onAuthenticationAttempt multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
         verify(exactly = 1) { gliaCore.getCurrentVisitor( any()) }
 
         verify(exactly = 0) { configurationManager.setQueueIds(any()) }
@@ -202,14 +202,14 @@ class PushClickHandlerControllerTest {
     }
 
     @Test
-    fun `onAuthenticated launches sc transcript activity when visitor ids match`() {
+    fun `onAuthenticationAttempt launches sc transcript activity when visitor ids match`() {
         every { isAuthenticatedUseCase() } returns false
         every { isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement } returns false
         val visitorId = "visitorId"
         val queueId = "queueId"
         mockkGetCurrentVisitorCallback(visitorId, true)
         pushClickHandlerController.handlePushClick(queueId, visitorId)
-        pushClickHandlerController.onAuthenticated()
+        pushClickHandlerController.onAuthenticationAttempt()
 
         verify { gliaCore.getCurrentVisitor(any()) }
 
@@ -222,10 +222,10 @@ class PushClickHandlerControllerTest {
             )
         }
 
-        //call onAuthenticated multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
+        //call onAuthenticationAttempt multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
         verify(exactly = 1) { gliaCore.getCurrentVisitor(any()) }
 
         verify(exactly = 1) { configurationManager.setQueueIds(listOf(queueId)) }
@@ -233,30 +233,27 @@ class PushClickHandlerControllerTest {
     }
 
     @Test
-    fun `onAuthenticated creates empty list when the queue id is null`() {
+    fun `onAuthenticationAttempt creates empty list when the queue id is null`() {
         every { isAuthenticatedUseCase() } returns false
         every { isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement } returns false
         val visitorId = "visitorId"
         val queueId = null
         mockkGetCurrentVisitorCallback(visitorId, true)
         pushClickHandlerController.handlePushClick(queueId, visitorId)
-        pushClickHandlerController.onAuthenticated()
+        pushClickHandlerController.onAuthenticationAttempt()
 
         verify { gliaCore.getCurrentVisitor(any()) }
 
         verify { configurationManager.setQueueIds(any()) }
         verify { uiComponentsDispatcher.launchChatScreen(any()) }
         verify {
-            Logger.i(
-                any(),
-                "Secure message push with matching `visitor_id` and authenticated visitor is processed to open chat transcript."
-            )
+            Logger.i(any(), "Secure message push with matching `visitor_id` and authenticated visitor is processed to open chat transcript.")
         }
 
-        //call onAuthenticated multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
-        pushClickHandlerController.onAuthenticated()
+        //call onAuthenticationAttempt multiple times to check that it doesn't call getCurrentVisitor again and pendingPn is null
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
+        pushClickHandlerController.onAuthenticationAttempt()
         verify(exactly = 1) { gliaCore.getCurrentVisitor(any()) }
 
         verify(exactly = 1) { configurationManager.setQueueIds(match { it.isEmpty() }) }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4431

**What was solved?**
According to [documentation](https://docs.glia.com/glia-mobile/docs/ios-authentication#end-ongoing-engagement) for authentication, when the authentication behavior is `ALLOWED_DURING_ENGAGEMENT`, the engagement ends after the visitor becomes deauthenticated.
But widgets ends engagement regardless of behvaior type.

❗ Will add test for AuthManager in next commit.


**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
