### PR TITLE
Remove unnecessary finishAfterTransition calls and improve survey animation

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/base/FadeTransitionActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/base/FadeTransitionActivity.kt
@@ -50,8 +50,13 @@ open class FadeTransitionActivity : AppCompatActivity() {
     }
 
     override fun finishAfterTransition() {
-        overrideAnimationApi33()
         super.finishAfterTransition()
+        overrideAnimationApi33()
+    }
+
+    override fun finish() {
+        super.finish()
+        overrideAnimationApi33()
     }
 
     override fun startActivity(intent: Intent) {

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallActivity.kt
@@ -33,10 +33,10 @@ internal class CallActivity : FadeTransitionActivity() {
     private val activityLauncher: ActivityLauncher by lazy { Dependencies.activityLauncher }
     private var callView: CallView by Delegates.notNull()
 
-    private var onBackClickedListener: CallView.OnBackClickedListener? = CallView.OnBackClickedListener { this.finishAfterTransition() }
+    private var onBackClickedListener: CallView.OnBackClickedListener? = CallView.OnBackClickedListener { this.finish() }
     private var onNavigateToChatListener: OnNavigateToChatListener? = OnNavigateToChatListener {
         navigateToChat()
-        finishAfterTransition()
+        finish()
     }
     private val onNavigateToWebBrowserListener = OnNavigateToWebBrowserListener(this::navigateToWebBrowser)
 
@@ -49,16 +49,16 @@ internal class CallActivity : FadeTransitionActivity() {
         val isUpgradeToCall = intent.getBooleanExtra(ExtraKeys.IS_UPGRADE_TO_CALL, false)
 
         if (!callView.shouldShowMediaEngagementView(isUpgradeToCall)) {
-            finishAfterTransition()
+            finish()
             return
         }
 
         callView.setOnTitleUpdatedListener(this::setTitle)
         onBackClickedListener?.also(callView::setOnBackClickedListener)
 
-        callView.setOnEndListener { this.finishAfterTransition() }
+        callView.setOnEndListener { this.finish() }
 
-        callView.setOnMinimizeListener { this.finishAfterTransition() }
+        callView.setOnMinimizeListener { this.finish() }
         onNavigateToChatListener?.also(callView::setOnNavigateToChatListener)
         callView.setOnNavigateToWebBrowserListener(onNavigateToWebBrowserListener)
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt
@@ -48,16 +48,16 @@ internal class ChatActivity : FadeTransitionActivity() {
         chatView.setOnTitleUpdatedListener(this::setTitle)
 
         if (!chatView.shouldShow()) {
-            finishAfterTransition()
+            finish()
             return
         }
 
-        chatView.setOnBackClickedListener(::finishAfterTransition)
+        chatView.setOnBackClickedListener(::finish)
         chatView.setOnBackToCallListener(::backToCallScreen)
 
-        chatView.setOnEndListener(::finishAfterTransition)
+        chatView.setOnEndListener(::finish)
 
-        chatView.setOnMinimizeListener(::finishAfterTransition)
+        chatView.setOnMinimizeListener(::finish)
 
         val intention = intent.getEnumExtra<Intention>(ExtraKeys.OPEN_CHAT_INTENTION)
 
@@ -89,6 +89,6 @@ internal class ChatActivity : FadeTransitionActivity() {
 
     private fun backToCallScreen() {
         activityLauncher.launchCall(this, null, false)
-        finishAfterTransition()
+        finish()
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterActivity.kt
@@ -54,7 +54,7 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             messageCenterView.onSystemBack()
-            finishAfterTransition()
+            finish()
         }
     }
 
@@ -107,12 +107,12 @@ internal class MessageCenterActivity : FadeTransitionActivity(),
 
     override fun navigateToMessaging() {
         Dependencies.activityLauncher.launchChat(this, Intention.SC_CHAT)
-        finishAfterTransition()
+        finish()
     }
 
     override fun returnToLiveChat() {
         Dependencies.activityLauncher.launchChat(this, Intention.RETURN_TO_CHAT)
-        finishAfterTransition()
+        finish()
     }
 
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/survey/SurveyActivity.kt
@@ -4,6 +4,7 @@ import android.graphics.Rect
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
+import android.view.animation.AnimationUtils
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.activity.OnBackPressedCallback
@@ -50,6 +51,8 @@ internal class SurveyActivity : FadeTransitionActivity(), SurveyView.OnFinishLis
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
 
         prepareSurveyView()
+        val slideUpAnim = AnimationUtils.loadAnimation(this, R.anim.slide_up)
+        surveyView.startAnimation(slideUpAnim)
     }
 
     override fun onDestroy() {
@@ -62,6 +65,12 @@ internal class SurveyActivity : FadeTransitionActivity(), SurveyView.OnFinishLis
 
     override fun onFinish() {
         finish()
+    }
+
+    override fun finish() {
+        super.finish()
+        val slideDownAnim = AnimationUtils.loadAnimation(this, R.anim.slide_down)
+        surveyView.startAnimation(slideDownAnim)
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
@@ -83,7 +92,7 @@ internal class SurveyActivity : FadeTransitionActivity(), SurveyView.OnFinishLis
             val isTappedOutsideSurveyView =
                 x < location[0] || x > location[0] + surveyView.width || y < location[1] || y > location[1] + surveyView.height
             if (isTappedOutsideSurveyView) {
-                finishAndRemoveTask()
+                finish()
                 return true // consume the event
             }
         }


### PR DESCRIPTION


**Jira issue:**
https://glia.atlassian.net/browse/MOB-4657
**What was solved?**

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
