### PR TITLE
Fix: Secure Push Notification flags

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/helper/IntentHelper.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/IntentHelper.kt
@@ -162,6 +162,8 @@ internal class IntentHelperImpl : IntentHelper {
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
 
+    // About these flags and overall why this activity has separate affinity etc. please refer to the official documentation:
+    // https://developer.android.com/develop/ui/views/notifications/navigation#ExtendedNotification
     private fun pushClickHandlerIntent(context: Context, queueId: String?, visitorId: String): Intent =
         Intent(context, PushClickHandlerActivity::class.java)
             .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/widgetssdk/src/main/java/com/glia/widgets/push/notifications/PushClickHandlerActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/push/notifications/PushClickHandlerActivity.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.push.notifications
 
-import android.content.Intent
 import android.os.Bundle
 import com.glia.widgets.base.FadeTransitionActivity
 import com.glia.widgets.di.Dependencies
@@ -12,11 +11,7 @@ internal class PushClickHandlerActivity : FadeTransitionActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // About these flags and overall why this activity has separate affinity etc. please refer to the official documentation:
-        // https://developer.android.com/develop/ui/views/notifications/navigation#ExtendedNotification
-        val appLauncherIntent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
+        val appLauncherIntent = packageManager.getLaunchIntentForPackage(packageName)
 
         // We need launcher intent to run the app's default flow.
         if (appLauncherIntent != null) {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4440

**What was solved?**
Remove flags for the Secure Push Notifications to not clear an application activity stack or state when a notification is clicked.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
