### PR TITLE
Always check remote repo for SNAPSHOTs updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,9 @@ test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.re
 test-robolectric = { module = "org.robolectric:robolectric", version.ref = "testRobolectricVersion" }
 test-mockk-android = { module = "io.mockk:mockk-android", version.ref = "testMockkVersion" }
 
+glia-core = { module = "com.glia:android-sdk" }
+glia-telemetry = { module = "com.glia:android-telemetry" }
+
 debug-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "debugLeakcanaryVersion" }
 
 [plugins]

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -126,13 +126,24 @@ dependencies {
   implementation libs.java.rxandroid
   implementation libs.java.rxjava
 
-  releaseApi "com.glia:android-sdk:$gliaSdkVersion"
-  debugApi "com.glia:android-sdk:${coreSdkDebugVersion(gliaSdkVersion)}"
+  releaseApi "${libs.glia.core.get().module}:$gliaSdkVersion"
+
+  def coreDebugVersion = coreSdkDebugVersion(gliaSdkVersion)
+  debugApi ("${libs.glia.core.get().module}:$coreDebugVersion") {
+    if (coreDebugVersion.endsWith("-SNAPSHOT")) {
+      changing = true
+    }
+  }
 
   // includeBuild doesn't work with custom build types, use local maven version instead
-  snapshotApi "com.glia:android-sdk:${coreSdkSnapshotVersion(gliaSdkVersion)}"
+  snapshotApi "${libs.glia.core.get().module}:${coreSdkSnapshotVersion(gliaSdkVersion)}"
 
-  implementation "com.glia:android-telemetry:${telemetrySdkVersion(telemetryLibVersion)}"
+  def telemetryVersion = telemetrySdkVersion(telemetryLibVersion)
+  implementation ("${libs.glia.telemetry.get().module}:$telemetryVersion") {
+    if (telemetryVersion.endsWith("-SNAPSHOT")) {
+      changing = true
+    }
+  }
 
   implementation libs.media.audioswitch
   implementation libs.media.lottie
@@ -159,6 +170,11 @@ dependencies {
 
   lintChecks project(':lint_checker')
   debugImplementation libs.debug.leakcanary
+}
+
+configurations.configureEach {
+  // Always check remote repo for changing modules (SNAPSHOTs)
+  resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
 
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"


### PR DESCRIPTION
**What was solved?**
Always check remote repo for SNAPSHOTs updates

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
