### PR TITLE
Refactor colors

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SingleQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SingleQuestionViewHolder.kt
@@ -22,6 +22,7 @@ import com.glia.widgets.view.unifiedui.applyTextTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveySingleQuestionTheme
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
+import androidx.core.graphics.toColorInt
 
 internal class SingleQuestionViewHolder(
     private val binding: SurveySingleQuestionItemBinding,
@@ -73,7 +74,7 @@ internal class SingleQuestionViewHolder(
                 // Set color for the center dot
                 val centerDot = drawable.findDrawableByLayerId(R.id.center_item)
                 val radiobuttonColor = singleTheme?.tintColor?.primaryColor
-                    ?: Color.parseColor(style.singleQuestion.tintColor)
+                    ?: style.singleQuestion.tintColor.toColorInt()
                 val colorStateList = getRadioButtonColors(radiobuttonColor)
                 centerDot.setTintList(colorStateList)
 
@@ -81,7 +82,7 @@ internal class SingleQuestionViewHolder(
                 val border =
                     drawable.findDrawableByLayerId(R.id.border_item) as GradientDrawable
                 val strokeColor =
-                    ContextCompat.getColorStateList(context, R.color.glia_shade_color)
+                    ContextCompat.getColorStateList(context, R.color.glia_normal_color_opacity_30)
                 val width = context.resources.getDimensionPixelSize(R.dimen.glia_px)
                 border.setStroke(width, strokeColor)
             }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/BooleanQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/BooleanQuestionConfiguration.java
@@ -96,7 +96,7 @@ public class BooleanQuestionConfiguration implements Parcelable {
 
             LayerConfiguration normalLayer = new LayerConfiguration.Builder()
                     .backgroundColor(resourceProvider.getString(R.color.glia_light_color))
-                    .borderColor(resourceProvider.getString(R.color.glia_stroke_gray))
+                    .borderColor(resourceProvider.getString(R.color.glia_normal_color_opacity_30))
                     .cornerRadius(resourceProvider.getDimension(R.dimen.glia_survey_default_corner_radius))
                     .borderWidth(borderWidth)
                     .build();

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/InputQuestionConfiguration.java
@@ -79,7 +79,7 @@ public class InputQuestionConfiguration implements Parcelable {
         @SuppressLint("ResourceType")
         private OptionButtonConfiguration prepareDefaultButtonConfiguration(ResourceProvider resourceProvider) {
             int borderWidth = resourceProvider.getDimensionPixelSize(R.dimen.glia_survey_default_border_width);
-            String normalColor = resourceProvider.getString(R.color.glia_stroke_gray);
+            String normalColor = resourceProvider.getString(R.color.glia_normal_color_opacity_30);
             LayerConfiguration normalLayer = new LayerConfiguration.Builder()
                     .borderColor(normalColor)
                     .borderWidth(borderWidth)

--- a/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/ScaleQuestionConfiguration.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/configuration/survey/ScaleQuestionConfiguration.java
@@ -96,7 +96,7 @@ public class ScaleQuestionConfiguration implements Parcelable {
 
             LayerConfiguration normalLayer = new LayerConfiguration.Builder()
                     .backgroundColor(resourceProvider.getString(R.color.glia_light_color))
-                    .borderColor(resourceProvider.getString(R.color.glia_stroke_gray))
+                    .borderColor(resourceProvider.getString(R.color.glia_normal_color_opacity_30))
                     .cornerRadius(resourceProvider.getDimension(R.dimen.glia_survey_default_corner_radius))
                     .borderWidth(borderWidth)
                     .build();

--- a/widgetssdk/src/main/res/layout/call_view.xml
+++ b/widgetssdk/src/main/res/layout/call_view.xml
@@ -8,7 +8,7 @@
         android:id="@+id/top_app_bar"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:backgroundTint="@color/glia_black_color_transparency"
+        android:backgroundTint="@color/glia_black_color_opacity_0"
         app:elevation="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/widgetssdk/src/main/res/layout/chat_view.xml
+++ b/widgetssdk/src/main/res/layout/chat_view.xml
@@ -279,7 +279,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         android:focusable="true"
         android:clickable="true"
-        android:background="@color/glia_black_color_transparency_2"
+        android:background="@color/glia_black_color_opacity_60"
         android:visibility="gone" />
 
     <com.glia.widgets.entrywidget.EntryWidgetView

--- a/widgetssdk/src/main/res/values/colors.xml
+++ b/widgetssdk/src/main/res/values/colors.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!--  Glia Mobile Color Tokens  -->
     <color name="glia_black_color">#000000</color>
-    <color name="glia_black_color_transparency">#00000000</color>
-    <color name="glia_black_color_transparency_1">#DC000000</color>
-    <color name="glia_black_color_transparency_2">#99000000</color>
-
+    <color name="glia_black_color_opacity_0">#00000000</color>
+    <color name="glia_black_color_opacity_60">#99000000</color>
+    <color name="glia_black_color_opacity_86">#DC000000</color>
     <color name="glia_primary_color">#0F6BFF</color>
     <color name="glia_dark_color">#2C0735</color>
     <color name="glia_light_color">#FFFFFF</color>
     <color name="glia_normal_color">#616A75</color>
+    <color name="glia_normal_color_opacity_30">#4D616A75</color>
     <color name="glia_shade_color">#B6BBC1</color>
     <color name="glia_negative_color">#BC0F42</color>
     <color name="glia_neutral_color">#F7F7F7</color>
@@ -17,7 +18,7 @@
     colors to prevent customisation.  -->
     <color name="glia_branding_color">#B6BBC1</color>
 
-    <color name="glia_call_view_background_color">@color/glia_black_color_transparency_1</color>
+    <color name="glia_call_view_background_color">@color/glia_black_color_opacity_86</color>
     <color name="glia_call_control_buttons_color">@color/glia_black_color</color>
 
     <color name="glia_stroke_light">@color/glia_shade_color</color>
@@ -25,7 +26,7 @@
     <color name="glia_separator_gray">@color/glia_shade_color</color>
     <color name="glia_attachment_menu_bg">@color/glia_neutral_color</color>
     <color name="glia_chat_background_color">@color/glia_light_color</color>
-    <color name="glia_dark_transparent_bg">@color/glia_black_color_transparency_2</color>
+    <color name="glia_dark_transparent_bg">@color/glia_black_color_opacity_60</color>
 
     <color name="glia_disable_button_bg">@color/glia_neutral_color</color>
     <color name="glia_disable_button_border">@color/glia_shade_color</color>


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4454

**What was solved?**
Use the opacity keyword instead of transparency with the percentage value. The value of opacity coincides with the value in Figma.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
