### PR TITLE
ADA hints for confirmation dialog buttons

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ViewExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ViewExtensions.kt
@@ -205,6 +205,17 @@ internal fun View.setAccessibilityHint(hint: String) {
     })
 }
 
+internal fun View.setLocaleAccessibilityHint(locale: LocaleString) {
+    registerLocaleListener(locale.stringKey, *locale.values.toTypedArray()) { upToDateTranslation ->
+        ViewCompat.setAccessibilityDelegate(this, object : AccessibilityDelegateCompat() {
+            override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+                super.onInitializeAccessibilityNodeInfo(host, info)
+                info.hintText = upToDateTranslation
+            }
+        })
+    }
+}
+
 internal fun View.setLocaleContentDescription(@StringRes stringKey: Int, vararg values: StringKeyPair) {
     registerLocaleListener(stringKey, *values) { upToDateTranslation ->
         contentDescription = upToDateTranslation

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -165,7 +165,9 @@ internal object Dialogs {
                 dialogName = DialogNames.LEAVE_ENGAGEMENT_CONFIRMATION,
                 buttonName = ButtonNames.NEGATIVE,
                 clickListener = negativeButtonClickListener
-            )
+            ),
+            positiveButtonAccessibilityHint = LocaleString(R.string.engagement_end_confirm_accessibility_hint),
+            negativeButtonAccessibilityHint = LocaleString(R.string.engagement_end_deny_accessibility_hint),
         )
 
         return dialogService.showDialog(
@@ -198,8 +200,9 @@ internal object Dialogs {
                 dialogName = DialogNames.LEAVE_QUEUE_CONFIRMATION,
                 buttonName = ButtonNames.NEGATIVE,
                 clickListener = negativeButtonClickListener
-            )
-
+            ),
+            positiveButtonAccessibilityHint = LocaleString(R.string.engagement_queue_leave_confirm_accessibility_hint),
+            negativeButtonAccessibilityHint = LocaleString(R.string.engagement_queue_leave_deny_accessibility_hint),
         )
 
         return dialogService.showDialog(
@@ -267,7 +270,9 @@ internal object Dialogs {
                 dialogName = DialogNames.LIVE_OBSERVATION_CONFIRMATION,
                 buttonName = ButtonNames.ENGAGEMENT_CONFIRMATION_LINK_2,
                 clickListener = { linkClickListener(links.link2) }
-            )
+            ),
+            positiveButtonAccessibilityHint = LocaleString(R.string.engagement_confirm_allow_accessibility_hint),
+            negativeButtonAccessibilityHint = LocaleString(R.string.engagement_confirm_cancel_accessibility_hint),
         )
 
         return dialogService.showDialog(
@@ -410,7 +415,9 @@ internal object Dialogs {
                 dialogName = DialogNames.LEAVE_SECURE_CONVERSATIONS_CONFIRMATION,
                 buttonName = ButtonNames.NEGATIVE,
                 clickListener = onLeave
-            )
+            ),
+            positiveButtonAccessibilityHint = LocaleString(R.string.secure_messaging_chat_leave_current_conversation_stay_accessibility_hint),
+            negativeButtonAccessibilityHint = LocaleString(R.string.secure_messaging_chat_leave_current_conversation_leave_accessibility_hint),
         )
 
         return dialogService.showDialog(
@@ -443,7 +450,9 @@ internal object Dialogs {
                 dialogName = DialogNames.ALLOW_PUSH_NOTIFICATION,
                 buttonName = ButtonNames.NEGATIVE,
                 clickListener = negativeButtonClickListener
-            )
+            ),
+            positiveButtonAccessibilityHint = LocaleString(R.string.push_notifications_alert_button_positive_accessibility_hint),
+            negativeButtonAccessibilityHint = LocaleString(R.string.push_notifications_alert_button_negative_accessibility_hint),
         )
 
         return dialogService.showDialog(

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
@@ -16,6 +16,8 @@ internal sealed interface DialogPayload {
         val poweredByText: LocaleString,
         val positiveButtonClickListener: View.OnClickListener,
         val negativeButtonClickListener: View.OnClickListener,
+        val positiveButtonAccessibilityHint: LocaleString? = null,
+        val negativeButtonAccessibilityHint: LocaleString? = null,
     ) : DialogPayload
 
     data class Confirmation(
@@ -30,6 +32,8 @@ internal sealed interface DialogPayload {
         val link2: Link,
         val link1ClickListener: View.OnClickListener,
         val link2ClickListener: View.OnClickListener,
+        val positiveButtonAccessibilityHint: LocaleString? = null,
+        val negativeButtonAccessibilityHint: LocaleString? = null,
     ) : DialogPayload
 
     data class Upgrade(

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewInflater.kt
@@ -6,6 +6,7 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.viewbinding.ViewBinding
 import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.setLocaleAccessibilityHint
 import com.glia.widgets.helper.setText
 import com.glia.widgets.internal.dialog.model.Link
 import com.glia.widgets.locale.LocaleString
@@ -55,13 +56,15 @@ internal abstract class DialogViewInflater<T : DialogViewBinding<out ViewBinding
         text: LocaleString,
         btnTheme: ButtonTheme?,
         typeface: Typeface?,
-        onClickListener: View.OnClickListener
+        onClickListener: View.OnClickListener,
+        accessibilityHint: LocaleString? = null
     ) {
         btn.apply {
             setText(text)
             applyButtonTheme(btnTheme)
             setupTypeface(this, typeface)
             setOnClickListener(onClickListener)
+            accessibilityHint?.let { setLocaleAccessibilityHint(it) }
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/confirmation/ConfirmationDialogViewInflater.kt
@@ -51,14 +51,16 @@ internal open class DefaultConfirmationDialogViewInflater<T : DefaultConfirmatio
             payload.positiveButtonText,
             alertTheme?.positiveButton,
             configuration.properties.typeface,
-            payload.positiveButtonClickListener
+            payload.positiveButtonClickListener,
+            payload.positiveButtonAccessibilityHint
         )
         setupButton(
             binding.negativeButton,
             payload.negativeButtonText,
             alertTheme?.negativeButton,
             configuration.properties.typeface,
-            payload.negativeButtonClickListener
+            payload.negativeButtonClickListener,
+            payload.negativeButtonAccessibilityHint
         )
         binding.additionalButtonsSpace.isGone = binding.link1Button.isVisible || binding.link2Button.isVisible
     }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/OptionDialogViewInflater.kt
@@ -35,14 +35,16 @@ internal open class DefaultOptionDialogViewInflater<T : DefaultOptionDialogViewB
             payload.positiveButtonText,
             alertTheme?.positiveButton,
             configuration.properties.typeface,
-            payload.positiveButtonClickListener
+            payload.positiveButtonClickListener,
+            payload.positiveButtonAccessibilityHint
         )
         setupButton(
             binding.negativeButton,
             payload.negativeButtonText,
             alertTheme?.negativeButton,
             configuration.properties.typeface,
-            payload.negativeButtonClickListener
+            payload.negativeButtonClickListener,
+            payload.negativeButtonAccessibilityHint
         )
     }
 }
@@ -70,14 +72,16 @@ internal open class DefaultReversedOptionDialogViewInflater<T : DefaultReversedO
             payload.positiveButtonText,
             alertTheme?.negativeButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
             configuration.properties.typeface,
-            payload.positiveButtonClickListener
+            payload.positiveButtonClickListener,
+            payload.positiveButtonAccessibilityHint
         )
         setupButton(
             binding.negativeButton,
             payload.negativeButtonText,
             alertTheme?.positiveButton,// Since buttons are reversed, the positive button is actually GliaNegativeButton and should use NegativeButton theming
             configuration.properties.typeface,
-            payload.negativeButtonClickListener
+            payload.negativeButtonClickListener,
+            payload.negativeButtonAccessibilityHint
         )
     }
 }
@@ -129,14 +133,16 @@ internal open class DefaultOptionWithNegativeNeutralDialogViewInflater<T : Defau
             payload.positiveButtonText,
             alertTheme?.positiveButton,
             configuration.properties.typeface,
-            payload.positiveButtonClickListener
+            payload.positiveButtonClickListener,
+            payload.positiveButtonAccessibilityHint
         )
         setupButton(
             binding.positiveButton,      // Reversed button positions: positive button takes all properties of negative
             payload.negativeButtonText,
             alertTheme?.negativeNeutralButton, // Not 'negative' theme but from 'negative neutral' theme
             configuration.properties.typeface,
-            payload.negativeButtonClickListener
+            payload.negativeButtonClickListener,
+            payload.negativeButtonAccessibilityHint
         )
     }
 }

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -38,12 +38,16 @@
     <string name="chat_media_upgrade_video_system_message">@string/glia_chat_upgraded_to_video_call</string>
     <string name="engagement_end_confirmation_header">@string/glia_dialog_end_engagement_title</string>
     <string name="engagement_end_message">@string/glia_dialog_end_engagement_message</string>
+    <string name="engagement_end_deny_accessibility_hint">Returns to the engagement.</string>
+    <string name="engagement_end_confirm_accessibility_hint">Ends the current engagement.</string>
     <string name="engagement_ended_header">@string/glia_dialog_engagement_ended_title</string>
     <string name="engagement_ended_message">@string/glia_dialog_engagement_ended_message</string>
     <string name="engagement_queue_closed_header">@string/glia_dialog_operators_unavailable_title</string>
     <string name="engagement_queue_closed_message">@string/glia_dialog_operators_unavailable_message</string>
     <string name="engagement_queue_leave_header">@string/glia_dialog_leave_queue_title</string>
     <string name="engagement_queue_leave_message">@string/glia_dialog_leave_queue_message</string>
+    <string name="engagement_queue_leave_deny_accessibility_hint">Keeps your place in the queue.</string>
+    <string name="engagement_queue_leave_confirm_accessibility_hint">Leaves the queue and cancels the engagement.</string>
     <string name="error_general">@string/glia_dialog_unexpected_error_title</string>
     <string name="message_center_unavailable_title">@string/glia_dialog_message_center_unavailable_title</string>
     <string name="message_center_unavailable_message">@string/glia_dialog_message_center_unavailable_message</string>
@@ -165,6 +169,8 @@
     <string name="secure_messaging_chat_leave_current_conversation_message">@string/message_center_leaving_conversation_message</string>
     <string name="secure_messaging_chat_leave_current_conversation_button_positive">@string/message_center_leaving_conversation_positive_button</string>
     <string name="secure_messaging_chat_leave_current_conversation_button_negative">@string/message_center_leaving_conversation_negative_button</string>
+    <string name="secure_messaging_chat_leave_current_conversation_stay_accessibility_hint">Stays in the current conversation.</string>
+    <string name="secure_messaging_chat_leave_current_conversation_leave_accessibility_hint">Leaves the current conversation and starts a new one.</string>
 
     <!-- General -->
     <string name="general_refresh">@string/glia_visitor_code_refresh_button</string>
@@ -205,6 +211,8 @@
     <string name="engagement_confirm_link1_url" />
     <string name="engagement_confirm_link2_text">Privacy Policies</string>
     <string name="engagement_confirm_link2_url" />
+    <string name="engagement_confirm_cancel_accessibility_hint">Dismisses the dialog and returns you to the previous screen. The engagement will not start.</string>
+    <string name="engagement_confirm_allow_accessibility_hint">Allows the operator to view your screen and starts the engagement.</string>
     <string name="live_observation_indicator_message">Your app screen is visible to the operator.</string>
     <string name="engagement_incoming_request_timed_out_message">The engagement request is timed out.</string>
 
@@ -241,6 +249,8 @@
     <string name="push_notifications_alert_message">Allow push notifications so we can message you (and return your messages) in the app.</string>
     <string name="push_notifications_alert_button_positive">Allow</string>
     <string name="push_notifications_alert_button_negative">Not right now</string>
+    <string name="push_notifications_alert_button_negative_accessibility_hint">Dismisses the prompt without enabling notifications.</string>
+    <string name="push_notifications_alert_button_positive_accessibility_hint">Allows the app to send push notifications.</string>
 
 <!--    Real-Time connection quality-->
     <string name="snackbar_no_connection_message">No connection. Trying to reconnect.</string>


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5146

**What was solved?**
Add TalkBack accessibility hints to confirmation dialog buttons

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
