### PR TITLE
Fix NullPointerException for the showError() function in VisitorInfoF…

### DIFF
--- a/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
+++ b/app/src/main/java/com/glia/exampleapp/VisitorInfoFragment.kt
@@ -84,7 +84,9 @@ class VisitorInfoFragment : Fragment() {
     }
 
     private fun showError(exception: GliaWidgetsException) {
-        Toast.makeText(context, exception.message ?: exception.debugMessage, Toast.LENGTH_LONG).show()
+        activity?.runOnUiThread {
+            Toast.makeText(context, exception.message ?: exception.debugMessage, Toast.LENGTH_LONG).show()
+        }
     }
 
     private fun obtainVisitorInfoUpdateRequest(): VisitorInfoUpdateRequest {


### PR DESCRIPTION
**Jira issue:**
[Developers want to fix NullPointerException for showError() function in VisitorInfoFragment (example app)](https://glia.atlassian.net/browse/MOB-4577)

**Additional info:**

Crash was caught by [Browserstack](https://app-automate.browserstack.com/dashboard/v2/builds/769f9e954557b22654558e996039c4d57f57c938/sessions/f9f5c18efcc49ea0ee21fe1bafb08da1abc2bd15?overallStatus=completed). Although the test succeeded, logs report a crash.

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

