### PR TITLE
Improve survey UI customization

### DIFF
--- a/app/src/main/res/raw/sample_unified_config.json
+++ b/app/src/main/res/raw/sample_unified_config.json
@@ -1345,6 +1345,60 @@
           ]
         }
       },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": [
+            "#FFFFFF"
+          ]
+        }
+      },
       "text": {
         "alignment": "center",
         "background": {
@@ -2080,6 +2134,60 @@
           ]
         }
       },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": [
+            "#2596be"
+          ]
+        }
+      },
       "text": {
         "alignment": "center",
         "background": {
@@ -2464,6 +2572,40 @@
           "type": "fill",
           "value": [
             "#000000"
+          ]
+        }
+      }
+    },
+    "inputDisabled": {
+      "mediaButton": {
+        "tintColor": {
+          "type": "fill",
+          "value": [
+            "#f9d12b"
+          ]
+        }
+      },
+      "placeholder": {
+        "foreground": {
+          "type": "fill",
+          "value": [
+            "#8E8E93"
+          ]
+        }
+      },
+      "sendButton": {
+        "tintColor": {
+          "type": "fill",
+          "value": [
+            "#FFFFFF"
+          ]
+        }
+      },
+      "text": {
+        "foreground": {
+          "type": "fill",
+          "value": [
+            "#4D4D53"
           ]
         }
       }
@@ -3363,6 +3505,12 @@
                 "#444444"
               ]
             }
+          },
+          "loadingTintColor": {
+            "type": "fill",
+            "value": [
+              "#444444"
+            ]
           }
         },
         "dividerColor": {
@@ -3562,6 +3710,25 @@
             "#000000"
           ]
         }
+      },
+      "error": {
+        "alignment": "leading",
+        "background": {
+          "type": "fill",
+          "value": [
+            "#FFFFFF"
+          ]
+        },
+        "font": {
+          "size": 12,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": [
+            "#6b2c6e"
+          ]
+        }
       }
     },
     "booleanQuestion": {
@@ -3601,7 +3768,7 @@
           "foreground": {
             "type": "fill",
             "value": [
-              "#FFFFFF"
+              "#00FF00"
             ]
           }
         },
@@ -3672,6 +3839,25 @@
             "type": "fill",
             "value": [
               "#FFFFFF"
+            ]
+          }
+        },
+        "error": {
+          "alignment": "leading",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "font": {
+            "size": 12,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#6b2c6e"
             ]
           }
         }
@@ -3733,7 +3919,7 @@
           "foreground": {
             "type": "fill",
             "value": [
-              "#FFFFFF"
+              "#00FF00"
             ]
           }
         },
@@ -3806,6 +3992,25 @@
               "#FFFFFF"
             ]
           }
+        },
+        "error": {
+          "alignment": "leading",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "font": {
+            "size": 12,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#6b2c6e"
+            ]
+          }
         }
       },
       "title": {
@@ -3829,26 +4034,29 @@
       }
     },
     "inputQuestion": {
-      "background": {
-        "border": {
-          "type": "fill",
-          "value": [
-            "#FFFFFF"
-          ]
-        },
-        "borderWidth": 4,
-        "color": {
-          "type": "fill",
-          "value": [
-            "#FFFFFF"
-          ]
-        },
-        "cornerRadius": 16
-      },
-      "option": {
+      "inputField": {
         "font": {
           "size": 12,
           "style": "regular"
+        },
+        "placeholder": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#000000"
+            ]
+          },
+          "font": {
+            "size": 20,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#000000"
+            ]
+          }
         },
         "highlightedLayer": {
           "border": {
@@ -3881,7 +4089,7 @@
           "foreground": {
             "type": "fill",
             "value": [
-              "#FFFFFF"
+              "#00FF00"
             ]
           }
         },
@@ -3954,25 +4162,25 @@
               "#FFFFFF"
             ]
           }
-        }
-      },
-      "text": {
-        "alignment": "center",
-        "background": {
-          "type": "fill",
-          "value": [
-            "#000000"
-          ]
         },
-        "font": {
-          "size": 16,
-          "style": "regular"
-        },
-        "foreground": {
-          "type": "fill",
-          "value": [
-            "#000000"
-          ]
+        "error": {
+          "alignment": "leading",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "font": {
+            "size": 12,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#6b2c6e"
+            ]
+          }
         }
       },
       "title": {
@@ -4136,6 +4344,60 @@
               "type": "fill",
               "value": [
                 "#04728c"
+              ]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": [
+                "#FFFFFF"
+              ]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 5
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": [
+                "#FFFFFF"
+              ]
+            },
+            "font": {
+              "size": 16,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": [
+                "#FFFFFF"
+              ]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": [
+              "#2596be"
+            ]
+          }
+        },
+        "endScreenSharingButton": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": [
+                "#FFFFFF"
+              ]
+            },
+            "borderWidth": 2,
+            "color": {
+              "type": "fill",
+              "value": [
+                "#FFFFFF"
               ]
             },
             "cornerRadius": 8
@@ -4599,6 +4861,60 @@
           ]
         }
       },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": [
+            "#FFFFFF"
+          ]
+        }
+      },
       "text": {
         "alignment": "center",
         "background": {
@@ -4919,6 +5235,60 @@
           "type": "fill",
           "value": [
             "#3e95a6"
+          ]
+        }
+      },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": [
+              "#FFFFFF"
+            ]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": [
+            "#FFFFFF"
           ]
         }
       },
@@ -5258,37 +5628,6 @@
               "#444444"
             ]
           }
-        },
-        "loadingTintColor": {
-          "type": "gradient",
-          "value": ["#FF8E45", "#FF7CB9"]
-        },
-        "badge": {
-          "background": {
-            "border": {
-              "type": "fill",
-              "value": [
-                "#fdd42b"
-              ]
-            },
-            "borderWidth": 1,
-            "color": {
-              "type": "fill",
-              "value": [
-                "#04728c"
-              ]
-            }
-          },
-          "font": {
-            "size": 12,
-            "style": "bold"
-          },
-          "fontColor": {
-            "type": "fill",
-            "value": [
-              "#fdd42b"
-            ]
-          }
         }
       },
       "dividerColor": {
@@ -5332,5 +5671,5 @@
       }
     }
   },
-  "isWhiteLabel": true
+  "isWhiteLabel": false
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.survey
 
 import android.graphics.Rect
-import android.os.Build
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
@@ -9,10 +8,9 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
-import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AppCompatActivity
 import com.glia.androidsdk.engagement.Survey
 import com.glia.widgets.R
+import com.glia.widgets.base.FadeTransitionActivity
 import com.glia.widgets.di.Dependencies.controllerFactory
 import com.glia.widgets.helper.ExtraKeys
 import com.glia.widgets.helper.Logger
@@ -31,14 +29,13 @@ import com.glia.widgets.helper.insetsControllerCompat
  *
  * This activity is used to display post-engagement surveys.
  */
-internal class SurveyActivity : AppCompatActivity(), SurveyView.OnFinishListener {
+internal class SurveyActivity : FadeTransitionActivity(), SurveyView.OnFinishListener {
     private val surveyView: SurveyView by lazy { findViewById(R.id.survey_view) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         this.enableEdgeToEdge()
         window.insetsControllerCompat.isAppearanceLightStatusBars = false
 
-        overrideEnterAnimation()
         super.onCreate(savedInstanceState)
 
         Logger.i(TAG, "Create Survey screen")
@@ -87,24 +84,11 @@ internal class SurveyActivity : AppCompatActivity(), SurveyView.OnFinishListener
             val isTappedOutsideSurveyView =
                 x < location[0] || x > location[0] + surveyView.width || y < location[1] || y > location[1] + surveyView.height
             if (isTappedOutsideSurveyView) {
-                // Hide with fade out animation
-                finishActivityWithAnimation(surveyView)
+                finishAndRemoveTask()
                 return true // consume the event
             }
         }
         return false
-    }
-
-    private fun finishActivityWithAnimation(surveyView: View) {
-        surveyView.animate()
-            .alpha(0f)
-            .setDuration(300)
-            .withEndAction {
-                surveyView.visibility = View.GONE
-                surveyView.alpha = 1f // Reset for future use
-                finishAndRemoveTask() // Close Activity
-            }
-            .start()
     }
 
     fun removeFocusWhenTappedOutsideSurveyEditText(event: MotionEvent) {
@@ -141,19 +125,5 @@ internal class SurveyActivity : AppCompatActivity(), SurveyView.OnFinishListener
 
     private fun updateTitle(title: String?) {
         this.title = title
-    }
-
-    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-    private fun overrideAnimations() {
-        overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, android.R.anim.fade_in, 0)
-    }
-
-    private fun overrideEnterAnimation() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            overrideAnimations()
-            return
-        }
-
-        overridePendingTransition(android.R.anim.fade_in, 0)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/BooleanQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/BooleanQuestionViewHolder.kt
@@ -81,11 +81,18 @@ internal class BooleanQuestionViewHolder(
         super.showRequiredError(error)
         yesButton.isError = error
         noButton.isError = error
+        if (error) applyBooleanThemeWithError() else applyBooleanTheme()
+    }
+
+    private fun applyBooleanThemeWithError() {
         applyBooleanTheme()
+        booleanTheme?.surveyOption?.also {
+            requiredError.applyTextTheme(it.error)
+        }
     }
 
     private fun applyBooleanTheme() {
-        booleanTheme?.optionButton?.also {
+        booleanTheme?.surveyOption?.also {
             yesButton.applyOptionButtonTheme(it)
             noButton.applyOptionButtonTheme(it)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/InputQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/InputQuestionViewHolder.kt
@@ -21,9 +21,10 @@ import com.glia.widgets.view.unifiedui.nullSafeMerge
 import com.glia.widgets.view.unifiedui.theme.base.ColorTheme
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
-import com.glia.widgets.view.unifiedui.theme.survey.OptionButtonTheme
+import com.glia.widgets.view.unifiedui.theme.survey.SurveyOptionTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyInputQuestionTheme
 import androidx.core.graphics.toColorInt
+import com.glia.widgets.view.unifiedui.applyHintTheme
 
 internal class InputQuestionViewHolder(
     val binding: SurveyInputQuestionItemBinding,
@@ -34,7 +35,7 @@ internal class InputQuestionViewHolder(
     }
     private val comment: EditText get() = binding.etComment
 
-    private val optionButtonTheme: OptionButtonTheme by lazy {
+    private val surveyOptionTheme: SurveyOptionTheme by lazy {
         createOptionButtonTheme(style.inputQuestion.optionButton)
     }
 
@@ -68,20 +69,19 @@ internal class InputQuestionViewHolder(
         super.showRequiredError(error)
 
         if (error) {
-            comment.applyLayerTheme(optionButtonTheme.highlightedLayer)
-        } else {
-            comment.applyLayerTheme(optionButtonTheme.normalLayer)
+            comment.applyLayerTheme(surveyOptionTheme.highlightedLayer)
+            requiredError.applyTextTheme(surveyOptionTheme.error)
         }
     }
 
-    private fun createOptionButtonTheme(optionButtonConfiguration: OptionButtonConfiguration): OptionButtonTheme {
+    private fun createOptionButtonTheme(optionButtonConfiguration: OptionButtonConfiguration): SurveyOptionTheme {
         val strokeWidth = optionButtonConfiguration.normalLayer.borderWidth.toFloat()
         val normalStrokeColor = optionButtonConfiguration.normalLayer.borderColor.toColorInt()
         val selectedStrokeColor = optionButtonConfiguration.selectedLayer.borderColor.toColorInt()
         val highlightedStrokeColor = optionButtonConfiguration.highlightedLayer.borderColor.toColorInt()
         val backgroundColor = ColorTheme(optionButtonConfiguration.normalLayer.backgroundColor.toColorInt())
 
-        return OptionButtonTheme(
+        return SurveyOptionTheme(
             normalText = TextTheme(),
             normalLayer = LayerTheme(fill = backgroundColor, stroke = normalStrokeColor, borderWidth = strokeWidth),
             selectedText = TextTheme(),
@@ -90,7 +90,7 @@ internal class InputQuestionViewHolder(
             highlightedLayer = LayerTheme(fill = backgroundColor, stroke = highlightedStrokeColor, borderWidth = strokeWidth),
             fontSize = null,
             fontStyle = null
-        ) nullSafeMerge inputTheme?.option
+        ) nullSafeMerge inputTheme?.inputField
 
     }
 
@@ -115,16 +115,17 @@ internal class InputQuestionViewHolder(
             setAnswer(comment.text.toString())
 
             if (hasFocus) {
-                comment.applyTextTheme(inputTheme?.text)
-                comment.applyLayerTheme(optionButtonTheme.selectedLayer)
+                comment.applyTextTheme(inputTheme?.inputField?.selectedText)
+                comment.applyLayerTheme(surveyOptionTheme.selectedLayer)
             } else {
-                comment.applyTextTheme(inputTheme?.text)
-                comment.applyLayerTheme(optionButtonTheme.normalLayer)
+                comment.applyTextTheme(inputTheme?.inputField?.normalText)
+                comment.applyLayerTheme(surveyOptionTheme.normalLayer)
             }
         }
         comment.doAfterTextChanged { setAnswer(it.toString()) }
 
-        comment.applyTextTheme(inputTheme?.text)
-        comment.applyLayerTheme(optionButtonTheme.normalLayer)
+        comment.applyTextTheme(inputTheme?.inputField?.normalText)
+        comment.applyLayerTheme(surveyOptionTheme.normalLayer)
+        surveyOptionTheme.placeholder?.let { comment.applyHintTheme(it) }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/ScaleQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/ScaleQuestionViewHolder.kt
@@ -38,7 +38,7 @@ internal class ScaleQuestionViewHolder(
 
         buttons.forEach {
             it.setStyle(style.scaleQuestion.optionButton)
-            it.applyOptionButtonTheme(questionTheme?.optionButton)
+            it.applyOptionButtonTheme(questionTheme?.surveyOption)
         }
     }
 
@@ -67,7 +67,7 @@ internal class ScaleQuestionViewHolder(
             val button: GliaSurveyOptionButton = buttons[i]
             val isSelected = i + 1 == value
             button.isSelected = isSelected
-            button.applyOptionButtonTheme(questionTheme?.optionButton)
+            button.applyOptionButtonTheme(questionTheme?.surveyOption)
         }
     }
 
@@ -79,7 +79,8 @@ internal class ScaleQuestionViewHolder(
         super.showRequiredError(error)
         buttons.forEach {
             it.isError = error
-            it.applyOptionButtonTheme(questionTheme?.optionButton)
+            it.applyOptionButtonTheme(questionTheme?.surveyOption)
         }
+        if (error) requiredError.applyTextTheme(questionTheme?.surveyOption?.error)
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SingleQuestionViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SingleQuestionViewHolder.kt
@@ -1,7 +1,6 @@
 package com.glia.widgets.survey.viewholder
 
 import android.content.res.ColorStateList
-import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
@@ -47,6 +46,11 @@ internal class SingleQuestionViewHolder(
     override fun onBind(questionItem: QuestionItem, listener: SurveyAdapter.SurveyAdapterListener?) {
         super.onBind(questionItem, listener)
         singleChoice(questionItem)
+    }
+
+    override fun showRequiredError(error: Boolean) {
+        super.showRequiredError(error)
+        if (error) requiredError.applyTextTheme(singleTheme?.error)
     }
 
     private fun singleChoice(item: QuestionItem) {

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SurveyViewHolder.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/viewholder/SurveyViewHolder.kt
@@ -18,7 +18,7 @@ import com.glia.widgets.survey.SurveyController
 internal abstract class SurveyViewHolder(
     itemView: View,
     val title: TextView,
-    private val requiredError: View
+    val requiredError: TextView
 ) : RecyclerView.ViewHolder(itemView),
     SurveyController.AnswerCallback {
     var questionItem: QuestionItem? = null
@@ -26,9 +26,7 @@ internal abstract class SurveyViewHolder(
     private val localeProvider = Dependencies.localeProvider
 
     init {
-        (requiredError as? TextView)?.setLocaleText(
-            R.string.survey_action_validation_error
-        )
+        requiredError.setLocaleText(R.string.survey_action_validation_error)
     }
 
     open fun onBind(questionItem: QuestionItem, listener: SurveyAdapter.SurveyAdapterListener?) {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/UnifiedUiExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/UnifiedUiExtensions.kt
@@ -29,7 +29,7 @@ import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 import com.glia.widgets.view.unifiedui.theme.call.BarButtonStatesTheme
 import com.glia.widgets.view.unifiedui.theme.call.BarButtonStyleTheme
-import com.glia.widgets.view.unifiedui.theme.survey.OptionButtonTheme
+import com.glia.widgets.view.unifiedui.theme.survey.SurveyOptionTheme
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -441,7 +441,7 @@ private fun ImageButton.applyBarButtonStyleTheme(
     colors.clear()
 }
 
-internal fun GliaSurveyOptionButton.applyOptionButtonTheme(theme: OptionButtonTheme?) {
+internal fun GliaSurveyOptionButton.applyOptionButtonTheme(theme: SurveyOptionTheme?) {
     val textTheme: TextTheme?
     val layerTheme: LayerTheme?
     when {

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyBooleanQuestionRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyBooleanQuestionRemoteConfig.kt
@@ -10,10 +10,10 @@ internal data class SurveyBooleanQuestionRemoteConfig(
     val title: TextRemoteConfig?,
 
     @SerializedName("optionButton")
-    val optionButtonRemoteConfig: OptionButtonRemoteConfig?
+    val surveyOptionRemoteConfig: SurveyOptionRemoteConfig?
 ) {
     fun toSurveyBooleanQuestionTheme(): SurveyBooleanQuestionTheme = SurveyBooleanQuestionTheme(
         title = title?.toTextTheme(),
-        optionButton = optionButtonRemoteConfig?.toOptionButtonTheme()
+        surveyOption = surveyOptionRemoteConfig?.toSurveyOptionTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyInputQuestionRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyInputQuestionRemoteConfig.kt
@@ -9,15 +9,12 @@ internal data class SurveyInputQuestionRemoteConfig(
     @SerializedName("title")
     val title: TextRemoteConfig?,
 
-    @SerializedName("option")
-    val option: OptionButtonRemoteConfig?,
+    @SerializedName("inputField")
+    val inputField: SurveyOptionRemoteConfig?,
 
-    @SerializedName("text")
-    val textRemoteConfig: TextRemoteConfig?
 ) {
     fun toSurveyInputQuestionTheme(): SurveyInputQuestionTheme = SurveyInputQuestionTheme(
         title = title?.toTextTheme(),
-        text = textRemoteConfig?.toTextTheme(),
-        option = option?.toOptionButtonTheme()
+        inputField = inputField?.toSurveyOptionTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyOptionRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyOptionRemoteConfig.kt
@@ -3,10 +3,10 @@ package com.glia.widgets.view.unifiedui.config.survey
 import com.glia.widgets.view.unifiedui.config.base.FontRemoteConfig
 import com.glia.widgets.view.unifiedui.config.base.LayerRemoteConfig
 import com.glia.widgets.view.unifiedui.config.base.TextRemoteConfig
-import com.glia.widgets.view.unifiedui.theme.survey.OptionButtonTheme
+import com.glia.widgets.view.unifiedui.theme.survey.SurveyOptionTheme
 import com.google.gson.annotations.SerializedName
 
-internal data class OptionButtonRemoteConfig(
+internal data class SurveyOptionRemoteConfig(
 
     @SerializedName("normalText")
     val normalTextRemoteConfig: TextRemoteConfig?,
@@ -27,9 +27,15 @@ internal data class OptionButtonRemoteConfig(
     val highlightedLayerRemoteConfig: LayerRemoteConfig?,
 
     @SerializedName("font")
-    val fontRemoteConfig: FontRemoteConfig?
+    val fontRemoteConfig: FontRemoteConfig?,
+
+    @SerializedName("placeholder")
+    val placeholderRemoteConfig: TextRemoteConfig?,
+
+    @SerializedName("error")
+    val errorRemoteConfig: TextRemoteConfig?
 ) {
-    fun toOptionButtonTheme(): OptionButtonTheme = OptionButtonTheme(
+    fun toSurveyOptionTheme(): SurveyOptionTheme = SurveyOptionTheme(
         normalText = normalTextRemoteConfig?.toTextTheme(),
         normalLayer = normalLayerRemoteConfig?.toLayerTheme(),
         selectedText = selectedTextRemoteConfig?.toTextTheme(),
@@ -37,6 +43,8 @@ internal data class OptionButtonRemoteConfig(
         highlightedText = highlightedTextRemoteConfig?.toTextTheme(),
         highlightedLayer = highlightedLayerRemoteConfig?.toLayerTheme(),
         fontSize = fontRemoteConfig?.size?.value,
-        fontStyle = fontRemoteConfig?.style?.style
+        fontStyle = fontRemoteConfig?.style?.style,
+        placeholder = placeholderRemoteConfig?.toTextTheme(),
+        error = errorRemoteConfig?.toTextTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyScaleQuestionRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveyScaleQuestionRemoteConfig.kt
@@ -10,10 +10,10 @@ internal data class SurveyScaleQuestionRemoteConfig(
     val title: TextRemoteConfig?,
 
     @SerializedName("optionButton")
-    val optionButtonRemoteConfig: OptionButtonRemoteConfig?
+    val surveyOptionRemoteConfig: SurveyOptionRemoteConfig?
 ) {
     fun toSurveyScaleQuestionTheme() = SurveyScaleQuestionTheme(
         title = title?.toTextTheme(),
-        optionButton = optionButtonRemoteConfig?.toOptionButtonTheme()
+        surveyOption = surveyOptionRemoteConfig?.toSurveyOptionTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveySingleQuestionRemoteConfig.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/config/survey/SurveySingleQuestionRemoteConfig.kt
@@ -14,11 +14,15 @@ internal data class SurveySingleQuestionRemoteConfig(
     val tintColor: ColorLayerRemoteConfig?,
 
     @SerializedName("option")
-    val option: TextRemoteConfig?
+    val option: TextRemoteConfig?,
+
+    @SerializedName("error")
+    val errorRemoteConfig: TextRemoteConfig?
 ) {
     fun toSurveySingleQuestionTheme(): SurveySingleQuestionTheme = SurveySingleQuestionTheme(
         title = title?.toTextTheme(),
         tintColor = tintColor?.toColorTheme(),
-        option = option?.toTextTheme()
+        option = option?.toTextTheme(),
+        error = errorRemoteConfig?.toTextTheme()
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Survey.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Survey.kt
@@ -6,7 +6,7 @@ import android.graphics.Color
 import com.glia.widgets.view.unifiedui.composeIfAtLeastOneNotNull
 import com.glia.widgets.view.unifiedui.theme.ColorPallet
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
-import com.glia.widgets.view.unifiedui.theme.survey.OptionButtonTheme
+import com.glia.widgets.view.unifiedui.theme.survey.SurveyOptionTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyBooleanQuestionTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyInputQuestionTheme
 import com.glia.widgets.view.unifiedui.theme.survey.SurveyScaleQuestionTheme
@@ -24,11 +24,11 @@ internal fun SurveyTheme(pallet: ColorPallet): SurveyTheme =
         cancelButton = NegativeDefaultButtonTheme(pallet),
         booleanQuestion = SurveyBooleanQuestionTheme(
             title = BaseDarkColorTextTheme(pallet),
-            SurveyOptionButtonTheme(pallet)
+            SurveyOptionTheme(pallet)
         ),
         scaleQuestion = SurveyScaleQuestionTheme(
             title = BaseDarkColorTextTheme(pallet),
-            SurveyOptionButtonTheme(pallet)
+            SurveyOptionTheme(pallet)
         ),
         singleQuestion = SurveySingleQuestionTheme(
             title = BaseDarkColorTextTheme(pallet),
@@ -37,15 +37,14 @@ internal fun SurveyTheme(pallet: ColorPallet): SurveyTheme =
         ),
         inputQuestion = SurveyInputQuestionTheme(
             title = BaseDarkColorTextTheme(pallet),
-            option = SurveyOptionButtonTheme(pallet),
-            text = BaseDarkColorTextTheme(pallet)
+            inputField = SurveyInputOptionTheme(pallet),
         )
     )
 
 /**
- * Default theme for Survey option button
+ * Default theme for Survey option
  */
-internal fun SurveyOptionButtonTheme(pallet: ColorPallet): OptionButtonTheme? = pallet.run {
+internal fun SurveyOptionTheme(pallet: ColorPallet): SurveyOptionTheme? = pallet.run {
     composeIfAtLeastOneNotNull(
         darkColorTheme,
         normalColorTheme,
@@ -53,7 +52,7 @@ internal fun SurveyOptionButtonTheme(pallet: ColorPallet): OptionButtonTheme? = 
         lightColorTheme,
         negativeColorTheme
     ) {
-        OptionButtonTheme(
+        SurveyOptionTheme(
             normalText = BaseDarkColorTextTheme(this),
             normalLayer = LayerTheme(
                 fill = lightColorTheme,
@@ -61,6 +60,34 @@ internal fun SurveyOptionButtonTheme(pallet: ColorPallet): OptionButtonTheme? = 
             ),
             selectedText = BaseLightColorTextTheme(this),
             selectedLayer = LayerTheme(fill = primaryColorTheme, stroke = Color.TRANSPARENT),
+            highlightedText = BaseNegativeColorTextTheme(this),
+            highlightedLayer = LayerTheme(
+                fill = lightColorTheme,
+                stroke = negativeColorTheme?.primaryColor
+            )
+        )
+    }
+}
+
+/**
+ * Default theme for Survey input option
+ */
+internal fun SurveyInputOptionTheme(pallet: ColorPallet): SurveyOptionTheme? = pallet.run {
+    composeIfAtLeastOneNotNull(
+        darkColorTheme,
+        normalColorTheme,
+        primaryColorTheme,
+        lightColorTheme,
+        negativeColorTheme
+    ) {
+        SurveyOptionTheme(
+            normalText = BaseDarkColorTextTheme(this),
+            normalLayer = LayerTheme(
+                fill = lightColorTheme,
+                stroke = normalColorTheme?.primaryColor
+            ),
+            selectedText = BaseDarkColorTextTheme(this),
+            selectedLayer = LayerTheme(fill = lightColorTheme, stroke = normalColorTheme?.primaryColor),
             highlightedText = BaseNegativeColorTextTheme(this),
             highlightedLayer = LayerTheme(
                 fill = lightColorTheme,

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyBooleanQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyBooleanQuestionTheme.kt
@@ -6,10 +6,10 @@ import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class SurveyBooleanQuestionTheme(
     val title: TextTheme? = null,
-    val optionButton: OptionButtonTheme? = null
+    val surveyOption: SurveyOptionTheme? = null
 ) : Mergeable<SurveyBooleanQuestionTheme> {
     override fun merge(other: SurveyBooleanQuestionTheme): SurveyBooleanQuestionTheme = SurveyBooleanQuestionTheme(
         title = title merge other.title,
-        optionButton = optionButton merge other.optionButton
+        surveyOption = surveyOption merge other.surveyOption
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyInputQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyInputQuestionTheme.kt
@@ -6,12 +6,10 @@ import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class SurveyInputQuestionTheme(
     val title: TextTheme? = null,
-    val option: OptionButtonTheme? = null,
-    val text: TextTheme? = null
+    val inputField: SurveyOptionTheme? = null,
 ) : Mergeable<SurveyInputQuestionTheme> {
     override fun merge(other: SurveyInputQuestionTheme): SurveyInputQuestionTheme = SurveyInputQuestionTheme(
         title = title merge other.title,
-        option = option merge other.option,
-        text = text merge other.text
+        inputField = inputField merge other.inputField
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyOptionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyOptionTheme.kt
@@ -5,7 +5,7 @@ import com.glia.widgets.view.unifiedui.merge
 import com.glia.widgets.view.unifiedui.theme.base.LayerTheme
 import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
-internal data class OptionButtonTheme(
+internal data class SurveyOptionTheme(
     val normalText: TextTheme? = null,
     val normalLayer: LayerTheme? = null,
     val selectedText: TextTheme? = null,
@@ -13,9 +13,11 @@ internal data class OptionButtonTheme(
     val highlightedText: TextTheme? = null,
     val highlightedLayer: LayerTheme? = null,
     val fontSize: Float? = null,
-    val fontStyle: Int? = null
-) : Mergeable<OptionButtonTheme> {
-    override fun merge(other: OptionButtonTheme): OptionButtonTheme = OptionButtonTheme(
+    val fontStyle: Int? = null,
+    val placeholder: TextTheme? = null,
+    val error: TextTheme? = null,
+) : Mergeable<SurveyOptionTheme> {
+    override fun merge(other: SurveyOptionTheme): SurveyOptionTheme = SurveyOptionTheme(
         normalText = normalText merge other.normalText,
         normalLayer = normalLayer merge other.normalLayer,
         selectedText = selectedText merge other.selectedText,
@@ -23,6 +25,8 @@ internal data class OptionButtonTheme(
         highlightedText = highlightedText merge other.highlightedText,
         highlightedLayer = highlightedLayer merge other.highlightedLayer,
         fontSize = fontSize merge other.fontSize,
-        fontStyle = fontStyle merge other.fontStyle
+        fontStyle = fontStyle merge other.fontStyle,
+        placeholder = placeholder merge other.placeholder,
+        error = error merge other.error
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyScaleQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveyScaleQuestionTheme.kt
@@ -6,10 +6,10 @@ import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 
 internal data class SurveyScaleQuestionTheme(
     val title: TextTheme? = null,
-    val optionButton: OptionButtonTheme? = null
+    val surveyOption: SurveyOptionTheme? = null
 ) : Mergeable<SurveyScaleQuestionTheme> {
     override fun merge(other: SurveyScaleQuestionTheme): SurveyScaleQuestionTheme = SurveyScaleQuestionTheme(
         title = title merge other.title,
-        optionButton = optionButton merge other.optionButton
+        surveyOption = surveyOption merge other.surveyOption
     )
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveySingleQuestionTheme.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/survey/SurveySingleQuestionTheme.kt
@@ -8,11 +8,13 @@ import com.glia.widgets.view.unifiedui.theme.base.TextTheme
 internal data class SurveySingleQuestionTheme(
     val title: TextTheme? = null,
     val tintColor: ColorTheme? = null,
-    val option: TextTheme? = null
+    val option: TextTheme? = null,
+    val error: TextTheme? = null
 ) : Mergeable<SurveySingleQuestionTheme> {
     override fun merge(other: SurveySingleQuestionTheme): SurveySingleQuestionTheme = SurveySingleQuestionTheme(
         title = title merge other.title,
         tintColor = tintColor merge other.tintColor,
-        option = option merge other.option
+        option = option merge other.option,
+        error = error merge other.error
     )
 }

--- a/widgetssdk/src/main/res/drawable/shadow_down_bg.xml
+++ b/widgetssdk/src/main/res/drawable/shadow_down_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:startColor="@android:color/transparent"
+        android:endColor="#11000000"
+        android:angle="90" />
+</shape>

--- a/widgetssdk/src/main/res/layout/survey_view.xml
+++ b/widgetssdk/src/main/res/layout/survey_view.xml
@@ -52,7 +52,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="4dp"
                     android:layout_gravity="top"
-                    android:background="@drawable/shadow_up_bg"
+                    android:background="@drawable/shadow_down_bg"
                     android:elevation="4dp"/>
 
                 <View


### PR DESCRIPTION
[[Android] The survey input field applies styles differently](https://glia.atlassian.net/browse/MOB-4610)

**What was solved?**
Improve survey UI customization
- apply more Unified UI styles (based on https://github.com/salemove/mobile-sdk-unified/pull/44)
- align survey styles between Android and iOS SDKs

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
<img width="253" height="542" alt="Screenshot 2025-09-05 at 15 03 51" src="https://github.com/user-attachments/assets/f41f0949-aea3-4eac-b335-f4c42a5759d7" />
<img width="253" height="542" alt="Screenshot 2025-09-05 at 15 04 02" src="https://github.com/user-attachments/assets/483ea0cc-b651-4feb-af5b-33defb129859" />
<img width="253" height="542" alt="Screenshot 2025-09-05 at 15 04 12" src="https://github.com/user-attachments/assets/a2ec5f6e-6a05-48aa-ad0b-6f2cc2f18684" />
<img width="253" height="542" alt="Screenshot 2025-09-05 at 15 04 17" src="https://github.com/user-attachments/assets/aa805eb4-2533-4544-a18c-405703ad5039" />
<img width="253" height="542" alt="Screenshot 2025-09-05 at 16 54 48" src="https://github.com/user-attachments/assets/9de5a33d-22e8-44ab-9dfa-ac8495619905" />


https://github.com/user-attachments/assets/6cc35399-3aeb-4f32-b11f-25387f2699fb

