### PR TITLE
Stay In Touch single button dialog

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/push/notifications/RequestPushNotificationDuringAuthenticationUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/push/notifications/RequestPushNotificationDuringAuthenticationUseCase.kt
@@ -51,11 +51,6 @@ internal class RequestPushNotificationDuringAuthenticationUseCaseImpl(
                         "Visitor's decision for intermediate push notification permission is 'allowed'"
                     )
                     requestNotificationPermission()
-                }, onCancel = {
-                    Logger.i(
-                        TAG,
-                        "Visitor's decision for intermediate push notification permission is 'declined'"
-                    )
                 })
             }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/Dialogs.kt
@@ -432,33 +432,25 @@ internal object Dialogs {
     fun showPushNotificationsPermissionDialog(
         context: Context,
         uiTheme: UiTheme,
-        positiveButtonClickListener: View.OnClickListener,
-        negativeButtonClickListener: View.OnClickListener
+        positiveButtonClickListener: View.OnClickListener
     ): AlertDialog {
-        val payload = DialogPayload.Option(
+        val payload = DialogPayload.SingleButtonOption(
             title = LocaleString(R.string.push_notifications_alert_title),
-            message = LocaleString(R.string.push_notifications_alert_message),
-            positiveButtonText = LocaleString(R.string.push_notifications_alert_button_positive),
-            negativeButtonText = LocaleString(R.string.push_notifications_alert_button_negative),
+            message = LocaleString(R.string.android_push_notifications_alert_message),
+            positiveButtonText = LocaleString(R.string.android_push_notifications_alert_button_positive),
             poweredByText = poweredByText,
             positiveButtonClickListener = handleDialogButtonClick(
                 dialogName = DialogNames.ALLOW_PUSH_NOTIFICATION,
                 buttonName = ButtonNames.POSITIVE,
                 clickListener = positiveButtonClickListener
             ),
-            negativeButtonClickListener = handleDialogButtonClick(
-                dialogName = DialogNames.ALLOW_PUSH_NOTIFICATION,
-                buttonName = ButtonNames.NEGATIVE,
-                clickListener = negativeButtonClickListener
-            ),
-            positiveButtonAccessibilityHint = LocaleString(R.string.push_notifications_alert_button_positive_accessibility_hint),
-            negativeButtonAccessibilityHint = LocaleString(R.string.push_notifications_alert_button_negative_accessibility_hint),
+            positiveButtonAccessibilityHint = LocaleString(R.string.android_push_notifications_alert_button_positive_accessibility_hint)
         )
 
         return dialogService.showDialog(
             context = context,
             theme = uiTheme,
-            type = DialogType.Option(payload),
+            type = DialogType.SingleButtonOption(payload),
             onShow = logDialogShown(DialogNames.ALLOW_PUSH_NOTIFICATION),
             onDismiss = logDialogDismissed(DialogNames.ALLOW_PUSH_NOTIFICATION)
         )

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/UiComponentsActivityWatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/UiComponentsActivityWatcher.kt
@@ -43,8 +43,7 @@ internal class UiComponentsActivityWatcher(
             state is UiComponentsDispatcher.State.NotificationPermissionDialog -> showPermissionsDialog(
                 activity,
                 event::markConsumed,
-                state.onAllow,
-                state.onCancel
+                state.onAllow
             )
 
             state is UiComponentsDispatcher.State.ShowSnackBar -> event.consume {
@@ -60,7 +59,7 @@ internal class UiComponentsActivityWatcher(
     private fun showSnackbar(activity: Activity, messageResId: Int) =
         SnackBarDelegateFactory(activity, messageResId, localeProvider, themeManager.theme).createDelegate().show()
 
-    private fun showPermissionsDialog(activity: Activity, consumeCallback: () -> Unit, onAllow: () -> Unit, onCancel: () -> Unit) {
+    private fun showPermissionsDialog(activity: Activity, consumeCallback: () -> Unit, onAllow: () -> Unit) {
         showAlertDialogWithStyledContext(activity) { context, uiTheme ->
             Dialogs.showPushNotificationsPermissionDialog(
                 context = context,
@@ -69,13 +68,8 @@ internal class UiComponentsActivityWatcher(
                     dismissDialogAndFinishHolderActivity()
                     consumeCallback()
                     onAllow()
-                },
-                negativeButtonClickListener = {
-                    dismissDialogAndFinishHolderActivity()
-                    consumeCallback()
-                    onCancel()
-                })
-
+                }
+            )
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/UiComponentsDispatcher.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/UiComponentsDispatcher.kt
@@ -13,7 +13,7 @@ internal interface UiComponentsDispatcher {
     val state: Flowable<OneTimeEvent<State>>
 
     // Dialog
-    fun showNotificationPermissionDialog(onAllow: () -> Unit, onCancel: () -> Unit = {})
+    fun showNotificationPermissionDialog(onAllow: () -> Unit)
     fun dismissDialog()
 
     // Snackbar
@@ -24,7 +24,7 @@ internal interface UiComponentsDispatcher {
 
     sealed interface State {
         data object DismissDialog : State
-        data class NotificationPermissionDialog(val onAllow: () -> Unit, val onCancel: () -> Unit) : State
+        data class NotificationPermissionDialog(val onAllow: () -> Unit) : State
         data class ShowSnackBar(@param:StringRes val messageResId: Int) : State
         data class LaunchChatScreen(val intention: Intention) : State
     }
@@ -34,8 +34,8 @@ internal class UiComponentsDispatcherImpl : UiComponentsDispatcher {
     private val _state: PublishProcessor<UiComponentsDispatcher.State> = PublishProcessor.create()
     override val state: Flowable<OneTimeEvent<UiComponentsDispatcher.State>> = _state.asOneTimeStateFlowable()
 
-    override fun showNotificationPermissionDialog(onAllow: () -> Unit, onCancel: () -> Unit) =
-        _state.onNext(NotificationPermissionDialog(onAllow, onCancel))
+    override fun showNotificationPermissionDialog(onAllow: () -> Unit) =
+        _state.onNext(NotificationPermissionDialog(onAllow))
 
     override fun dismissDialog() = _state.onNext(DismissDialog)
 

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogPayload.kt
@@ -54,6 +54,15 @@ internal sealed interface DialogPayload {
         val buttonClickListener: View.OnClickListener,
     ) : DialogPayload
 
+    data class SingleButtonOption(
+        override val title: LocaleString,
+        val message: LocaleString,
+        val positiveButtonText: LocaleString,
+        val poweredByText: LocaleString,
+        val positiveButtonClickListener: View.OnClickListener,
+        val positiveButtonAccessibilityHint: LocaleString? = null,
+    ) : DialogPayload
+
     data class AlertDialog(
         override val title: LocaleString,
         val message: LocaleString,

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogType.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogType.kt
@@ -7,5 +7,6 @@ internal sealed class DialogType(payload: DialogPayload) {
     data class Confirmation(val payload: DialogPayload.Confirmation) : DialogType(payload)
     data class Upgrade(val payload: DialogPayload.Upgrade) : DialogType(payload)
     data class OperatorEndedEngagement(val payload: DialogPayload.OperatorEndedEngagement) : DialogType(payload)
+    data class SingleButtonOption(val payload: DialogPayload.SingleButtonOption) : DialogType(payload)
     data class AlertDialog(val payload: DialogPayload.AlertDialog) : DialogType(payload)
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/base/DialogViewFactory.kt
@@ -8,6 +8,7 @@ import com.glia.widgets.view.dialog.alert.AlertDialogViewInflater
 import com.glia.widgets.view.dialog.confirmation.ConfirmationDialogViewInflater
 import com.glia.widgets.view.dialog.confirmation.VerticalConfirmationDialogViewInflater
 import com.glia.widgets.view.dialog.operatorendedengagement.OperatorEndedEngagementDialogViewInflater
+import com.glia.widgets.view.dialog.singlebuttonoption.SingleButtonOptionDialogViewInflater
 import com.glia.widgets.view.dialog.option.OptionDialogViewInflater
 import com.glia.widgets.view.dialog.option.OptionWithNegativeNeutralDialogViewInflater
 import com.glia.widgets.view.dialog.option.ReversedOptionDialogViewInflater
@@ -45,6 +46,7 @@ internal class DialogViewFactory(context: Context, uiTheme: UiTheme, unifiedThem
         type is DialogType.Confirmation -> ConfirmationDialogViewInflater(layoutInflater, configuration, type.payload)
         type is DialogType.Upgrade && isVerticalAxis -> VerticalUpgradeDialogViewInflater(layoutInflater, configuration, type.payload)
         type is DialogType.Upgrade -> UpgradeDialogViewInflater(layoutInflater, configuration, type.payload)
+        type is DialogType.SingleButtonOption -> SingleButtonOptionDialogViewInflater(layoutInflater, configuration, type.payload)
         type is DialogType.OperatorEndedEngagement -> OperatorEndedEngagementDialogViewInflater(layoutInflater, configuration, type.payload)
         type is DialogType.AlertDialog -> AlertDialogViewInflater(layoutInflater, configuration, type.payload)
         else -> throw UnsupportedOperationException("Dialog of unsupported -> $type type was requested")

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/SingleButtonOptionDialogViewBinding.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/option/SingleButtonOptionDialogViewBinding.kt
@@ -1,0 +1,24 @@
+package com.glia.widgets.view.dialog.option
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import com.glia.widgets.databinding.SingleButtonOptionDialogBinding
+import com.glia.widgets.view.button.GliaPositiveButton
+import com.glia.widgets.view.dialog.base.DialogViewBinding
+
+internal class SingleButtonOptionDialogViewBinding(layoutInflater: LayoutInflater) : BaseOptionDialogViewBinding<SingleButtonOptionDialogBinding> {
+    override val binding: SingleButtonOptionDialogBinding = SingleButtonOptionDialogBinding.inflate(layoutInflater)
+    override val root: View
+        get() = binding.root
+    val positiveButton: GliaPositiveButton
+        get() = binding.acceptButton
+    override val logoContainer: View
+        get() = binding.logoContainer
+    override val poweredByTv: TextView
+        get() = binding.poweredByText
+    override val titleTv: TextView
+        get() = binding.dialogTitleView
+    override val messageTv: TextView
+        get() = binding.dialogMessageView
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/view/dialog/singlebuttonoption/SingleButtonOptionDialogViewInflater.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/dialog/singlebuttonoption/SingleButtonOptionDialogViewInflater.kt
@@ -1,0 +1,36 @@
+package com.glia.widgets.view.dialog.singlebuttonoption
+
+import android.view.LayoutInflater
+import com.glia.widgets.helper.setText
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogViewInflater
+import com.glia.widgets.view.dialog.option.SingleButtonOptionDialogViewBinding
+import com.glia.widgets.view.unifiedui.applyWhiteLabel
+import com.glia.widgets.view.unifiedui.theme.AlertDialogConfiguration
+
+internal class SingleButtonOptionDialogViewInflater(
+    layoutInflater: LayoutInflater,
+    themeWrapper: AlertDialogConfiguration,
+    payload: DialogPayload.SingleButtonOption
+) : DialogViewInflater<SingleButtonOptionDialogViewBinding, DialogPayload.SingleButtonOption>(
+    SingleButtonOptionDialogViewBinding(layoutInflater), themeWrapper, payload
+) {
+    override fun setup(
+        binding: SingleButtonOptionDialogViewBinding,
+        configuration: AlertDialogConfiguration,
+        payload: DialogPayload.SingleButtonOption
+    ) {
+        val theme = configuration.theme
+        binding.logoContainer.applyWhiteLabel(theme.isWhiteLabel)
+        binding.poweredByTv.setText(payload.poweredByText)
+        setupText(binding.messageTv, payload.message, theme.alertTheme?.message, configuration.properties.typeface)
+        setupButton(
+            binding.positiveButton,
+            payload.positiveButtonText,
+            theme.alertTheme?.positiveButton,
+            configuration.properties.typeface,
+            payload.positiveButtonClickListener,
+            payload.positiveButtonAccessibilityHint
+        )
+    }
+}

--- a/widgetssdk/src/main/res/layout/single_button_option_dialog.xml
+++ b/widgetssdk/src/main/res/layout/single_button_option_dialog.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/start_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/glia_x_large" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/end_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/glia_x_large" />
+
+    <TextView
+        android:id="@+id/dialog_title_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_x_large"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceHeadline2"
+        app:layout_constraintEnd_toStartOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginTop="@dimen/glia_x_large"
+        tools:textSize="20sp" />
+
+    <TextView
+        android:id="@+id/dialog_message_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_large"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceBody1"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/dialog_title_view"
+        app:layout_goneMarginTop="@dimen/glia_large" />
+
+    <com.glia.widgets.view.button.GliaPositiveButton
+        android:id="@+id/accept_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_large_x_large"
+        android:insetTop="0dp"
+        android:insetBottom="0dp"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/dialog_message_view" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/logo_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_large_x_large"
+        app:layout_constraintTop_toBottomOf="@+id/accept_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/powered_by_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/Application.Glia.Caption"
+            android:textColor="@color/glia_branding_color"
+            android:layout_marginEnd="@dimen/glia_small"
+            android:paddingBottom="@dimen/glia_small"
+            android:importantForAccessibility="no"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintEnd_toStartOf="@id/logo_view"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <ImageView
+            android:id="@+id/logo_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_glia_logo"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/powered_by_text"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <Space
+        android:id="@+id/space"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/glia_large_x_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/logo_container"
+        app:layout_constraintVertical_bias="0"
+        app:layout_goneMarginTop="@dimen/glia_x_large" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/widgetssdk/src/main/res/values/new_strings.xml
+++ b/widgetssdk/src/main/res/values/new_strings.xml
@@ -247,10 +247,9 @@
     <!--    Push Notifications-->
     <string name="push_notifications_alert_title">Stay In Touch</string>
     <string name="push_notifications_alert_message">Allow push notifications so we can message you (and return your messages) in the app.</string>
-    <string name="push_notifications_alert_button_positive">Allow</string>
-    <string name="push_notifications_alert_button_negative">Not right now</string>
-    <string name="push_notifications_alert_button_negative_accessibility_hint">Dismisses the prompt without enabling notifications.</string>
-    <string name="push_notifications_alert_button_positive_accessibility_hint">Allows the app to send push notifications.</string>
+    <string name="android_push_notifications_alert_button_positive">Continue</string>
+    <string name="android_push_notifications_alert_button_positive_accessibility_hint">Opens the system permission request.</string>
+    <string name="android_push_notifications_alert_message">To receive and reply to messages in the app, please enable push notifications in the next step.</string>
 
 <!--    Real-Time connection quality-->
     <string name="snackbar_no_connection_message">No connection. Trying to reconnect.</string>

--- a/widgetssdk/src/test/java/com/glia/widgets/push/notifications/RequestPushNotificationDuringAuthenticationUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/push/notifications/RequestPushNotificationDuringAuthenticationUseCaseTest.kt
@@ -47,7 +47,7 @@ class RequestPushNotificationDuringAuthenticationUseCaseTest {
 
         useCase()
 
-        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any(), any()) }
+        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any()) }
         verify(exactly = 0) { permissionManager.handlePermissions(any(), any(), any(), any(), any()) }
     }
 
@@ -59,7 +59,7 @@ class RequestPushNotificationDuringAuthenticationUseCaseTest {
 
         useCase()
 
-        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any(), any()) }
+        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any()) }
         verify(exactly = 0) { permissionManager.handlePermissions(any(), any(), any(), any(), any()) }
     }
 
@@ -70,7 +70,7 @@ class RequestPushNotificationDuringAuthenticationUseCaseTest {
 
         useCase()
 
-        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any(), any()) }
+        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any()) }
         verify(exactly = 0) { permissionManager.handlePermissions(any(), any(), any(), any(), any()) }
     }
 
@@ -82,14 +82,13 @@ class RequestPushNotificationDuringAuthenticationUseCaseTest {
 
         useCase()
 
-        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any(), any()) }
+        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any()) }
         verify(exactly = 0) { permissionManager.handlePermissions(any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `invoke shows intermediate dialog when shouldShowPermissionRationale is true`() {
         val onAllowSlot = slot<() -> Unit>()
-        val onCancelSlot = slot<() -> Unit>()
 
         every { configurationManager.suppressPushNotificationsPermissionRequestDuringAuthentication } returns false
         every { isPushNotificationsSetUpUseCase() } returns true
@@ -99,10 +98,7 @@ class RequestPushNotificationDuringAuthenticationUseCaseTest {
         useCase()
 
         verify { permissionManager.shouldShowPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) }
-        verify { uiComponentsDispatcher.showNotificationPermissionDialog(capture(onAllowSlot), capture(onCancelSlot)) }
-
-        onCancelSlot.captured.invoke()
-        verify(exactly = 0) { permissionManager.handlePermissions(any(), any(), any(), any(), any()) }
+        verify { uiComponentsDispatcher.showNotificationPermissionDialog(capture(onAllowSlot)) }
 
         onAllowSlot.captured.invoke()
         verify { permissionManager.handlePermissions(any(), eq(listOf(Manifest.permission.POST_NOTIFICATIONS)), any(), any(), any()) }
@@ -118,7 +114,7 @@ class RequestPushNotificationDuringAuthenticationUseCaseTest {
         useCase()
 
         verify { permissionManager.shouldShowPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) }
-        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any(), any()) }
+        verify(exactly = 0) { uiComponentsDispatcher.showNotificationPermissionDialog(any()) }
         verify { permissionManager.handlePermissions(any(), eq(listOf(Manifest.permission.POST_NOTIFICATIONS)), any(), any(), any()) }
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/view/dialog/UiComponentsActivityWatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/dialog/UiComponentsActivityWatcherTest.kt
@@ -95,7 +95,7 @@ internal class UiComponentsActivityWatcherTest {
     fun `handleState will skip when activity is finishing`() {
         val activity = mockkActivity(isFinishing = true)
         watcher.onActivityResumed(activity)
-        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog({ }, {}))
+        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog({ }))
         stateFlowable.onNext(event)
 
         verify { event.consumed }
@@ -110,7 +110,7 @@ internal class UiComponentsActivityWatcherTest {
         watcher.onActivityResumed(activity)
         resumedActivity.values().forEach { it.clear() }
 
-        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog({ }, {}))
+        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog({ }))
         stateFlowable.onNext(event)
 
         verify { event.consumed }
@@ -123,26 +123,20 @@ internal class UiComponentsActivityWatcherTest {
 
         val dialog: AlertDialog = mockk(relaxed = true)
         val positiveButtonSlot = slot<View.OnClickListener>()
-        val negativeButtonSlot = slot<View.OnClickListener>()
-        every { Dialogs.showPushNotificationsPermissionDialog(any(), any(), any(), any()) } returns dialog
+        every { Dialogs.showPushNotificationsPermissionDialog(any(), any(), any()) } returns dialog
 
         watcher.onActivityResumed(activity)
         val onAllow = mockk<() -> Unit>(relaxed = true)
-        val onCancel = mockk<() -> Unit>(relaxed = true)
-        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog(onAllow, onCancel))
+        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog(onAllow))
         stateFlowable.onNext(event)
 
         verify(exactly = 0) { Logger.d(any(), match(skippingMatcher)) }
-        verify { Dialogs.showPushNotificationsPermissionDialog(any(), any(), capture(positiveButtonSlot), capture(negativeButtonSlot)) }
+        verify { Dialogs.showPushNotificationsPermissionDialog(any(), any(), capture(positiveButtonSlot)) }
 
         positiveButtonSlot.captured.onClick(mockk(relaxed = true))
         verify { event.markConsumed() }
         verify { dialog.dismiss() }
         verify { onAllow() }
-
-        negativeButtonSlot.captured.onClick(mockk(relaxed = true))
-        verify { event.markConsumed() }
-        verify { onCancel() }
     }
 
     @Test
@@ -150,16 +144,15 @@ internal class UiComponentsActivityWatcherTest {
         val activity = mockkActivity()
 
         val dialog: AlertDialog = mockk(relaxed = true)
-        every { Dialogs.showPushNotificationsPermissionDialog(any(), any(), any(), any()) } returns dialog
+        every { Dialogs.showPushNotificationsPermissionDialog(any(), any(), any()) } returns dialog
 
         watcher.onActivityResumed(activity)
         val onAllow = mockk<() -> Unit>(relaxed = true)
-        val onCancel = mockk<() -> Unit>(relaxed = true)
-        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog(onAllow, onCancel))
+        val event = mockkOneTimeEvent(UiComponentsDispatcher.State.NotificationPermissionDialog(onAllow))
         stateFlowable.onNext(event)
 
         verify(exactly = 0) { Logger.d(any(), match(skippingMatcher)) }
-        verify { Dialogs.showPushNotificationsPermissionDialog(any(), any(), any(), any()) }
+        verify { Dialogs.showPushNotificationsPermissionDialog(any(), any(), any()) }
 
         val dismissEvent = mockkOneTimeEvent(UiComponentsDispatcher.State.DismissDialog)
         every { dismissEvent.consume(captureLambda()) } answers {
@@ -168,7 +161,6 @@ internal class UiComponentsActivityWatcherTest {
         stateFlowable.onNext(dismissEvent)
         verify { dialog.dismiss() }
         verify(exactly = 0) { onAllow() }
-        verify(exactly = 0) { onCancel() }
     }
 
     @Test

--- a/widgetssdk/src/test/java/com/glia/widgets/view/dialog/UiComponentsDispatcherTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/dialog/UiComponentsDispatcherTest.kt
@@ -33,17 +33,13 @@ internal class UiComponentsDispatcherTest {
         state.assertEmpty().assertNotComplete()
 
         val onAllow: () -> Unit = mockk(relaxed = true)
-        val onCancel: () -> Unit = mockk(relaxed = true)
 
-        dispatcher.showNotificationPermissionDialog(onAllow, onCancel)
+        dispatcher.showNotificationPermissionDialog(onAllow)
 
         val currentState = state.values().last().value as NotificationPermissionDialog
 
         currentState.onAllow.invoke()
         verify { onAllow() }
-
-        currentState.onCancel.invoke()
-        verify { onCancel() }
     }
 
     @Test

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_SingleButtonOptionDialogTest_withDefaultTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_SingleButtonOptionDialogTest_withDefaultTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e34d62182d3d4225d6cfe67ad039c7f0a24e3f4ce7d231b143685e33db9eccc9
+size 38419

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_SingleButtonOptionDialogTest_withGlobalColors.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_SingleButtonOptionDialogTest_withGlobalColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:239df56db013485f221d0011c945ba3bf4c7cadf65fd5873c8ff5da4d473ef88
+size 27584

--- a/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_SingleButtonOptionDialogTest_withUnifiedTheme.png
+++ b/widgetssdk/src/test/snapshots/images/com.glia.widgets.dialog_SingleButtonOptionDialogTest_withUnifiedTheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75a43f5b8f4cae028451318c021ab22fdca9f0598df750d8c8e21309d6d1277a
+size 27907

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/SingleButtonOptionDialogTest.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/dialog/SingleButtonOptionDialogTest.kt
@@ -1,0 +1,40 @@
+package com.glia.widgets.dialog
+
+import com.glia.widgets.SnapshotTest
+import com.glia.widgets.snapshotutils.SnapshotDialog
+import com.glia.widgets.view.dialog.base.DialogPayload
+import com.glia.widgets.view.dialog.base.DialogType
+import org.junit.Test
+
+internal class SingleButtonOptionDialogTest : SnapshotTest(
+    renderingMode = fullWidthRenderMode
+), SnapshotDialog {
+
+    private val dialogType: DialogType = DialogType.SingleButtonOption(
+        DialogPayload.SingleButtonOption(
+            title = title,
+            message = message,
+            positiveButtonText = positiveButtonText,
+            poweredByText = poweredByText,
+            positiveButtonClickListener = {}
+        )
+    )
+
+    @Test
+    fun withDefaultTheme() {
+        val view = inflateView(context = context, dialogType = dialogType)
+        snapshot(view)
+    }
+
+    @Test
+    fun withUnifiedTheme() {
+        val view = inflateView(context = context, unifiedTheme(), dialogType = dialogType)
+        snapshot(view)
+    }
+
+    @Test
+    fun withGlobalColors() {
+        val view = inflateView(context = context, unifiedThemeWithGlobalColors(), dialogType = dialogType)
+        snapshot(view)
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5156

**What was solved?**
Replace two-button push notification (Stay In Touch) dialog with single Continue button

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
See new snapshots