### PR TITLE
Add the GliaWidgets.init() error causes

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt
@@ -173,10 +173,32 @@ object GliaWidgets {
                         onComplete.onComplete()
                     } else {
                         Logger.i(TAG, "Glia Widgets SDK initialization failed")
-                        val invalidInputError = GliaWidgetsException(
-                            "Failed to initialise Glia Widgets SDK. Please check credentials.",
-                            GliaWidgetsException.Cause.INVALID_INPUT
-                        )
+                        val invalidInputError = when (exception.cause) {
+                            GliaException.Cause.NETWORK_TIMEOUT -> {
+                                GliaWidgetsException(
+                                    "Network timeout. Please check the Internet connection.",
+                                    GliaWidgetsException.Cause.NETWORK_TIMEOUT
+                                )
+                            }
+                            GliaException.Cause.INVALID_INPUT -> {
+                                GliaWidgetsException(
+                                    "Failed to initialise Glia Widgets SDK. Invalid input. Please check credentials.",
+                                    GliaWidgetsException.Cause.INVALID_INPUT
+                                )
+                            }
+                            GliaException.Cause.FORBIDDEN -> {
+                                GliaWidgetsException(
+                                    "Failed to initialise Glia Widgets SDK. Forbidden. Please check credentials.",
+                                    GliaWidgetsException.Cause.INVALID_INPUT
+                                )
+                            }
+                            else -> {
+                                GliaWidgetsException(
+                                    "Failed to initialise Glia Widgets SDK. Please check logs.",
+                                    GliaWidgetsException.Cause.INVALID_INPUT
+                                )
+                            }
+                        }
                         onError.onError(invalidInputError)
                     }
                 }

--- a/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/GliaWidgetsTest.kt
@@ -155,7 +155,34 @@ class GliaWidgetsTest {
     }
 
     @Test
-    fun `init should invoke onError with specific exception when initialization fails`() {
+    fun `init should invoke onError with specific exception when initialization fails with NETWORK_TIMEOUT error`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val gliaWidgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .setSiteId("SiteId")
+            .setRegion("Region")
+            .setContext(mock())
+            .build()
+        val onComplete = mock<OnComplete>()
+        val onError = mock<OnError>()
+        val callbackCaptor = argumentCaptor<RequestCallback<Boolean?>>()
+        whenever(gliaCore.init(any(), callbackCaptor.capture())).thenAnswer {
+            // Simulate error by invoking the captured callback
+            callbackCaptor.firstValue.onResult(null, GliaException("Glia Core SDK exception", GliaException.Cause.NETWORK_TIMEOUT))
+        }
+
+        GliaWidgets.init(gliaWidgetsConfig, onComplete, onError)
+
+        verify(onComplete, never()).onComplete()
+        argumentCaptor<GliaWidgetsException>().apply {
+            verify(onError).onError(capture())
+            Assert.assertEquals(GliaWidgetsException.Cause.NETWORK_TIMEOUT, firstValue.gliaCause)
+            Assert.assertEquals("Network timeout. Please check the Internet connection.", firstValue.debugMessage)
+        }
+    }
+
+    @Test
+    fun `init should invoke onError with specific exception when initialization fails with INVALID_INPUT error`() {
         val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
         val gliaWidgetsConfig = GliaWidgetsConfig.Builder()
             .setSiteApiKey(siteApiKey)
@@ -177,7 +204,34 @@ class GliaWidgetsTest {
         argumentCaptor<GliaWidgetsException>().apply {
             verify(onError).onError(capture())
             Assert.assertEquals(GliaWidgetsException.Cause.INVALID_INPUT, firstValue.gliaCause)
-            Assert.assertEquals("Failed to initialise Glia Widgets SDK. Please check credentials.", firstValue.debugMessage)
+            Assert.assertEquals("Failed to initialise Glia Widgets SDK. Invalid input. Please check credentials.", firstValue.debugMessage)
+        }
+    }
+
+    @Test
+    fun `init should invoke onError with specific exception when initialization fails with FORBIDDEN error`() {
+        val siteApiKey = SiteApiKey("SiteApiId", "SiteApiSecret")
+        val gliaWidgetsConfig = GliaWidgetsConfig.Builder()
+            .setSiteApiKey(siteApiKey)
+            .setSiteId("SiteId")
+            .setRegion("Region")
+            .setContext(mock())
+            .build()
+        val onComplete = mock<OnComplete>()
+        val onError = mock<OnError>()
+        val callbackCaptor = argumentCaptor<RequestCallback<Boolean?>>()
+        whenever(gliaCore.init(any(), callbackCaptor.capture())).thenAnswer {
+            // Simulate error by invoking the captured callback
+            callbackCaptor.firstValue.onResult(null, GliaException("Glia Core SDK exception", GliaException.Cause.FORBIDDEN))
+        }
+
+        GliaWidgets.init(gliaWidgetsConfig, onComplete, onError)
+
+        verify(onComplete, never()).onComplete()
+        argumentCaptor<GliaWidgetsException>().apply {
+            verify(onError).onError(capture())
+            Assert.assertEquals(GliaWidgetsException.Cause.INVALID_INPUT, firstValue.gliaCause)
+            Assert.assertEquals("Failed to initialise Glia Widgets SDK. Forbidden. Please check credentials.", firstValue.debugMessage)
         }
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4590

**What was solved?**
Added additional error causes to understand better the reason why the initialization failed.

The Core SDK causes:
- `NETWORK_TIMEOUT`: any network issue,
- `INVALID_INPUT`: wrong credentials (the [changes on the Core SDK](https://github.com/salemove/android-sdk/pull/879) are needed),
- `FORBIDDEN`:  if credentials are correct, but they don't have enough permissions for other initial requests.

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
