### PR TITLE
Override the com.fasterxml.jackson.core version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTask
-
 buildscript {
   repositories {
     google()
@@ -41,6 +39,15 @@ allprojects {
     // Needed for using SNAPSHOT releases
     maven {
       url 'https://central.sonatype.com/repository/maven-snapshots/'
+    }
+  }
+
+  // Dokka uses the com.fasterxml.jackson.core version that has vulnerability: Stack-based Buffer Overflow [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-10500754]
+  // To fix it, we override the com.fasterxml.jackson.core version for all configurations (mainly for Dokka)
+  // This solution is applied until fasterxml version is upgraded in Dokka https://github.com/Kotlin/dokka/issues/4162
+  configurations.configureEach {
+    resolutionStrategy {
+      force 'com.fasterxml.jackson.core:jackson-core:2.15.3'
     }
   }
 }


### PR DESCRIPTION
**Jira issue:**
[Migrate Android Widgets SDK to Dokka Gradle plugin V2](https://glia.atlassian.net/browse/MOB-4459)

**What was solved?**
- Override the com.fasterxml.jackson.core version for all configurations (mainly for Dokka) to use a version without a 'Stack-based Buffer Overflow' vulnerability

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

