### PR TITLE
Downgrade the ColorDeserializer log level to warning

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/parse/Deserializers.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/parse/Deserializers.kt
@@ -60,7 +60,7 @@ internal class ColorDeserializer : JsonDeserializer<ColorRemoteConfig?> {
         typeOfT: Type,
         context: JsonDeserializationContext
     ): ColorRemoteConfig? = tryOrNull(onError = {
-        Logger.e(TAG, "ColorDeserializer", IllegalArgumentException("${it.message}: -> $json"))
+        Logger.w(TAG, "ColorDeserializer IllegalArgumentException(${it.message}: -> $json)")
     }) {
         ColorRemoteConfig(SystemColor.parseColor(json.asString))
     }


### PR DESCRIPTION
**Jira issue:**
[Map "ColorDeserializer" error to a warning](https://glia.atlassian.net/browse/MOB-4555)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

