### PR TITLE
[ADA] for the Chat Message EditText

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt
@@ -70,6 +70,7 @@ import com.glia.widgets.helper.hideKeyboard
 import com.glia.widgets.helper.insetsController
 import com.glia.widgets.helper.layoutInflater
 import com.glia.widgets.helper.requireActivity
+import com.glia.widgets.helper.setAccessibilityHint
 import com.glia.widgets.helper.setLocaleContentDescription
 import com.glia.widgets.helper.setLocaleHint
 import com.glia.widgets.helper.setLocaleText
@@ -713,6 +714,7 @@ internal class ChatView(context: Context, attrs: AttributeSet?, defStyleAttr: In
     }
 
     private fun setupViewActions() {
+        binding.chatEditText.setAccessibilityHint(R.string.general_message)
         binding.chatEditText.addTextChangedListener(textWatcher)
         binding.sendButton.setOnClickListener {
             val message = binding.chatEditText.text.toString().trim { it <= ' ' }

--- a/widgetssdk/src/main/java/com/glia/widgets/helper/ViewExtensions.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/helper/ViewExtensions.kt
@@ -205,6 +205,12 @@ internal fun View.setAccessibilityHint(hint: String) {
     })
 }
 
+internal fun View.setAccessibilityHint(@StringRes stringKey: Int, vararg values: StringKeyPair) {
+    registerLocaleListener(stringKey, *values) { upToDateTranslation ->
+        setAccessibilityHint(upToDateTranslation)
+    }
+}
+
 internal fun View.setLocaleAccessibilityHint(locale: LocaleString) {
     registerLocaleListener(locale.stringKey, *locale.values.toTypedArray()) { upToDateTranslation ->
         ViewCompat.setAccessibilityDelegate(this, object : AccessibilityDelegateCompat() {

--- a/widgetssdk/src/test/java/com/glia/widgets/survey/viewholder/SurveyViewHolderTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/survey/viewholder/SurveyViewHolderTest.kt
@@ -60,7 +60,7 @@ class SurveyViewHolderTest {
 
         every { requiredErrorView.setLocaleText(any<Int>()) } just Runs
         every { titleView.setLocaleContentDescription(any<Int>()) } just Runs
-        every { titleView.setAccessibilityHint(any()) } just Runs
+        every { titleView.setAccessibilityHint(any<Int>()) } just Runs
 
         listener = mockk(relaxed = true)
     }
@@ -129,7 +129,7 @@ class SurveyViewHolderTest {
 
         viewHolder.onBind(questionItem, listener)
 
-        verify(exactly = 0) { titleView.setAccessibilityHint(any()) }
+        verify(exactly = 0) { titleView.setAccessibilityHint(any<Int>()) }
     }
 
     @Test


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5049

**What was solved?**
Add accessibility identifier to the Chat Message EditText.
Now TalkBack pronounces: Editing. [Your input]. Edit Box **"Message"**.

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
