### PR TITLE
Fix several memory leaks

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,8 @@ testRobolectricVersion = "4.14.1"
 testJunitVersion = "4.13.2"
 testJsonVersion = "20250107"
 
+debugLeakcanaryVersion = "3.0-alpha-8"
+
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agpVersion" }
 
@@ -79,6 +81,8 @@ test-json = { module = "org.json:json", version.ref = "testJsonVersion" }
 test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "testMockitoKotlinVersion" }
 test-robolectric = { module = "org.robolectric:robolectric", version.ref = "testRobolectricVersion" }
 test-mockk-android = { module = "io.mockk:mockk-android", version.ref = "testMockkVersion" }
+
+debug-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "debugLeakcanaryVersion" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaVersion" }

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -150,6 +150,7 @@ dependencies {
   testImplementation libs.test.json
 
   lintChecks project(':lint_checker')
+  debugImplementation libs.debug.leakcanary
 }
 
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"

--- a/widgetssdk/src/main/java/com/glia/widgets/base/FadeTransitionActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/base/FadeTransitionActivity.kt
@@ -49,19 +49,19 @@ open class FadeTransitionActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
     }
 
-    override fun finishAndRemoveTask() {
-        super.finishAndRemoveTask()
+    override fun finishAfterTransition() {
         overrideAnimationApi33()
+        super.finishAfterTransition()
     }
 
     override fun startActivity(intent: Intent) {
-        super.startActivity(intent)
         overrideAnimationApi33()
+        super.startActivity(intent)
     }
 
     override fun startActivity(intent: Intent, options: Bundle?) {
-        super.startActivity(intent, options)
         overrideAnimationApi33()
+        super.startActivity(intent, options)
     }
 
     fun setTitle(locale: LocaleString?) {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
@@ -33,10 +33,10 @@ internal class CallActivity : FadeTransitionActivity() {
     private val activityLauncher: ActivityLauncher by lazy { Dependencies.activityLauncher }
     private var callView: CallView by Delegates.notNull()
 
-    private var onBackClickedListener: CallView.OnBackClickedListener? = CallView.OnBackClickedListener { this.finish() }
+    private var onBackClickedListener: CallView.OnBackClickedListener? = CallView.OnBackClickedListener { this.finishAfterTransition() }
     private var onNavigateToChatListener: OnNavigateToChatListener? = OnNavigateToChatListener {
         navigateToChat()
-        finish()
+        finishAfterTransition()
     }
     private val onNavigateToWebBrowserListener = OnNavigateToWebBrowserListener(this::navigateToWebBrowser)
 
@@ -49,19 +49,16 @@ internal class CallActivity : FadeTransitionActivity() {
         val isUpgradeToCall = intent.getBooleanExtra(ExtraKeys.IS_UPGRADE_TO_CALL, false)
 
         if (!callView.shouldShowMediaEngagementView(isUpgradeToCall)) {
-            finishAndRemoveTask()
+            finishAfterTransition()
             return
         }
 
         callView.setOnTitleUpdatedListener(this::setTitle)
         onBackClickedListener?.also(callView::setOnBackClickedListener)
 
-        // In case the engagement ends, Activity is removed from the device's Recent menu
-        // to avoid app users to accidentally start queueing for another call when they resume
-        // the app from the Recent menu and the app's backstack was empty.
-        callView.setOnEndListener { this.finishAndRemoveTask() }
+        callView.setOnEndListener { this.finishAfterTransition() }
 
-        callView.setOnMinimizeListener { this.finish() }
+        callView.setOnMinimizeListener { this.finishAfterTransition() }
         onNavigateToChatListener?.also(callView::setOnNavigateToChatListener)
         callView.setOnNavigateToWebBrowserListener(onNavigateToWebBrowserListener)
 

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
@@ -79,11 +79,11 @@ internal class CallActivity : FadeTransitionActivity() {
     }
 
     override fun onDestroy() {
+        super.onDestroy()
         Logger.i(TAG, "Destroy Call screen")
         onBackClickedListener = null
         onNavigateToChatListener = null
         callView.onDestroy()
-        super.onDestroy()
     }
 
     override fun onUserInteraction() {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -267,6 +267,7 @@ internal class CallController(
             messagesNotSeenHandler.removeListener(messagesNotSeenHandlerListener)
             messagesNotSeenHandlerListener = null
             mediaUpgradeDisposable.clear()
+            callState = CallState.initial(callState.isCallVisualizer)
         }
     }
 
@@ -407,6 +408,7 @@ internal class CallController(
 
     override fun onBackClicked() {
         updateFromCallScreenUseCase(false)
+        onDestroy(true)
     }
 
     @Synchronized
@@ -608,5 +610,6 @@ internal class CallController(
 
     private fun minimizeView() {
         view?.minimizeView()
+        onDestroy(true)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -38,13 +38,11 @@ import com.glia.widgets.engagement.domain.ToggleVisitorAudioMediaStateUseCase
 import com.glia.widgets.engagement.domain.ToggleVisitorVideoMediaStateUseCase
 import com.glia.widgets.engagement.domain.VisitorMediaUseCase
 import com.glia.widgets.helper.Logger
-import com.glia.widgets.helper.Logger.d
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.TimeCounter
 import com.glia.widgets.helper.TimeCounter.FormattedTimerStatusListener
 import com.glia.widgets.helper.TimeCounter.RawTimerStatusListener
 import com.glia.widgets.helper.imageUrl
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.view.MessagesNotSeenHandler
 import com.glia.widgets.view.MessagesNotSeenHandler.MessagesNotSeenHandlerListener
 import com.glia.widgets.view.MinimizeHandler
@@ -102,21 +100,22 @@ internal class CallController(
     private var view: CallContract.View? = null
 
     init {
-        d(TAG, "constructor")
+        Logger.d(TAG, "constructor")
 
         if (isCurrentEngagementCallVisualizerUseCase()) {
             shouldShowMediaEngagementView(true)
         }
 
         subscribeToEngagement()
-        decideOnQueueingUseCase().unSafeSubscribe { enqueueForEngagement() }
+        disposable.add(decideOnQueueingUseCase().subscribe { enqueueForEngagement() })
+
     }
 
     private fun subscribeToEngagement() {
-        engagementStateUseCase().unSafeSubscribe(::onEngagementStateChanged)
+        engagementStateUseCase().subscribe(::onEngagementStateChanged).also(disposable::add)
         subscribeToMediaState()
-        visitorMediaUseCase.onHoldState.unSafeSubscribe(::onHoldChanged)
-        flipCameraButtonStateUseCase().unSafeSubscribe(::onNewFlipCameraButtonState)
+        visitorMediaUseCase.onHoldState.subscribe(::onHoldChanged).also(disposable::add)
+        flipCameraButtonStateUseCase().subscribe(::onNewFlipCameraButtonState).also(disposable::add)
     }
 
     // This method combines both visitor and operator media state updates so that they would be fired one after another.
@@ -134,13 +133,13 @@ internal class CallController(
         ) { visitorState, operatorState ->
             Pair(visitorState, operatorState)
         }.debounce(200, TimeUnit.MILLISECONDS)
-            .unSafeSubscribe {
+            .subscribe {
                 val visitorMedia = it.first.orElse(null)
                 val operatorMedia = it.second.orElse(null)
                 onNewVisitorMediaState(visitorMedia)
                 onNewOperatorMediaState(operatorMedia)
                 callNotificationUseCase(visitorMedia, operatorMedia)
-            }
+            }.also(disposable::add)
     }
 
     private fun onNewVisitorMediaState(visitorMediaState: MediaState?) {
@@ -221,7 +220,7 @@ internal class CallController(
         get() = confirmationDialogLinksUseCase.invoke()
 
     override fun onLinkClicked(link: Link) {
-        d(TAG, "onLinkClicked")
+        Logger.d(TAG, "onLinkClicked")
         getUrlFromLinkUseCase(link)?.let {
             view?.navigateToWebBrowserActivity(link.title, it)
         } ?: run {
@@ -230,13 +229,13 @@ internal class CallController(
     }
 
     override fun onLiveObservationDialogAllowed() {
-        d(TAG, "onLiveObservationDialogAllowed")
+        Logger.d(TAG, "onLiveObservationDialogAllowed")
         dialogController.dismissCurrentDialog()
         decideOnQueueingUseCase.onQueueingRequested()
     }
 
     override fun onLiveObservationDialogRejected() {
-        d(TAG, "onLiveObservationDialogRejected")
+        Logger.d(TAG, "onLiveObservationDialogRejected")
         stop()
         dialogController.dismissDialogs()
     }
@@ -246,9 +245,9 @@ internal class CallController(
     }
 
     override fun onDestroy(retained: Boolean) {
-        d(TAG, "onDestroy, retain: $retained")
+        Logger.d(TAG, "onDestroy, retain: $retained")
         view?.also {
-            d(TAG, "destroyingView")
+            Logger.d(TAG, "destroyingView")
             it.destroyView()
             view = null
         }
@@ -280,52 +279,52 @@ internal class CallController(
     }
 
     override fun leaveChatClicked() {
-        d(TAG, "leaveChatClicked")
+        Logger.d(TAG, "leaveChatClicked")
         showExitChatDialog()
     }
 
     override fun setView(view: CallContract.View) {
-        d(TAG, "setViewCallback")
+        Logger.d(TAG, "setViewCallback")
         this.view = view
         view.emitState(callState)
     }
 
     override fun endEngagementDialogYesClicked() {
-        d(TAG, "endEngagementDialogYesClicked")
+        Logger.d(TAG, "endEngagementDialogYesClicked")
         stop()
         dialogController.dismissDialogs()
     }
 
     override fun endEngagementDialogDismissed() {
-        d(TAG, "endEngagementDialogDismissed")
+        Logger.d(TAG, "endEngagementDialogDismissed")
         dialogController.dismissCurrentDialog()
     }
 
     override fun noMoreOperatorsAvailableDismissed() {
-        d(TAG, "noMoreOperatorsAvailableDismissed")
+        Logger.d(TAG, "noMoreOperatorsAvailableDismissed")
         stop()
         dialogController.dismissDialogs()
     }
 
     override fun unexpectedErrorDialogDismissed() {
-        d(TAG, "unexpectedErrorDialogDismissed")
+        Logger.d(TAG, "unexpectedErrorDialogDismissed")
         stop()
         dialogController.dismissDialogs()
     }
 
     override fun overlayPermissionsDialogDismissed() {
-        d(TAG, "overlayPermissionsDialogDismissed")
+        Logger.d(TAG, "overlayPermissionsDialogDismissed")
         decideOnQueueingUseCase.onOverlayDialogShown()
         dialogController.dismissCurrentDialog()
     }
 
     override fun leaveChatQueueClicked() {
-        d(TAG, "leaveChatQueueClicked")
+        Logger.d(TAG, "leaveChatQueueClicked")
         dialogController.showExitQueueDialog()
     }
 
     override fun onResume() {
-        d(TAG, "onResume\n")
+        Logger.d(TAG, "onResume\n")
         onResumeSetup()
     }
 
@@ -339,7 +338,7 @@ internal class CallController(
     }
 
     private fun handleMediaUpgradeAcceptResult(it: MediaUpgradeOffer) {
-        d(TAG, "upgradeOfferChoiceSubmitSuccess")
+        Logger.d(TAG, "upgradeOfferChoiceSubmitSuccess")
         val mediaType: MediaType = if (it.video != null && it.video != MediaDirection.NONE) {
             MediaType.VIDEO
         } else {
@@ -349,7 +348,7 @@ internal class CallController(
     }
 
     override fun chatButtonClicked() {
-        d(TAG, "chatButtonClicked")
+        Logger.d(TAG, "chatButtonClicked")
         updateFromCallScreenUseCase(true)
         view?.navigateToChat()
         onDestroy(true)
@@ -364,7 +363,7 @@ internal class CallController(
     }
 
     override fun minimizeButtonClicked() {
-        d(TAG, "minimizeButtonClicked")
+        Logger.d(TAG, "minimizeButtonClicked")
         minimizeHandler.minimize()
     }
 
@@ -382,7 +381,7 @@ internal class CallController(
 
     private fun onNewOperatorMediaState(operatorMediaState: MediaState) {
         if (!isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement) return
-        d(TAG, "newOperatorMediaState: $operatorMediaState, timer task running: ${callTimer.isRunning}")
+        Logger.d(TAG, "newOperatorMediaState: $operatorMediaState, timer task running: ${callTimer.isRunning}")
         if (operatorMediaState.video != null) {
             onOperatorMediaStateVideo(operatorMediaState)
         } else if (operatorMediaState.audio != null) {
@@ -397,7 +396,7 @@ internal class CallController(
 
     override fun onSpeakerButtonPressed() {
         val newValue = !callState.isSpeakerOn
-        d(TAG, "onSpeakerButtonPressed, new value: $newValue")
+        Logger.d(TAG, "onSpeakerButtonPressed, new value: $newValue")
         emitViewState(callState.speakerValueChanged(newValue))
         turnSpeakerphoneUseCase.invoke(newValue)
     }
@@ -414,7 +413,7 @@ internal class CallController(
     @Synchronized
     private fun emitViewState(state: CallState) {
         if (setState(state) && view != null) {
-            d(TAG, "Emit state:\n$state")
+            Logger.d(TAG, "Emit state:\n$state")
             view?.emitState(callState)
         }
     }
@@ -430,7 +429,7 @@ internal class CallController(
         return object : RawTimerStatusListener {
             override fun onNewRawTimerValue(timerValue: Int) {
                 if (callState.isVideoCall) {
-                    d(TAG, "inactivityTimer onNewTimerValue: $timerValue")
+                    Logger.d(TAG, "inactivityTimer onNewTimerValue: $timerValue")
                     emitViewState(callState.landscapeControlsVisibleChanged(timerValue < MAX_IDLE_TIME))
                 }
                 if (timerValue >= MAX_IDLE_TIME) {
@@ -489,14 +488,14 @@ internal class CallController(
     }
 
     private fun stop() {
-        d(TAG, "Stop, engagement ended")
+        Logger.d(TAG, "Stop, engagement ended")
         endEngagementUseCase()
         mediaUpgradeDisposable.clear()
         emitViewState(callState.stop())
     }
 
     private fun onOperatorMediaStateVideo(operatorMediaState: MediaState) {
-        d(TAG, "newOperatorMediaState: video")
+        Logger.d(TAG, "newOperatorMediaState: video")
         var formattedTime = DateUtils.formatElapsedTime(0)
         if (callState.isCallOngoingAndOperatorConnected) {
             formattedTime = callState.callStatus.time
@@ -506,7 +505,7 @@ internal class CallController(
     }
 
     private fun onOperatorMediaStateAudio(operatorMediaState: MediaState) {
-        d(TAG, "newOperatorMediaState: audio")
+        Logger.d(TAG, "newOperatorMediaState: audio")
         var formattedTime = DateUtils.formatElapsedTime(0)
         if (callState.isCallOngoingAndOperatorConnected) formattedTime = callState.callStatus.time
         emitViewState(callState.audioCallStarted(operatorMediaState, formattedTime))
@@ -514,7 +513,7 @@ internal class CallController(
     }
 
     private fun onOperatorMediaStateUnknown() {
-        d(TAG, "newOperatorMediaState: null")
+        Logger.d(TAG, "newOperatorMediaState: null")
         if (callState.isMediaEngagementStarted) {
             emitViewState(callState.backToOngoing())
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -7,7 +7,6 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
-import android.view.View.OnClickListener
 import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -315,10 +314,10 @@ internal class CallView(
     }
 
     private fun handleOperatorVideoState(state: CallState) {
-        if (state.showOperatorVideo() && operatorVideoContainer.visibility == GONE) {
+        if (state.showOperatorVideo() && operatorVideoContainer.isGone) {
             operatorVideoContainer.visibility = VISIBLE
             showOperatorVideo(state.callStatus.operatorMediaState)
-        } else if (!state.showOperatorVideo() && operatorVideoContainer.visibility == VISIBLE) {
+        } else if (!state.showOperatorVideo() && operatorVideoContainer.isVisible) {
             operatorVideoContainer.visibility = GONE
             hideOperatorVideo()
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/CallVisualizerController.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.callvisualizer.controller
 
+import android.annotation.SuppressLint
 import com.glia.widgets.engagement.EndAction
 import com.glia.widgets.engagement.domain.EngagementRequestUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
@@ -8,7 +9,6 @@ import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.OneTimeEvent
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.asOneTimeStateFlowable
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.internal.dialog.DialogContract
 import com.glia.widgets.internal.dialog.domain.ConfirmationDialogLinksUseCase
 import com.glia.widgets.internal.dialog.model.ConfirmationDialogLinks
@@ -68,11 +68,12 @@ internal class CallVisualizerController(
         registerCallVisualizerListeners()
     }
 
+    @SuppressLint("CheckResult")
     private fun registerCallVisualizerListeners() {
-        engagementRequestUseCase().unSafeSubscribe { onEngagementRequested() }
-        onIncomingEngagementRequestTimeoutUseCase().unSafeSubscribe { onIncomingEngagementRequestTimeout() }
+        engagementRequestUseCase().subscribe { onEngagementRequested() }
+        onIncomingEngagementRequestTimeoutUseCase().subscribe { onIncomingEngagementRequestTimeout() }
         dialogController.addCallback(::handleDialogState)
-        engagementStartFlow.unSafeSubscribe { dismissVisitorCodeDialog() }
+        engagementStartFlow.subscribe { dismissVisitorCodeDialog() }
     }
 
     private fun handleDialogState(dialogState: DialogState) {

--- a/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/VisitorCodeController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/callvisualizer/controller/VisitorCodeController.kt
@@ -23,31 +23,31 @@ internal class VisitorCodeController(
 
     private val defaultRefreshDurationMilliseconds: Long = 30 * 60 * 1000L
 
-    private lateinit var view: VisitorCodeContract.View
+    private var view: VisitorCodeContract.View? = null
 
     override fun setView(view: VisitorCodeContract.View) {
         this.view = view
-        this.view.notifySetupComplete()
+        this.view?.notifySetupComplete()
         this.autoCloseOnEngagement()
     }
 
     override fun onCloseButtonClicked() {
         callVisualizerController.dismissVisitorCodeDialog()
-        view.destroyTimer()
+        view?.destroyTimer()
     }
 
     override fun onLoadVisitorCode() {
-        view.startLoading()
+        view?.startLoading()
         disposable = visitorCodeRepository.getVisitorCode()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 { visitorCode ->
-                    view.showVisitorCode(visitorCode)
-                    view.setTimer(failGuardDuration(visitorCode))
+                    view?.showVisitorCode(visitorCode)
+                    view?.setTimer(failGuardDuration(visitorCode))
                 },
                 { error ->
-                    view.showError(error)
+                    view?.showError(error)
                 }
             )
     }
@@ -70,12 +70,13 @@ internal class VisitorCodeController(
         }
         engagementStateDisposable?.dispose()
         engagementStateDisposable = engagementStateUseCase().filter { it is State.EngagementStarted && it.isCallVisualizer }.subscribe {
-            view.destroyTimer()
+            view?.destroyTimer()
         }
     }
 
     override fun onDestroy() {
         engagementStateDisposable?.dispose()
-        view.destroyTimer()
+        view?.destroyTimer()
+        view = null
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
@@ -48,19 +48,19 @@ internal class ChatActivity : FadeTransitionActivity() {
         chatView.setOnTitleUpdatedListener(this::setTitle)
 
         if (!chatView.shouldShow()) {
-            finishAndRemoveTask()
+            finishAfterTransition()
             return
         }
 
-        chatView.setOnBackClickedListener(::finish)
+        chatView.setOnBackClickedListener(::finishAfterTransition)
         chatView.setOnBackToCallListener(::backToCallScreen)
 
         // In case the engagement ends, Activity is removed from the device's Recents menu
         // to avoid app users to accidentally start queueing for another call when they resume
         // the app from the Recents menu and the app's backstack was empty.
-        chatView.setOnEndListener(::finishAndRemoveTask)
+        chatView.setOnEndListener(::finishAfterTransition)
 
-        chatView.setOnMinimizeListener(::finish)
+        chatView.setOnMinimizeListener(::finishAfterTransition)
 
         val intention = intent.getEnumExtra<Intention>(ExtraKeys.OPEN_CHAT_INTENTION)
 
@@ -91,6 +91,6 @@ internal class ChatActivity : FadeTransitionActivity() {
 
     private fun backToCallScreen() {
         activityLauncher.launchCall(this, null, false)
-        finish()
+        finishAfterTransition()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
@@ -2,7 +2,6 @@ package com.glia.widgets.chat
 
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.enableEdgeToEdge
 import com.glia.widgets.R
 import com.glia.widgets.base.FadeTransitionActivity
 import com.glia.widgets.di.Dependencies
@@ -39,7 +38,6 @@ internal class ChatActivity : FadeTransitionActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        this.enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         Logger.i(TAG, "Create Chat screen")
         setContentView(R.layout.chat_activity)
@@ -57,9 +55,6 @@ internal class ChatActivity : FadeTransitionActivity() {
         chatView.setOnBackClickedListener(::finishAfterTransition)
         chatView.setOnBackToCallListener(::backToCallScreen)
 
-        // In case the engagement ends, Activity is removed from the device's Recents menu
-        // to avoid app users to accidentally start queueing for another call when they resume
-        // the app from the Recents menu and the app's backstack was empty.
         chatView.setOnEndListener(::finishAfterTransition)
 
         chatView.setOnMinimizeListener(::finishAfterTransition)

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
@@ -32,6 +32,12 @@ internal class ChatActivity : FadeTransitionActivity() {
 
     private var chatView: ChatView by Delegates.notNull()
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            chatView.onBackPressed()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         this.enableEdgeToEdge()
         super.onCreate(savedInstanceState)
@@ -39,11 +45,7 @@ internal class ChatActivity : FadeTransitionActivity() {
         setContentView(R.layout.chat_activity)
         chatView = findViewById(R.id.chat_view)
 
-        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                chatView.onBackPressed()
-            }
-        })
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
 
         chatView.setOnTitleUpdatedListener(this::setTitle)
 
@@ -84,9 +86,10 @@ internal class ChatActivity : FadeTransitionActivity() {
     }
 
     override fun onDestroy() {
-        chatView.onDestroyView()
-        Logger.i(TAG, "Destroy Chat screen")
         super.onDestroy()
+        chatView.onDestroyView()
+        onBackPressedCallback.remove()
+        Logger.i(TAG, "Destroy Chat screen")
     }
 
     private fun backToCallScreen() {

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -430,7 +430,7 @@ internal class ChatManager(
     fun mapInQueue(state: State): State = state.apply {
         OperatorStatusItem.InQueue.also {
             operatorStatusItem = it
-            val isQueueingItemAlreadyDisplayed = chatItems.size > 0 && chatItems[chatItems.lastIndex] == it
+            val isQueueingItemAlreadyDisplayed = chatItems.isNotEmpty() && chatItems[chatItems.lastIndex] == it
             if (!isQueueingItemAlreadyDisplayed) chatItems += it
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -62,7 +62,6 @@ import com.glia.widgets.helper.exists
 import com.glia.widgets.helper.formattedName
 import com.glia.widgets.helper.imageUrl
 import com.glia.widgets.helper.isValid
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.internal.dialog.DialogContract
 import com.glia.widgets.internal.dialog.domain.ConfirmationDialogLinksUseCase
 import com.glia.widgets.internal.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
@@ -211,7 +210,7 @@ internal class ChatController(
         Logger.d(TAG, "constructor")
         chatState = ChatState()
         subscribeToEngagement()
-        decideOnQueueingUseCase().unSafeSubscribe { enqueueForEngagement() }
+        decideOnQueueingUseCase().subscribe { enqueueForEngagement() }.also(disposable::add)
     }
 
     override fun initChat(intention: Intention) {
@@ -268,9 +267,11 @@ internal class ChatController(
     }
 
     private fun subscribeToEngagement() {
-        engagementStateUseCase().unSafeSubscribe(::onEngagementStateChanged)
-        operatorMediaUseCase().unSafeSubscribe(::onNewOperatorMediaState)
-        onOperatorTypingUseCase().unSafeSubscribe(::onOperatorTyping)
+        disposable.addAll(
+            engagementStateUseCase().subscribe(::onEngagementStateChanged),
+            operatorMediaUseCase().subscribe(::onNewOperatorMediaState),
+            onOperatorTypingUseCase().subscribe(::onOperatorTyping),
+        )
     }
 
     private fun ensureSecureMessagingAvailable() {

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -277,8 +277,7 @@ public class ControllerFactory {
                 messagesNotSeenHandler,
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.getCurrentOperatorUseCase(),
-                useCaseFactory.getVisitorMediaUseCase(),
-                useCaseFactory.getEngagementTypeUseCase()
+                useCaseFactory.getVisitorMediaUseCase()
             );
         }
         return applicationChatHeadController;

--- a/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java
@@ -262,8 +262,7 @@ public class ControllerFactory {
                 new ChatHeadPosition(),
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.getCurrentOperatorUseCase(),
-                useCaseFactory.getVisitorMediaUseCase(),
-                useCaseFactory.getEngagementTypeUseCase()
+                useCaseFactory.getVisitorMediaUseCase()
             );
         }
         return serviceChatHeadController;
@@ -341,12 +340,12 @@ public class ControllerFactory {
     public ActivityWatcherForChatHeadContract.Controller getActivityWatcherForChatHeadController() {
         if (activityWatcherForChatHeadController == null) {
             activityWatcherForChatHeadController = new ActivityWatcherForChatHeadController(
-                serviceChatHeadController,
+                getChatHeadController(),
                 getChatHeadLayoutController(),
                 useCaseFactory.getEngagementStateUseCase(),
                 useCaseFactory.createIsFromCallScreenUseCase(),
-                useCaseFactory.createUpdateFromCallScreenUseCase(),
-                useCaseFactory.getIsCurrentEngagementCallVisualizer());
+                useCaseFactory.createUpdateFromCallScreenUseCase()
+            );
         }
         return activityWatcherForChatHeadController;
     }
@@ -385,12 +384,8 @@ public class ControllerFactory {
             useCaseFactory.getAcceptMediaUpgradeOfferUseCase(),
             useCaseFactory.getDeclineMediaUpgradeOfferUseCase(),
             useCaseFactory.getCheckMediaUpgradePermissionsUseCase(),
-            useCaseFactory.getCurrentOperatorUseCase(),
-            useCaseFactory.createIsShowOverlayPermissionRequestDialogUseCase(),
-            useCaseFactory.getIsCurrentEngagementCallVisualizer(),
             useCaseFactory.createSetOverlayPermissionRequestDialogShownUseCase(),
-            dialogController,
-            useCaseFactory.getWithNotificationPermissionUseCase()
+            dialogController
         );
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/EngagementRepositoryImpl.kt
@@ -26,14 +26,12 @@ import com.glia.androidsdk.queuing.QueueTicket
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.Data
 import com.glia.widgets.helper.Logger
-import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.isAudioOrVideo
 import com.glia.widgets.helper.isCallVisualizer
 import com.glia.widgets.helper.isQueueUnavailable
 import com.glia.widgets.helper.isRetain
 import com.glia.widgets.helper.isShowEndDialog
 import com.glia.widgets.helper.isSurvey
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.internal.engagement.GliaOperatorRepository
 import com.glia.widgets.internal.queue.QueueRepository
 import com.glia.widgets.launcher.ConfigurationManager
@@ -287,9 +285,15 @@ internal class EngagementRepositoryImpl(
         }
     }
 
+
+    @SuppressLint("CheckResult")
     override fun acceptCurrentEngagementRequest(visitorContextAssetId: String) {
-        _engagementRequest.firstOrError().flatMapCompletable { accept(it, visitorContextAssetId) }.unSafeSubscribe {
-            Logger.i(TAG, "Incoming Call Visualizer engagement was accepted")
+        _engagementRequest.firstOrError().flatMapCompletable { accept(it, visitorContextAssetId) }.subscribe(
+            {
+                Logger.i(TAG, "Incoming Call Visualizer engagement was accepted")
+            }
+        ) {
+            Logger.w(TAG, "Error during accepting engagement request, reason: ${it.message}")
         }
     }
 
@@ -349,9 +353,10 @@ internal class EngagementRepositoryImpl(
         _engagementRequest.onNext(engagementRequest)
     }
 
+    @SuppressLint("CheckResult")
     private fun handleEngagementOutcome(outcome: Outcome) {
         _engagementOutcome.onNext(outcome)
-        _engagementRequest.firstOrError().unSafeSubscribe { request ->
+        _engagementRequest.firstOrError().subscribe { request ->
             request.off(EngagementRequest.Events.OUTCOME, engagementOutcomeCallback)
         }
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/completion/EngagementCompletionController.kt
@@ -1,12 +1,12 @@
 package com.glia.widgets.engagement.completion
 
+import android.annotation.SuppressLint
 import com.glia.widgets.engagement.EndAction
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
 import com.glia.widgets.engagement.domain.ReleaseResourcesUseCase
 import com.glia.widgets.helper.OneTimeEvent
 import com.glia.widgets.helper.asOneTimeStateFlowable
-import com.glia.widgets.helper.unSafeSubscribe
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.processors.BehaviorProcessor
 
@@ -26,7 +26,8 @@ internal class EngagementCompletionController(
     override val state: Flowable<OneTimeEvent<EngagementCompletionState>> = _state.asOneTimeStateFlowable()
 
     init {
-        engagementStateUseCase().unSafeSubscribe(::handleEngagementState)
+        @SuppressLint("CheckResult")
+        engagementStateUseCase().subscribe(::handleEngagementState)
     }
 
     private fun handleEngagementState(state: State) {

--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetActivity.kt
@@ -1,14 +1,14 @@
 package com.glia.widgets.entrywidget
 
 import android.os.Bundle
-import com.glia.widgets.base.FadeTransitionActivity
+import androidx.appcompat.app.AppCompatActivity
 import com.glia.widgets.di.Dependencies
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 
 /**
  * EntryWidgetActivity provides a way to display the EntryWidget bottom sheet.
  */
-internal class EntryWidgetActivity : FadeTransitionActivity(), EntryWidgetFragment.OnDismissListener {
+internal class EntryWidgetActivity : AppCompatActivity(), EntryWidgetFragment.OnDismissListener {
 
     private var disposable: CompositeDisposable = CompositeDisposable()
 

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewActivity.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -52,6 +53,12 @@ internal class ImagePreviewActivity : AppCompatActivity(), ImagePreviewContract.
 
     private var imagePreviewController: ImagePreviewContract.Controller? = null
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            finishAfterTransition()
+        }
+    }
+
     override fun attachBaseContext(newBase: Context) {
         super.attachBaseContext(newBase)
 
@@ -72,6 +79,7 @@ internal class ImagePreviewActivity : AppCompatActivity(), ImagePreviewContract.
         setSupportActionBar(binding.toolbar)
         binding.toolbar.setLocaleContentDescription(R.string.android_preview_title)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 
     private fun onImageDataReceived(intent: Intent) {
@@ -113,7 +121,7 @@ internal class ImagePreviewActivity : AppCompatActivity(), ImagePreviewContract.
     }
 
     override fun onSupportNavigateUp(): Boolean {
-        onBackPressedDispatcher.onBackPressed()
+        finishAfterTransition()
         return true
     }
 
@@ -132,6 +140,7 @@ internal class ImagePreviewActivity : AppCompatActivity(), ImagePreviewContract.
         super.onDestroy()
         Logger.i(TAG, "Destroy Image Preview screen")
         imagePreviewController?.onDestroy()
+        onBackPressedCallback.remove()
     }
 
     override fun onRequestPermissionsResult(
@@ -206,7 +215,4 @@ internal class ImagePreviewActivity : AppCompatActivity(), ImagePreviewContract.
         showToast(localeProvider.getString(R.string.android_image_preview_fetch_error))
     }
 
-    override fun engagementEnded() {
-        finishAfterTransition()
-    }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewActivity.kt
@@ -129,9 +129,9 @@ internal class ImagePreviewActivity : AppCompatActivity(), ImagePreviewContract.
     }
 
     override fun onDestroy() {
+        super.onDestroy()
         Logger.i(TAG, "Destroy Image Preview screen")
         imagePreviewController?.onDestroy()
-        super.onDestroy()
     }
 
     override fun onRequestPermissionsResult(

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewContract.kt
@@ -20,7 +20,6 @@ internal interface ImagePreviewContract {
         fun showOnImageSaveSuccess()
         fun showOnImageSaveFailed()
         fun showOnImageLoadingFailed()
-        fun engagementEnded()
         fun shareImageFile(uri: Uri)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/filepreview/ui/ImagePreviewController.kt
@@ -78,6 +78,7 @@ internal class ImagePreviewController @JvmOverloads constructor(
     }
 
     override fun onDestroy() {
+        view = null
         disposables.clear()
         state = State()
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/CommonExtensions.kt
@@ -1,6 +1,5 @@
 package com.glia.widgets.helper
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
@@ -27,10 +26,7 @@ import com.glia.widgets.UiTheme
 import com.glia.widgets.engagement.MediaType
 import com.glia.widgets.queue.Queue
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
-import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
-import io.reactivex.rxjava3.core.Single
-import io.reactivex.rxjava3.functions.Action
 import io.reactivex.rxjava3.processors.FlowableProcessor
 import java.io.File
 import kotlin.io.path.createTempFile
@@ -96,21 +92,6 @@ internal val ActionOnEnd?.isShowEndDialog: Boolean get() = this == ActionOnEnd.E
 internal val ActionOnEnd?.isUnknown: Boolean get() = this == ActionOnEnd.UNKNOWN
 
 internal val Engagement.isCallVisualizer: Boolean get() = this is OmnibrowseEngagement
-
-@SuppressLint("CheckResult")
-internal fun <T : Any> Flowable<out T>.unSafeSubscribe(onNextCallback: (T) -> Unit) {
-    subscribe({ onNextCallback(it) }) { Logger.e("Observable<T>.unSafeSubscribe", "Unexpected local exception happened", it) }
-}
-
-@SuppressLint("CheckResult")
-internal fun <T : Any> Single<out T>.unSafeSubscribe(onNextCallback: (T) -> Unit) {
-    subscribe({ onNextCallback(it) }) { Logger.e("Single<T>.unSafeSubscribe", "Unexpected local exception happened", it) }
-}
-
-@SuppressLint("CheckResult")
-internal fun Completable.unSafeSubscribe(onComplete: Action) {
-    subscribe(onComplete) { Logger.e("Single<T>.unSafeSubscribe", "Unexpected local exception happened", it) }
-}
 
 internal fun <T : Any> FlowableProcessor<T>.asStateFlowable(): Flowable<T> = onBackpressureBuffer().observeOn(AndroidSchedulers.mainThread())
 internal fun <T : Any> FlowableProcessor<T>.asOneTimeStateFlowable(): Flowable<OneTimeEvent<T>> =

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/callvisualizer/CallVisualizerManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/callvisualizer/CallVisualizerManager.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.view.View
 import com.glia.widgets.callvisualizer.controller.CallVisualizerContract
 import com.glia.widgets.core.callvisualizer.domain.CallVisualizer
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.internal.callvisualizer.domain.VisitorCodeViewBuilderUseCase
 
 internal class CallVisualizerManager(
@@ -27,11 +26,11 @@ internal class CallVisualizerManager(
 
     @SuppressLint("CheckResult")
     override fun onEngagementStart(runnable: Runnable) {
-        callVisualizerController.engagementStartFlow.unSafeSubscribe { runnable.run() }
+        callVisualizerController.engagementStartFlow.subscribe { runnable.run() }
     }
 
     @SuppressLint("CheckResult")
     override fun onEngagementEnd(runnable: Runnable) {
-        callVisualizerController.engagementEndFlow.unSafeSubscribe { runnable.run() }
+        callVisualizerController.engagementEndFlow.subscribe { runnable.run() }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/dialog/DialogController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/dialog/DialogController.kt
@@ -19,7 +19,6 @@ internal interface DialogContract {
         fun dismissVisitorCodeDialog()
         fun showUnexpectedErrorDialog()
         fun showOverlayPermissionsDialog()
-        fun showCVOverlayPermissionDialog()
         fun dismissOverlayPermissionsDialog()
         fun dismissMessageCenterUnavailableDialog()
         fun dismissCVEngagementConfirmationDialog()
@@ -95,11 +94,6 @@ internal class DialogController : DialogContract.Controller {
     override fun showOverlayPermissionsDialog() {
         Logger.i(TAG, "Show Overlay permissions Dialog")
         dialogManager.addAndEmit(DialogState.OverlayPermission)
-    }
-
-    override fun showCVOverlayPermissionDialog() {
-        Logger.i(TAG, "Show CV Overlay permissions Dialog")
-        dialogManager.addAndEmit(DialogState.CVOverlayPermission)
     }
 
     override fun dismissOverlayPermissionsDialog() {

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/dialog/model/DialogState.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/dialog/model/DialogState.kt
@@ -5,7 +5,6 @@ import com.glia.widgets.engagement.domain.MediaUpgradeOfferData
 internal sealed interface DialogState {
     data object None : DialogState
     data object OverlayPermission : DialogState
-    data object CVOverlayPermission : DialogState
     data object ExitQueue : DialogState
     data object VisitorCode : DialogState
     data object MessageCenterUnavailable : DialogState

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/SecureConversationsRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/SecureConversationsRepository.kt
@@ -1,5 +1,6 @@
 package com.glia.widgets.internal.secureconversations
 
+import android.annotation.SuppressLint
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.chat.SendMessagePayload
@@ -9,7 +10,6 @@ import com.glia.widgets.chat.data.GliaChatRepository
 import com.glia.widgets.chat.domain.GliaSendMessageUseCase
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.asStateFlowable
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.internal.queue.QueueRepository
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Observable
@@ -67,9 +67,10 @@ internal class SecureConversationsRepository(private val core: GliaCore, private
         }
     }
 
+    @SuppressLint("CheckResult")
     fun send(payload: SendMessagePayload, callback: RequestCallback<VisitorMessage?>) {
         _messageSendingObservable.onNext(true)
-        queueRepository.relevantQueueIds.unSafeSubscribe { queueIds ->
+        queueRepository.relevantQueueIds.subscribe { queueIds ->
             if (queueIds.isNotEmpty()) {
                 secureConversations.send(payload, queueIds.toTypedArray(), handleResult(callback))
             } else {

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/domain/HasOngoingSecureConversationUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/domain/HasOngoingSecureConversationUseCase.kt
@@ -1,8 +1,8 @@
 package com.glia.widgets.internal.secureconversations.domain
 
+import android.annotation.SuppressLint
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Flowable
@@ -25,13 +25,16 @@ internal class HasOngoingSecureConversationUseCase(
 
     operator fun invoke(): Flowable<Boolean> = hasOngoingInteraction.distinctUntilChanged().observeOn(AndroidSchedulers.mainThread())
 
+    @SuppressLint("CheckResult")
     operator fun invoke(onHasOngoingSecureConversation: () -> Unit, onNoOngoingSecureConversation: () -> Unit = {}) {
-        invoke().firstOrError().unSafeSubscribe { hasOngoing ->
+        invoke().firstOrError().subscribe({ hasOngoing ->
             if (hasOngoing) {
                 onHasOngoingSecureConversation()
             } else {
                 onNoOngoingSecureConversation()
             }
+        }) {
+            // no-op
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
@@ -65,7 +65,7 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
         onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 messageCenterView.onSystemBack()
-                finishAndRemoveTask()
+                finishAfterTransition()
             }
         })
 
@@ -103,12 +103,12 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
 
     override fun navigateToMessaging() {
         Dependencies.activityLauncher.launchChat(this, Intention.SC_CHAT)
-        finish()
+        finishAfterTransition()
     }
 
     override fun returnToLiveChat() {
         Dependencies.activityLauncher.launchChat(this, Intention.RETURN_TO_CHAT)
-        finish()
+        finishAfterTransition()
     }
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
@@ -51,6 +51,13 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
         }
     }
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            messageCenterView.onSystemBack()
+            finishAfterTransition()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Logger.i(TAG, "Create Message Center screen")
@@ -62,12 +69,7 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
         messageCenterView.onAttachFileListener = this
 
         messageCenterView.setController(controller)
-        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                messageCenterView.onSystemBack()
-                finishAfterTransition()
-            }
-        })
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
 
         messageCenterView.initialize()
     }
@@ -86,6 +88,7 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
 
     override fun onDestroy() {
         super.onDestroy()
+        onBackPressedCallback.remove()
         Logger.i(TAG, "Destroy Message Center screen")
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
@@ -89,6 +89,7 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
     override fun onDestroy() {
         super.onDestroy()
         onBackPressedCallback.remove()
+        controller.onDestroy()
         Logger.i(TAG, "Destroy Message Center screen")
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
@@ -237,6 +237,7 @@ internal class MessageCenterController(
     }
 
     override fun onDestroy() {
+        view = null
         disposables.dispose()
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/operator/OperatorRequestActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/operator/OperatorRequestActivityWatcher.kt
@@ -2,12 +2,10 @@ package com.glia.widgets.operator
 
 import android.app.Activity
 import android.content.Intent
-import android.media.projection.MediaProjectionManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.collection.ArrayMap
-import androidx.core.content.getSystemService
 import com.glia.androidsdk.Engagement
 import com.glia.widgets.base.BaseSingleActivityWatcher
 import com.glia.widgets.call.CallActivity
@@ -57,7 +55,6 @@ internal class OperatorRequestActivityWatcher(
             state is ControllerState.OpenCallActivity -> event.consume { openCallActivity(state.mediaType, activity) }
             state is ControllerState.RequestMediaUpgrade -> showUpgradeDialog(state, activity, event::markConsumed)
             state is ControllerState.DisplayToast -> event.consume { displayToast(activity, state.message) }
-            state is ControllerState.ShowOverlayDialog -> showOverlayDialog(activity, event::markConsumed)
             state is ControllerState.OpenOverlayPermissionScreen -> event.consume { openOverlayPermissionsScreen(activity) }
         }
     }
@@ -74,18 +71,6 @@ internal class OperatorRequestActivityWatcher(
             }, onFailure = {
                 controller.failedToOpenOverlayPermissionScreen()
             })
-    }
-
-    private fun showOverlayDialog(activity: Activity, consumeCallback: () -> Unit) {
-        showAlertDialogWithStyledContext(activity) { context, uiTheme ->
-            Dialogs.showOverlayPermissionsDialog(context, uiTheme, {
-                consumeCallback()
-                controller.onOverlayPermissionRequestAccepted(activity)
-            }) {
-                consumeCallback()
-                controller.onOverlayPermissionRequestDeclined(activity)
-            }
-        }
     }
 
     private fun openCallActivity(mediaType: Engagement.MediaType, activity: Activity) {

--- a/widgetssdk/src/main/java/com/glia/widgets/operator/OperatorRequestContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/operator/OperatorRequestContract.kt
@@ -1,8 +1,6 @@
 package com.glia.widgets.operator
 
 import android.app.Activity
-import androidx.activity.ComponentActivity
-import androidx.activity.result.ActivityResult
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.widgets.engagement.domain.MediaUpgradeOfferData
@@ -15,7 +13,6 @@ internal interface OperatorRequestContract {
         data class OpenCallActivity(val mediaType: Engagement.MediaType) : State
         object DismissAlertDialog : State
         data class DisplayToast(val message: String) : State
-        object ShowOverlayDialog : State
         object OpenOverlayPermissionScreen : State
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
@@ -34,6 +34,12 @@ import com.glia.widgets.helper.insetsControllerCompat
 internal class SurveyActivity : AppCompatActivity(), SurveyView.OnFinishListener {
     private val surveyView: SurveyView by lazy { findViewById(R.id.survey_view) }
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            finish()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         this.enableEdgeToEdge()
         window.insetsControllerCompat.isAppearanceLightStatusBars = false
@@ -44,20 +50,17 @@ internal class SurveyActivity : AppCompatActivity(), SurveyView.OnFinishListener
         Logger.i(TAG, "Create Survey screen")
         setContentView(R.layout.survey_activity)
 
-        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                finish()
-            }
-        })
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
 
         prepareSurveyView()
     }
 
     override fun onDestroy() {
-        Logger.i(TAG, "Destroy Survey screen")
+        super.onDestroy()
         hideSoftKeyboard()
         surveyView.onDestroyView()
-        super.onDestroy()
+        onBackPressedCallback.remove()
+        Logger.i(TAG, "Destroy Survey screen")
     }
 
     override fun onFinish() {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
@@ -46,7 +46,7 @@ internal class SurveyActivity : AppCompatActivity(), SurveyView.OnFinishListener
 
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                finishAndRemoveTask()
+                finish()
             }
         })
 
@@ -61,11 +61,7 @@ internal class SurveyActivity : AppCompatActivity(), SurveyView.OnFinishListener
     }
 
     override fun onFinish() {
-        // In case the engagement ends, Activity is removed from the device's Recents menu
-        // to avoid app users to accidentally start queueing for another call when they resume
-        // the app from the Recents menu and the app's backstack was empty.
-
-        finishAndRemoveTask()
+        finish()
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyController.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyController.java
@@ -205,6 +205,7 @@ public class SurveyController implements SurveyContract.Controller {
     @Override
     public void onDestroy() {
         this.view = null;
+        resetController();
     }
 
     private void resetController() {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/MessagesNotSeenHandler.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/MessagesNotSeenHandler.java
@@ -104,6 +104,7 @@ public class MessagesNotSeenHandler {
     /**
      * @hide
      */
+    @FunctionalInterface
     public interface MessagesNotSeenHandlerListener {
         void onNewCount(int count);
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.kt
@@ -48,6 +48,7 @@ internal class FloatingVisitorVideoView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        removeView(videoView)
         releaseVideoStream()
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadLayout.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/ChatHeadLayout.kt
@@ -121,8 +121,8 @@ internal class ChatHeadLayout @JvmOverloads constructor(
     }
 
     override fun onDetachedFromWindow() {
-        chatHeadController.onDestroy()
         super.onDetachedFromWindow()
+        chatHeadController.onDestroy()
     }
 
     /**

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ActivityWatcherForChatHeadController.kt
@@ -1,14 +1,13 @@
 package com.glia.widgets.view.head.controller
 
+import android.annotation.SuppressLint
 import com.glia.widgets.GliaWidgets
 import com.glia.widgets.chat.domain.IsFromCallScreenUseCase
 import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
-import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.TAG
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.view.head.ChatHeadContract
 import com.glia.widgets.view.head.ChatHeadLayoutContract
 
@@ -17,8 +16,7 @@ internal class ActivityWatcherForChatHeadController(
     private var applicationChatHeadController: ChatHeadLayoutContract.Controller,
     private val engagementStateUseCase: EngagementStateUseCase,
     private val isFromCallScreenUseCase: IsFromCallScreenUseCase,
-    private val updateFromCallScreenUseCase: UpdateFromCallScreenUseCase,
-    private val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase
+    private val updateFromCallScreenUseCase: UpdateFromCallScreenUseCase
 ) : ActivityWatcherForChatHeadContract.Controller {
 
     private lateinit var watcher: ActivityWatcherForChatHeadContract.Watcher
@@ -27,8 +25,9 @@ internal class ActivityWatcherForChatHeadController(
         this.watcher = watcher
     }
 
+    @SuppressLint("CheckResult")
     override fun init() {
-        engagementStateUseCase().unSafeSubscribe(::handleEngagementState)
+        engagementStateUseCase().subscribe(::handleEngagementState)
     }
 
     private fun handleEngagementState(state: State) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ApplicationChatHeadLayoutController.kt
@@ -1,11 +1,11 @@
 package com.glia.widgets.view.head.controller
 
+import android.annotation.SuppressLint
 import com.glia.androidsdk.Operator
 import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
 import com.glia.widgets.engagement.domain.VisitorMediaUseCase
 import com.glia.widgets.helper.imageUrl
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.internal.chathead.domain.IsDisplayBubbleInsideAppUseCase
 import com.glia.widgets.internal.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.internal.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
@@ -43,9 +43,10 @@ internal class ApplicationChatHeadLayoutController(
         subscribeToEvents()
     }
 
+    @SuppressLint("CheckResult")
     private fun subscribeToEvents() {
         messagesNotSeenHandler.addListener(onUnreadMessagesCountListener)
-        engagementStateUseCase().unSafeSubscribe {
+        engagementStateUseCase().subscribe {
             when (it) {
                 is EngagementState.EngagementEnded,
                 is EngagementState.QueueUnstaffed,
@@ -64,8 +65,8 @@ internal class ApplicationChatHeadLayoutController(
                 }
             }
         }
-        visitorMediaUseCase.onHoldState.unSafeSubscribe(::onHoldChanged)
-        currentOperatorUseCase().unSafeSubscribe(::operatorDataLoaded)
+        visitorMediaUseCase.onHoldState.subscribe(::onHoldChanged)
+        currentOperatorUseCase().subscribe(::operatorDataLoaded)
     }
 
     private fun onEngagementUpdated() {
@@ -90,7 +91,7 @@ internal class ApplicationChatHeadLayoutController(
     override fun onDestroy() {
         chatHeadLayout?.hide()
         chatHeadLayout = null
-        messagesNotSeenHandler.removeListener(onUnreadMessagesCountListener)
+        //The class is singleton, so we need to keep subscription to the `onUnreadMessagesCountListener`
     }
 
     private fun onHoldChanged(isOnHold: Boolean) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/head/controller/ServiceChatHeadController.kt
@@ -1,23 +1,24 @@
 package com.glia.widgets.view.head.controller
 
+import android.annotation.SuppressLint
 import android.view.View
 import com.glia.androidsdk.Operator
+import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
+import com.glia.widgets.engagement.domain.EngagementStateUseCase
+import com.glia.widgets.engagement.domain.VisitorMediaUseCase
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
+import com.glia.widgets.helper.imageUrl
 import com.glia.widgets.internal.chathead.domain.IsDisplayBubbleOutsideAppUseCase
 import com.glia.widgets.internal.chathead.domain.ResolveChatHeadNavigationUseCase
 import com.glia.widgets.internal.chathead.domain.ResolveChatHeadNavigationUseCase.Destinations
-import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
-import com.glia.widgets.engagement.domain.EngagementStateUseCase
-import com.glia.widgets.engagement.domain.EngagementTypeUseCase
-import com.glia.widgets.engagement.domain.VisitorMediaUseCase
-import com.glia.widgets.helper.Logger.d
-import com.glia.widgets.helper.TAG
-import com.glia.widgets.helper.imageUrl
-import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.view.MessagesNotSeenHandler
 import com.glia.widgets.view.head.ChatHeadContract
 import com.glia.widgets.view.head.ChatHeadPosition
 import com.glia.widgets.engagement.State as EngagementState
 
+//This is in fact a singleton
+@SuppressLint("CheckResult")
 internal class ServiceChatHeadController(
     private val isDisplayBubbleOutsideAppUseCase: IsDisplayBubbleOutsideAppUseCase,
     private val resolveChatHeadNavigationUseCase: ResolveChatHeadNavigationUseCase,
@@ -25,8 +26,7 @@ internal class ServiceChatHeadController(
     private var _chatHeadPosition: ChatHeadPosition,
     engagementStateUseCase: EngagementStateUseCase,
     currentOperatorUseCase: CurrentOperatorUseCase,
-    visitorMediaUseCase: VisitorMediaUseCase,
-    private val engagementTypeUseCase: EngagementTypeUseCase
+    visitorMediaUseCase: VisitorMediaUseCase
 ) : ChatHeadContract.Controller {
     private var chatHeadView: ChatHeadContract.View? = null
     private var state = State.ENDED
@@ -46,10 +46,10 @@ internal class ServiceChatHeadController(
     override val chatHeadPosition: ChatHeadPosition get() = _chatHeadPosition
 
     init {
-        engagementStateUseCase().unSafeSubscribe(::handleEngagementState)
-        currentOperatorUseCase().unSafeSubscribe(::operatorDataLoaded)
+        engagementStateUseCase().subscribe(::handleEngagementState)
+        currentOperatorUseCase().subscribe(::operatorDataLoaded)
         messagesNotSeenHandler.addListener(::onUnreadMessageCountChange)
-        visitorMediaUseCase.onHoldState.unSafeSubscribe(::onHoldChanged)
+        visitorMediaUseCase.onHoldState.subscribe(::onHoldChanged)
     }
 
     override fun onResume(view: View?) {
@@ -69,7 +69,7 @@ internal class ServiceChatHeadController(
     }
 
     override fun onApplicationStop() {
-        d(TAG, "onApplicationStop()")
+        Logger.d(TAG, "onApplicationStop()")
         isDisplayBubbleOutsideAppUseCase(null)
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/operator/OperatorRequestActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/operator/OperatorRequestActivityWatcherTest.kt
@@ -5,13 +5,7 @@ import android.CONTEXT_EXTENSIONS_CLASS_PATH
 import android.LOGGER_PATH
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
-import android.targetActivityName
 import android.view.View
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.ActivityResultCallback
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import com.glia.androidsdk.Engagement.MediaType
 import com.glia.androidsdk.comms.MediaUpgradeOffer
@@ -19,7 +13,6 @@ import com.glia.widgets.UiTheme
 import com.glia.widgets.call.CallActivity
 import com.glia.widgets.chat.ChatActivity
 import com.glia.widgets.engagement.domain.MediaUpgradeOfferData
-import com.glia.widgets.helper.DialogHolderActivity
 import com.glia.widgets.helper.GliaActivityManager
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.OneTimeEvent
@@ -43,7 +36,6 @@ import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import io.reactivex.rxjava3.processors.PublishProcessor
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.junit.After
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
@@ -320,58 +312,6 @@ class OperatorRequestActivityWatcherTest {
             verify { controller.failedToOpenOverlayPermissionScreen() }
             confirmVerified(activityLauncher)
         }
-    }
-
-    @Test
-    fun `showOverlayDialog will call onOverlayPermissionRequestAccepted when dialog is accepted`() {
-        mockkObject(Dialogs)
-        fireState<ChatActivity>(
-            controllerState,
-            watcher,
-            OperatorRequestContract.State.ShowOverlayDialog
-        ) { state, activity ->
-            val onAcceptSlot = slot<View.OnClickListener>()
-            val onDeclineSlot = slot<View.OnClickListener>()
-            verify {
-                Dialogs.showOverlayPermissionsDialog(
-                    activity,
-                    any(),
-                    capture(onAcceptSlot),
-                    capture(onDeclineSlot)
-                )
-            }
-            onAcceptSlot.captured.onClick(mockk())
-
-            verify { state.markConsumed() }
-            verify { controller.onOverlayPermissionRequestAccepted(activity) }
-        }
-        unmockkObject(Dialogs)
-    }
-
-    @Test
-    fun `showOverlayDialog will call onOverlayPermissionRequestDeclined when dialog is declined`() {
-        mockkObject(Dialogs)
-        fireState<ChatActivity>(
-            controllerState,
-            watcher,
-            OperatorRequestContract.State.ShowOverlayDialog
-        ) { state, activity ->
-            val onAcceptSlot = slot<View.OnClickListener>()
-            val onDeclineSlot = slot<View.OnClickListener>()
-            verify {
-                Dialogs.showOverlayPermissionsDialog(
-                    activity,
-                    any(),
-                    capture(onAcceptSlot),
-                    capture(onDeclineSlot)
-                )
-            }
-            onDeclineSlot.captured.onClick(mockk())
-
-            verify { state.markConsumed() }
-            verify { controller.onOverlayPermissionRequestDeclined(activity) }
-        }
-        unmockkObject(Dialogs)
     }
 
     private fun mockLogger() {

--- a/widgetssdk/src/test/java/com/glia/widgets/operator/OperatorRequestControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/operator/OperatorRequestControllerTest.kt
@@ -3,27 +3,21 @@ package com.glia.widgets.operator
 import android.COMMON_EXTENSIONS_CLASS_PATH
 import android.LOGGER_PATH
 import android.app.Activity
-import android.content.Intent
-import androidx.activity.result.ActivityResult
 import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.comms.MediaUpgradeOffer
 import com.glia.widgets.chat.ChatActivity
-import com.glia.widgets.internal.dialog.DialogContract
-import com.glia.widgets.internal.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
-import com.glia.widgets.internal.dialog.domain.SetOverlayPermissionRequestDialogShownUseCase
-import com.glia.widgets.internal.dialog.model.DialogState
-import com.glia.widgets.internal.permissions.domain.WithNotificationPermissionUseCase
 import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCase
 import com.glia.widgets.engagement.domain.CheckMediaUpgradePermissionsUseCase
-import com.glia.widgets.engagement.domain.CurrentOperatorUseCase
 import com.glia.widgets.engagement.domain.DeclineMediaUpgradeOfferUseCase
-import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
 import com.glia.widgets.engagement.domain.MediaUpgradeOfferData
 import com.glia.widgets.engagement.domain.OperatorMediaUpgradeOfferUseCase
 import com.glia.widgets.helper.DialogHolderActivity
 import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.OneTimeEvent
 import com.glia.widgets.helper.isAudio
+import com.glia.widgets.internal.dialog.DialogContract
+import com.glia.widgets.internal.dialog.domain.SetOverlayPermissionRequestDialogShownUseCase
+import com.glia.widgets.internal.dialog.model.DialogState
 import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.confirmVerified
@@ -49,13 +43,9 @@ class OperatorRequestControllerTest {
     private lateinit var acceptMediaUpgradeOfferUseCase: AcceptMediaUpgradeOfferUseCase
     private lateinit var declineMediaUpgradeOfferUseCase: DeclineMediaUpgradeOfferUseCase
     private lateinit var checkMediaUpgradePermissionsUseCase: CheckMediaUpgradePermissionsUseCase
-    private lateinit var currentOperatorUseCase: CurrentOperatorUseCase
-    private lateinit var isShowOverlayPermissionRequestDialogUseCase: IsShowOverlayPermissionRequestDialogUseCase
-    private lateinit var isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase
     private lateinit var setOverlayPermissionRequestDialogShownUseCase: SetOverlayPermissionRequestDialogShownUseCase
     private lateinit var dialogController: DialogContract.Controller
     private lateinit var dialogCallbackSlot: CapturingSlot<DialogContract.Controller.Callback>
-    private lateinit var withNotificationPermissionUseCase: WithNotificationPermissionUseCase
 
     private lateinit var controller: OperatorRequestContract.Controller
 
@@ -70,11 +60,7 @@ class OperatorRequestControllerTest {
         }
         declineMediaUpgradeOfferUseCase = mockk(relaxUnitFun = true)
         checkMediaUpgradePermissionsUseCase = mockk(relaxUnitFun = true)
-        currentOperatorUseCase = mockk(relaxUnitFun = true)
-        isShowOverlayPermissionRequestDialogUseCase = mockk(relaxUnitFun = true)
-        isCurrentEngagementCallVisualizerUseCase = mockk(relaxUnitFun = true)
         setOverlayPermissionRequestDialogShownUseCase = mockk(relaxUnitFun = true)
-        withNotificationPermissionUseCase = mockk(relaxUnitFun = true)
         dialogController = mockk(relaxUnitFun = true)
 
         dialogCallbackSlot = slot()
@@ -84,12 +70,8 @@ class OperatorRequestControllerTest {
             acceptMediaUpgradeOfferUseCase,
             declineMediaUpgradeOfferUseCase,
             checkMediaUpgradePermissionsUseCase,
-            currentOperatorUseCase,
-            isShowOverlayPermissionRequestDialogUseCase,
-            isCurrentEngagementCallVisualizerUseCase,
             setOverlayPermissionRequestDialogShownUseCase,
-            dialogController,
-            withNotificationPermissionUseCase
+            dialogController
         )
 
         verify { operatorMediaUpgradeOfferUseCase() }
@@ -169,15 +151,6 @@ class OperatorRequestControllerTest {
         dialogCallbackSlot.captured.emitDialogState(DialogState.None)
 
         state.assertNotComplete().assertValue(OneTimeEvent(OperatorRequestContract.State.DismissAlertDialog))
-    }
-
-    @Test
-    fun `handleDialogCallback will produce ShowOverlayDialog state when CVOverlayPermission dialog state is triggered`() {
-        val state = controller.state.test()
-
-        dialogCallbackSlot.captured.emitDialogState(DialogState.CVOverlayPermission)
-
-        state.assertNotComplete().assertValue(OneTimeEvent(OperatorRequestContract.State.ShowOverlayDialog))
     }
 
     @Test

--- a/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/head/ActivityWatcherForChatHeadTest.kt
@@ -10,7 +10,6 @@ import com.glia.widgets.engagement.EndAction
 import com.glia.widgets.engagement.MediaType
 import com.glia.widgets.engagement.State
 import com.glia.widgets.engagement.domain.EngagementStateUseCase
-import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
 import com.glia.widgets.view.head.controller.ActivityWatcherForChatHeadContract
 import com.glia.widgets.view.head.controller.ActivityWatcherForChatHeadController
 import com.glia.widgets.view.head.controller.ApplicationChatHeadLayoutController
@@ -42,7 +41,6 @@ internal class ActivityWatcherForChatHeadTest {
         Mockito.mock(ApplicationChatHeadLayoutController::class.java)
     private val isFromCallScreenUseCase = Mockito.mock(IsFromCallScreenUseCase::class.java)
     private val updateFromCallScreenUseCase = Mockito.mock(UpdateFromCallScreenUseCase::class.java)
-    private val isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase = mock()
     private val engagementStateUseCase: EngagementStateUseCase = mock {
         on { invoke() } doReturn engagementStateFlowable
     }
@@ -52,8 +50,7 @@ internal class ActivityWatcherForChatHeadTest {
         applicationChatHeadController,
         engagementStateUseCase,
         isFromCallScreenUseCase,
-        updateFromCallScreenUseCase,
-        isCurrentEngagementCallVisualizerUseCase
+        updateFromCallScreenUseCase
     )
     private val activity = Mockito.mock(Activity::class.java)
     private val view = Mockito.mock(View::class.java)
@@ -150,7 +147,6 @@ internal class ActivityWatcherForChatHeadTest {
     private fun mockShouldShowChatHead() {
         val mockView: ChatView = mock()
         whenever(watcher.fetchGliaOrRootView()) doReturn mockView
-        whenever(isCurrentEngagementCallVisualizerUseCase()) doReturn true
         whenever(applicationChatHeadController.shouldShow(any())) doReturn true
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4632

**What was solved?**
- Get rid of `finishAndRemoveTask` calls because we do not run our activities inside separate task.
- For cases, where we do not need to finish a bunch of activities(when engagement ends) call finishAfterTransition to make activity wait until transition ends.

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
