### PR TITLE
Fix inconsistent operator name behavior

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -43,6 +43,7 @@ import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.TimeCounter
 import com.glia.widgets.helper.TimeCounter.FormattedTimerStatusListener
 import com.glia.widgets.helper.TimeCounter.RawTimerStatusListener
+import com.glia.widgets.helper.formattedName
 import com.glia.widgets.helper.imageUrl
 import com.glia.widgets.helper.unSafeSubscribe
 import com.glia.widgets.view.MessagesNotSeenHandler
@@ -552,13 +553,13 @@ internal class CallController(
     }
 
     private fun onOperatorConnected(operator: Operator) {
-        val name = operator.name
+        val name = operator.formattedName
         val imageUrl = operator.imageUrl
         operatorConnected(name, imageUrl)
     }
 
     private fun onOperatorChanged(operator: Operator) {
-        val name = operator.name
+        val name = operator.formattedName
         val imageUrl = operator.imageUrl
         operatorChanged(name, imageUrl)
     }


### PR DESCRIPTION




**Jira issue:**
https://glia.atlassian.net/browse/MOB-4629

**What was solved?**
Both the chat screen and the call screen should display only the operator's first name, rather than their full name. However, for some reason, on the Android only, and only in call screen, it was displaying the full name.

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
