### PR TITLE
Disable item animator for chat RecyclerView to avoid crashes.

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -348,6 +348,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
     }
 
     override fun emitItems(items: List<ChatItem>) {
+        binding.chatRecyclerView.itemAnimator?.endAnimations()
         adapter.submitList(items)
     }
 
@@ -607,7 +608,6 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         binding.chatRecyclerView.layoutManager = LinearLayoutManager(this.context)
         adapter.registerAdapterDataObserver(dataObserver)
         binding.chatRecyclerView.adapter = adapter
-        binding.chatRecyclerView.itemAnimator = null
         binding.chatRecyclerView.addOnScrollListener(onScrollListener)
         uploadAttachmentAdapter = UploadAttachmentAdapter()
         uploadAttachmentAdapter.setItemCallback { controller?.onRemoveAttachment(it) }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -8,7 +8,6 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
-import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
@@ -537,11 +536,11 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
             showToolbar(LocaleString(R.string.message_center_header))
             binding.appBarView.hideBackButton()
             binding.appBarView.showXButton()
-            binding.secureConversationsBottomBanner.visibility = View.VISIBLE
+            binding.secureConversationsBottomBanner.visibility = VISIBLE
         } else {
             showToolbar(LocaleString(R.string.engagement_chat_title))
             binding.appBarView.showBackButton()
-            binding.secureConversationsBottomBanner.visibility = View.GONE
+            binding.secureConversationsBottomBanner.visibility = GONE
         }
     }
 
@@ -608,6 +607,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
         binding.chatRecyclerView.layoutManager = LinearLayoutManager(this.context)
         adapter.registerAdapterDataObserver(dataObserver)
         binding.chatRecyclerView.adapter = adapter
+        binding.chatRecyclerView.itemAnimator = null
         binding.chatRecyclerView.addOnScrollListener(onScrollListener)
         uploadAttachmentAdapter = UploadAttachmentAdapter()
         uploadAttachmentAdapter.setItemCallback { controller?.onRemoveAttachment(it) }
@@ -963,7 +963,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
                 override fun onTransitionEnd(transition: Transition) {
                     binding.blockingCurtain.apply {
                         if (isInvisible) {
-                            visibility = FrameLayout.GONE
+                            visibility = GONE
                         }
                     }
                 }
@@ -976,7 +976,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
             if (shouldShowDropDown) {
                 clear(R.id.sc_top_banner_options, ConstraintSet.BOTTOM)
                 setVisibility(R.id.blocking_curtain, VISIBLE)
-                setVisibility(R.id.sc_top_banner_divider, View.INVISIBLE)
+                setVisibility(R.id.sc_top_banner_divider, INVISIBLE)
                 setRotation(R.id.sc_top_banner_icon, 180f)
             } else {
                 connect(R.id.sc_top_banner_options, ConstraintSet.BOTTOM, R.id.header_barrier, ConstraintSet.BOTTOM)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4595

**What was solved?**
This PR resolves a `RecyclerView` crash `(IllegalArgumentException: Tmp detached view)`. The crash occurred due to a race condition between item animations and data updates. The fix disables the `ItemAnimator` by setting it to `null`, which prevents the conflicting state and stabilizes the view.

**Additional info:**
**Disabled Animation**
[Screen_recording_20250916_095703.webm](https://github.com/user-attachments/assets/b44bf417-ba49-47e8-ac31-b01116390a75)

**Enabled Animation**
[Screen_recording_20250916_095938.webm](https://github.com/user-attachments/assets/edaf9c4e-d720-4500-b01e-5be00d900269)

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
