### PR TITLE
Fix Telemetry attribute for Entry Widget item click event

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/entrywidget/EntryWidgetController.kt
@@ -228,7 +228,7 @@ internal class EntryWidgetController @JvmOverloads constructor(
         if (entryWidgetItem != null) {
             GliaLogger.i(LogEvents.ENTRY_WIDGET_ITEM_CLICKED) {
                 put(EventAttribute.ViewType, viewType.toTelemetryViewType() ?: "N/A")
-                put(EventAttribute.ButtonName, entryWidgetItem)
+                put(EventAttribute.EngagementType, entryWidgetItem)
             }
         } else {
             val buttonName = itemType.toTelemetryButtonName()


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-4762

**What was solved?**
Fix Telemetry attribute for Entry Widget item click event

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
