### PR TITLE
Improve Dokka setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,17 +80,16 @@ dokka {
       }
       sourceLink {
         localDirectory = file("widgetssdk/src/main/java")
-        remoteUrl = new URI("https://github.com/salemove/android-sdk-widgets/tree/master/widgetssdk/src/main/java")
+        remoteUrl = new URI("https://github.com/salemove/android-sdk-widgets/blob/master/widgetssdk/src/main/java")
         remoteLineSuffix = "#L"
       }
     }
   }
-  String currentYear = Calendar.getInstance().get(Calendar.YEAR)
   String gliaSvgLogoPath = rootProject.file("dokkaAssets/logo-icon.svg")
   pluginsConfiguration {
     html {
       customAssets.from("${gliaSvgLogoPath}")
-      footerMessage = "(c) ${currentYear} Glia Technologies, Inc. All rights reserved."
+      footerMessage = "© Glia Technologies, Inc. All rights reserved."
     }
   }
   dokkaPublications.html {


### PR DESCRIPTION
**Jira issue:**
[Migrate Android Widgets SDK to Dokka Gradle plugin V2](https://glia.atlassian.net/browse/MOB-4459)

**What was solved?**
- Replaced `tree` with `blob` in `remoteUrl` to make it work without a redirect
- Removed `currentYear` from `footerMessage` and replaced `(c)` with `©`. The new footer message is `© Glia Technologies, Inc. All rights reserved.` now.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

