### PR TITLE
Add deep-research CLAUDE.md hierarchy for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+<!-- deep-research: completed 2026-04-24 | v: deep-research/1.7 | generator: glia/deep-research -->
+# GliaWidgets Android SDK
+> Drop-in AAR (`com.glia:android-widgets`) providing chat, audio/video call, secure conversations, call visualizer, entry widget, and survey UI — layered on top of Glia Core SDK.
+
+## Architecture
+
+```
+Integrator App
+  -> GliaWidgets.init(GliaWidgetsConfig) -> Dependencies.onSdkInit()
+  -> GliaWidgets.getEngagementLauncher(queueIds)
+EngagementLauncher -> ActivityLauncherImpl -> ChatActivity | CallActivity | MessageCenterActivity | ...
+Activities inflate Views (ChatView, CallView, ...) which self-wire Controllers via Dependencies.controllerFactory
+Controllers -> UseCases (operator fun invoke()) -> EngagementRepository (BehaviorProcessor<State>)
+  -> GliaCore interface -> Glia.* (Core SDK — all networking, auth, data)
+```
+
+MVP pattern: View + Controller + Contract interfaces. `ChatController` and `CallController` are retained across Activity recreation via `ControllerFactory` (not ViewModel). DI is a single `Dependencies` Kotlin object — no Dagger/Hilt.
+
+## Context Loading Order
+
+1. `.claude/CLAUDE.md` — authoritative rules: logging, PII, MVP cleanup, no singletons, theme mandate
+2. `widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt` — public API surface, init chain, engagement launcher
+3. `widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt` — full DI container, init order, mock seams
+4. `widgetssdk/src/main/java/com/glia/widgets/InitializationProvider.kt` — ContentProvider auto-init; why integrators call nothing manually
+5. `widgetssdk/src/main/java/com/glia/widgets/engagement/States.kt` — sealed state machine that is the single source of truth for all engagement state
+6. `widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/` — three-stage theme pipeline; required reading before any UI change
+7. `gradle/libs.versions.toml` — version pins with rationale comments
+
+## Where to Look
+
+| Task | Location |
+|------|----------|
+| Public API changes | `GliaWidgets.kt`, `GliaWidgetsConfig.kt` |
+| Add/change DI wiring | `di/Dependencies.kt` → see [di/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/di/CLAUDE.md) |
+| Chat or secure conversations | `chat/` → see [chat/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/chat/CLAUDE.md) |
+| Engagement state machine | `engagement/` → see [engagement/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/engagement/CLAUDE.md) |
+| Theme / styling | `view/unifiedui/` → see [unifiedui/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/CLAUDE.md) |
+| Snapshot (UI) tests | `widgetssdk/src/testSnapshot/` → see [testSnapshot/CLAUDE.md](widgetssdk/src/testSnapshot/CLAUDE.md) |
+| Version, dependency pins | `gradle/libs.versions.toml`, root `build.gradle` |
+| Push notifications | `fcm/`, `push/` |
+| Custom lint rules | `lint_checker/` |
+| Release / version scripts | `scripts/` |
+
+## Gotchas
+
+1. **Snapshot build type cannot use composite-build Core substitution.** Debug and release use `includeBuild` to substitute Core SDK; the `snapshot` build type cannot. Run `./gradlew widgetssdk:publishCoreSdkToLocalMaven` first, then snapshot tasks. Mixing these causes silent resolution failures.
+
+2. **ContentProvider auto-init makes manual init redundant.** `InitializationProvider` runs `Dependencies.onAppCreate()` before `Application.onCreate()`. The deprecated `GliaWidgets.onAppCreate()` still contains real work — calling it from integrator code re-invokes initialization and risks double-init. Do not call it.
+
+3. **`ChatController` and `CallController` are retained across Activity recreation by design.** `ControllerFactory` holds `retainedChatController` and `retainedCallController`. This is intentional — there is no ViewModel. The no-arg `onDestroy()` override throws `RuntimeException("no op")`; always call `onDestroy(retain: Boolean)` so the factory can decide whether to clear or keep the controller instance.
+
+## For AI Agents
+
+- Never use `android.util.Log` directly — route all logging through `helper/Logger.kt` and `GliaLogger` from the telemetry SDK. Public API entry points must log to both.
+- Never log PII: no chat content, operator names, visitor names, or API keys at any severity level.
+- Never bypass the `GliaCore` interface — all networking, auth, and data storage must flow through `GliaCoreImpl`, never through direct Glia SDK calls from feature code.
+- Never use `!!` — use `?.`, `?:`, `requireNotNull("message")`, or early returns.
+- Never block the main thread — use RxJava 3 schedulers (`io.reactivex.rxjava3.*`); always provide an error handler in `.subscribe()`.
+- Never hardcode colors, dimensions, or strings — use the Unified Theme system and string resources (prefix `glia_`, wrap in `LocaleString`); legacy `UiTheme.kt` is deprecated.
+- Never introduce a new singleton class — add dependencies to the `Dependencies` object.
+- Never use Jetpack Compose — traditional View system only.
+- Never write new classes in Java — all new code must be Kotlin. When touching an existing Java file for a small, self-contained change, migrate it to Kotlin in the same PR if doing so fits the task's context; leave large/high-churn Java files (e.g., `ControllerFactory.java`, `UseCaseFactory.java`, `RepositoryFactory.java`) for coordinated migration.
+- Always dispose `CompositeDisposable` in `onDestroy(retain = false)`, not in `onPause` or unconditional `onDestroy`.
+- Always declare explicit return types on Kotlin functions and class/file-level variables; local variables may use inference.
+- Always add or update unit tests for every changed layer; always run `recordPaparazziSnapshot` + `verifyPaparazziSnapshot` for any UI change.
+- MockK and Mockito-Kotlin coexist in the test suite intentionally — do not migrate one to the other.
+
+## Directory Map
+
+```
+widgetssdk/             # Published AAR → see widgetssdk/CLAUDE.md
+├── src/main/java/com/glia/widgets/
+│   ├── di/             # DI container + ControllerFactory → see di/CLAUDE.md
+│   ├── chat/           # Chat + secure conversations → see chat/CLAUDE.md
+│   ├── engagement/     # State machine, single source of truth → see engagement/CLAUDE.md
+│   ├── view/unifiedui/ # Three-stage theme pipeline → see view/unifiedui/CLAUDE.md
+│   ├── call/, callvisualizer/, survey/, messagecenter/, entrywidget/, webbrowser/
+│   ├── fcm/, push/     # Firebase push (integrator-owned FCM proxy pattern)
+│   ├── internal/       # Kotlin-internal implementation detail
+│   └── helper/, view/  # Shared helpers, legacy UI base classes
+├── src/test/           # Unit tests (MockK + Mockito-Kotlin, JUnit 4, Robolectric)
+└── src/testSnapshot/   # Paparazzi snapshot tests (custom build type) → see testSnapshot/CLAUDE.md
+app/                    # Demo app (compileSdk 36; release consumes locally-published SNAPSHOT)
+lint_checker/           # Custom lint: UndocumentedApiIssue at ERROR severity
+scripts/                # version-updater.gradle, direct-core.gradle, changelog, git-hooks setup
+.git-hooks/             # pre-commit (gitleaks + trufflehog), pre-push (git-lfs)
+```
+
+## References
+
+### [docs/claude-reference.md](docs/claude-reference.md)
+- [Module Dependencies](docs/claude-reference.md#module-dependencies)
+- [Conventions](docs/claude-reference.md#conventions)
+- [Anti-Patterns](docs/claude-reference.md#anti-patterns)
+- [Gotchas](docs/claude-reference.md#gotchas)
+- [Stack Constraints](docs/claude-reference.md#stack-constraints)
+- [Workflows and Commands](docs/claude-reference.md#workflows-and-commands)
+- [Git Intelligence](docs/claude-reference.md#git-intelligence)
+
+### Subdirectory Guides
+| File | Description |
+|------|-------------|
+| [widgetssdk/CLAUDE.md](widgetssdk/CLAUDE.md) | SDK module build config, publishing, AAR internals |
+| [di/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/di/CLAUDE.md) | DI wiring, ControllerFactory retention, mock seams |
+| [chat/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/chat/CLAUDE.md) | Chat + secure conversations patterns |
+| [engagement/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/engagement/CLAUDE.md) | State machine, EndAction, EngagementRepository |
+| [view/unifiedui/CLAUDE.md](widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/CLAUDE.md) | Theme pipeline stages, LocaleString, remote JSON config |
+| [testSnapshot/CLAUDE.md](widgetssdk/src/testSnapshot/CLAUDE.md) | Paparazzi setup, snapshot build type, record/verify workflow |
+
+### External
+- [Developer Guide](.claude/DEVELOPER_GUIDE.md) — local setup, composite build, git hooks
+- [Developer Docs](https://developer.glia.com/api-usage-refs/android-api) — public API reference
+- [iOS counterpart](https://github.com/salemove/ios-sdk-widgets) — cross-platform parity reference

--- a/docs/claude-reference.md
+++ b/docs/claude-reference.md
@@ -1,0 +1,365 @@
+# GliaWidgets Android SDK — Deep Reference
+
+## Contents
+
+- [Module Dependencies](#module-dependencies)
+- [Conventions](#conventions)
+- [Anti-Patterns](#anti-patterns)
+- [Gotchas](#gotchas)
+- [Stack Constraints](#stack-constraints)
+- [Workflows and Commands](#workflows-and-commands)
+- [Git Intelligence](#git-intelligence)
+
+---
+
+## Module Dependencies
+
+**`ControllerFactory.java` ↔ `UseCaseFactory.java` ↔ `RepositoryFactory.java`**
+
+These three Java files form the manual DI registry. They must change in lockstep whenever a new screen, use case, or repository is introduced. All three remain Java and are annotated `@hide` to exclude from Dokka-generated Javadoc. Evidence: `widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java`, `widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java`, `widgetssdk/src/main/java/com/glia/widgets/di/RepositoryFactory.java`
+
+**`ControllerFactory` ↔ Activity lifecycle (retained slots)**
+
+`ControllerFactory` holds `retainedChatController` and `retainedCallController` as instance fields. These survive Activity recreation (config changes, screen rotations), which is why no `ViewModel` exists in the project. Other controllers are recreated per screen. Do not introduce `ViewModel` without understanding what the retained slots already provide.
+
+**`Dependencies.onAppCreate` ↔ ActivityLifecycleCallbacks watchers**
+
+`CallVisualizerActivityWatcher`, `ActivityWatcherForChatHead`, `ActivityWatcherForLiveObservation`, `ActivityWatcherForPermissionsRequest`, `EngagementCompletionActivityWatcher`, `OperatorRequestActivityWatcher`, `UiComponentsActivityWatcher` all extend `BaseSingleActivityWatcher` and expose `resumedActivity: Flowable<WeakReference<Activity>>` backed by a `PublishProcessor`. This is the implicit UI coordination bus — anything needing "top activity" reads from it. Moving watcher registration between `onAppCreate` and `onSdkInit` causes watchers to miss early app lifecycle events or run without config. Evidence: `widgetssdk/src/main/java/com/glia/widgets/base/BaseActivityWatcher.kt`
+
+**Views ↔ `Dependencies.gliaThemeManager.theme`**
+
+Views read the active `UnifiedTheme` directly from `Dependencies.gliaThemeManager.theme?.<screenTheme>`. Theme is a View-layer concern — it never flows through MVP contracts or controllers. Evidence: `widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt`
+
+**`DefaultTheme` ↔ `RemoteConfiguration`**
+
+Adding a theme property requires edits to both `DefaultTheme` (the top-level function at `widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Base.kt`) AND the corresponding `RemoteConfiguration` data class and its `toUnifiedTheme()` conversion. The `Mergeable<T>` merge semantics — remote wins when non-null, default is fallback — mean that omitting either side yields `null` for that property in all theme configurations. Evidence: `widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/Merge.kt`
+
+**`EngagementRepository.engagementState` ↔ every controller**
+
+`EngagementRepositoryImpl` owns a `BehaviorProcessor<State>` fed by `Glia.on(OmnicoreEvent, …)` callbacks from Core. Every controller and use case subscribes to `engagementState: Flowable<State>`. State hierarchy or naming changes cascade to all subscribers simultaneously.
+
+**`PushNotificationsImpl` ↔ Core SDK events**
+
+`PushNotificationsImpl` intercepts `SECURE_MESSAGING_TYPE` push payloads before Core ever sees them. Core has zero visibility into secure messaging push. Treat this as a hidden interception layer when debugging PN behavior.
+
+**`version.properties` ↔ Bitrise automation**
+
+Version is read from `version.properties`, NOT `gradle.properties`. Bitrise workflows use `git stash` around version bumps to prevent bot PR merge conflicts. The timestamp field was deliberately removed from `version.properties` to eliminate a recurring source of conflicts.
+
+**`app/build.gradle` release variant ↔ locally-published SNAPSHOT**
+
+The demo app's release variant does NOT reference `project(':widgetssdk')`. Instead, `preReleaseBuild.dependsOn ':widgetssdk:publishSnapshotPublicationToMavenLocal'` publishes a SNAPSHOT to `~/.m2` and the release variant consumes it. Debug uses the project dependency directly. Evidence: `app/build.gradle`
+
+**`InitializationProvider` ↔ Core SDK's `InitializationProvider`**
+
+`widgetssdk/src/main/AndroidManifest.xml` removes Core's `InitializationProvider` via `tools:node="remove"` and registers Widgets' own provider under the same authority. Widgets' provider EXTENDS Core's (a `@hide` class). `super.onCreate()` runs Core init, then `Dependencies.onAppCreate(application)` + `GliaWidgets.setupRxErrorHandler()`. Both must execute — removing either breaks initialization silently.
+
+---
+
+## Conventions
+
+### Kotlin Style
+
+- All new classes must be written in Kotlin, not Java. Java legacy exists but is not a pattern to copy.
+- When modifying an existing Java file for a small, self-contained change, convert it to Kotlin in the same PR if the scope stays manageable. Skip the migration for high-churn Java files (`ControllerFactory.java`, `UseCaseFactory.java`, `RepositoryFactory.java`) — those need coordinated rewrites because feature branches touch them constantly.
+- Explicit return types on all functions. Explicit types on class/file-level variables; local variables may use inference.
+- `ktlint_official` code style, `import-ordering` disabled, 150-character line max. Evidence: `.editorconfig`
+- No detekt. Custom lint rules in `lint_checker/` enforce `UndocumentedApiIssue` at `Severity.ERROR` for undocumented public APIs.
+- Suppressed lint rules (project-wide, in `widgetssdk/build.gradle`): `WrongLayoutName`, `LayoutFileNameMatchesClass`, `MatchingViewId`, `RawDimen`, `WrongAnnotationOrder`, `ColorCasing`, `WrongViewIdFormat`, `HardcodedText`.
+- No `!!` operator — use safe calls (`?.`) and explicit null handling throughout.
+
+### MVP Pattern
+
+- `BaseController.onDestroy()` (no-arg) is DELIBERATELY unusable for `ChatController` and `CallController` — the override throws `RuntimeException("no op")`. Always call `onDestroy(retain: Boolean)`. `retain=true` detaches view and stops timers but preserves the main `CompositeDisposable`; `retain=false` clears everything. Evidence: `widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt`, `widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt`
+- Views self-register controllers in their own `setupControllers()` method — Activities do not inject controllers. Pattern: `setController(Dependencies.controllerFactory.chatController); controller.setView(this)`. Evidence: `widgetssdk/src/main/java/com/glia/widgets/chat/ChatView.kt`
+- `GliaActivity<T>` is an INTERFACE (not an abstract class) with `val gliaView: T`. Activities both extend `FadeTransitionActivity()` AND implement `GliaActivity<ViewType>`. Evidence: `widgetssdk/src/main/java/com/glia/widgets/base/GliaActivity.kt`, `widgetssdk/src/main/java/com/glia/widgets/chat/ChatActivity.kt`
+
+### Dependency Injection
+
+- `Dependencies` is an `internal object` (Kotlin singleton) with `@JvmStatic` for Java interop. Evidence: `widgetssdk/src/main/java/com/glia/widgets/di/Dependencies.kt`
+- Use `by lazy` for properties not instantiated until `onSdkInit` (e.g., `activityLauncher`, `engagementLauncher`, `pushNotifications`, `liveObservation`, `secureConversations`).
+- `entryWidget` is a computed `get()` property — NOT `by lazy` — returning a fresh `EntryWidgetImpl` on every call. Caching it externally causes double-parent attachment issues.
+- `@VisibleForTesting set` on `gliaCore`, `controllerFactory`, `useCaseFactory`, `repositoryFactory`, and `schedulers` is the ONLY supported test injection seam — no DI framework, no test rule, no setup utility.
+- `ControllerFactory`, `UseCaseFactory`, `RepositoryFactory` remain Java with `@hide` Javadoc to exclude them from the public API surface.
+
+### UseCase Conventions
+
+- Either a plain Kotlin class (no interface) or an `interface` + `Impl` pair. The `Impl` suffix is used only when an interface exists for testability.
+- All use cases expose `operator fun invoke(...)`, callable like functions. Evidence: `widgetssdk/src/main/java/com/glia/widgets/engagement/domain/EndEngagementUseCase.kt`
+
+### RxJava 3
+
+- Controllers use SEGREGATED `CompositeDisposable`s: `disposable` (main, long-lived), `mediaUpgradeDisposable` (cleared on pause), `connectionDisposable` (cleared on pause). Evidence: `widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt`, `widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt`
+- Subscriptions added via `disposable.add(...)` or `.also(disposable::add)` — both styles coexist, no enforced preference.
+- Tests must set up `RxAndroidPlugins.setInitMainThreadSchedulerHandler { Schedulers.trampoline() }` in `@Before` and reset in `@After`. No shared rule. Evidence: `widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt`
+- Always provide error handlers in `.subscribe()` — bare lambda subscriptions that swallow errors are forbidden.
+
+### Dual Logging Channels
+
+Both channels are required when logging on public API paths:
+
+- `Logger` (internal, `widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt`): operational debug/info/warn/error. Debug builds route to `android.util.Log` and return early to avoid double-logging through `LoggingAdapter`. Release dispatches to Core-injected `ClientLoggerAdapter`.
+- `GliaLogger` (telemetry_lib): structured product analytics using typed `LogEvents.*` constants. Exposes `logMethodUse`, `logDeprecatedApiUse`.
+- TAG convention: `internal val Any.TAG: String get() = javaClass.simpleName` extension property. Java classes define `TAG` manually as a constant. Evidence: `widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt`
+
+### Theme System
+
+- `Mergeable<T>` with `infix fun merge`: `defaultTheme merge remoteTheme` — the `other` (remote) operand always wins when non-null. Evidence: `widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/Merge.kt`
+- `DefaultTheme` in `defaulttheme/` is a TOP-LEVEL FUNCTION (not a class or companion object), annotated with `@file:Suppress("FunctionName")` because its name starts with a capital letter. Evidence: `widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/theme/defaulttheme/Base.kt`
+- Views apply theme via extension functions in `UnifiedUiExtensions.kt` (`applyColorTheme`, `applyLayerTheme`, `applyButtonTheme`, `applyTextTheme`). Theme access goes directly through `Dependencies.gliaThemeManager` — not through contracts.
+- All hardcoded colors and dimensions are forbidden — use theme system and resources.
+
+### Locale and Strings
+
+- All UI strings are wrapped in `LocaleString(@StringRes stringKey: Int, vararg values: StringKeyPair)`. `LocaleProvider` resolves at runtime and emits on locale change.
+- View extension functions (`TextView.setLocaleText`, `setLocaleHint`, `View.setLocaleContentDescription`, `setAccessibilityHint`) register LIVE listeners — they update automatically on locale change.
+- All SDK string resource names are prefixed `glia_`. `new_strings.xml` provides backward-compatible aliases mapping old public-facing names to current `glia_*` names. Evidence: `widgetssdk/src/main/res/values/new_strings.xml`
+
+### Testing
+
+- Mockito-Kotlin (`org.mockito.kotlin.mock`, `whenever`, `verify`, `argumentCaptor`) is used in older controller tests. MockK (`io.mockk`, `@MockK`, `every {}`) is used in newer Kotlin-first tests. Both coexist intentionally.
+- Test function names use backticks.
+- Assertions use `junit.framework.TestCase.assert*` — not AssertJ or Hamcrest.
+- Snapshot tests extend `SnapshotTest` (open base class), implement `Snapshot*` interfaces. Paparazzi rule name uses underscore prefix: `_paparazzi`. Defaults: `PIXEL_4A`, `"ThemeOverlay_Glia_Chat_Material"`, max pixel diff `0.001`. Evidence: `widgetssdk/src/testSnapshot/java/com/glia/widgets/SnapshotTest.kt`
+
+### Package Organization
+
+- Feature-based top-level packages: `chat/`, `call/`, `engagement/`, `entrywidget/`, etc.
+- Sub-layers within each feature: `domain/` (use cases), `data/` (repositories, sources), `model/` (data types), `controller/` (when multiple controllers exist), `adapter/` (RecyclerView adapters).
+- Cross-cutting concerns live in `internal/`.
+- `com.glia.widgets.internal.*` uses Kotlin `internal` visibility — invisible at the language level to integrators. No ProGuard keep rules needed.
+
+### Thread Safety
+
+- `@Volatile` for state fields accessed from multiple threads (e.g., `isChatViewPaused`, `chatState`, `callState`). Evidence: `widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt`
+- View detach uses `synchronized(this) { view = null }` (bare `synchronized` block, NOT `@Synchronized` annotation).
+
+### Accessibility
+
+- Content descriptions are mandatory on all interactive and meaningful views. TalkBack support is required — not optional polish.
+- Use `View.setLocaleContentDescription` and `setAccessibilityHint` (live listener variants) — not one-shot assignments. Evidence: `widgetssdk/src/main/java/com/glia/widgets/helper/ViewExtensions.kt`
+
+---
+
+## Anti-Patterns
+
+1. **Never add a singleton class.** Use the `Dependencies` object. `GliaWidgets` and `Dependencies` are the only sanctioned Kotlin `object` singletons. Java `*Factory` static fields are grandfathered.
+
+2. **Never call `GliaWidgets.onAppCreate()` from integrator code or tests.** It is deprecated and redundant because `InitializationProvider` already invoked the initialization path; calling it again re-runs setup and risks double-init side effects. Evidence: `widgetssdk/src/main/java/com/glia/widgets/GliaWidgets.kt`
+
+3. **Never store Activity, Fragment, or View in static fields outside `ControllerFactory`'s retained slots.** Memory leaks. Use the `resumedActivity: Flowable<WeakReference<Activity>>` surface exposed by the registered `ActivityLifecycleCallbacks` watchers.
+
+4. **Never run the `dokkaHtml` Gradle task.** Dokka V2 is used in this project; the task `dokkaGeneratePublicationJavadoc` is what Maven publishing is wired to. Evidence: `widgetssdk/build.gradle`
+
+5. **Never add a theme property to only one of `DefaultTheme` or `RemoteConfiguration`.** The `Mergeable<T>` merge requires both sides. Missing either yields `null` for that property at runtime with no error.
+
+6. **Never reference `project(':widgetssdk')` in the demo app's release variant.** The release variant consumes a locally-published SNAPSHOT via `preReleaseBuild.dependsOn ':widgetssdk:publishSnapshotPublicationToMavenLocal'`. Evidence: `app/build.gradle`
+
+7. **Never add Paparazzi to the default `buildTypes` block.** It is scoped to the `snapshot` build type specifically to isolate Kotlin classpath injection. Evidence: `widgetssdk/build.gradle`
+
+8. **Never put version numbers in `gradle.properties`.** `version.properties` is the single source of truth. Bitrise automation reads it via Gradle tasks and uses `git stash` around bot-authored version bumps.
+
+9. **Never commit Paparazzi snapshot PNGs without Git LFS.** `.gitattributes` routes `widgetssdk/src/test/snapshots/**/*.png` through LFS. Always verify LFS is initialized (`git lfs install`) before working on snapshot tests.
+
+10. **Never assume Firebase Messaging is transitively available to integrators.** The SDK declares `implementation` on `firebase-messaging`, but the published POM strips this dependency via `excludeOptionalDependencies`. Integrators must declare their own Firebase Messaging dependency and proxy push payloads through `PushNotifications.onNewMessage()`.
+
+11. **Never systematically migrate all Mockito tests to MockK.** Both coexist intentionally. Opportunistic migration during feature work is fine; a dedicated migration sweep is not planned.
+
+12. **Never introduce `ViewModel`.** Retained controller slots in `ControllerFactory` already handle config-change survival for `ChatController` and `CallController`.
+
+13. **Never call the no-arg `onDestroy()` on `ChatController` or `CallController`.** The override throws `RuntimeException("no op")` intentionally. Call `onDestroy(retain: Boolean)`. Evidence: `widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt`
+
+14. **Never define a TAG constant in a Kotlin companion object.** The `internal val Any.TAG` extension property is the convention. Evidence: `widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt`
+
+15. **Never use the `snapshot` build type with `includeBuild` composite for local Core SDK.** Composite build does not support custom build types. Run `./gradlew widgetssdk:publishCoreSdkToLocalMaven` first, then run snapshot tasks.
+
+16. **Never upgrade `jackson-core` beyond the force-pinned version.** `com.fasterxml.jackson.core:jackson-core` is forced to `2.15.3` project-wide via `resolutionStrategy { force ... }` in root `build.gradle` to work around a Dokka CVE. Upgrading to "fix" a Snyk alert breaks Dokka generation. Evidence: `build.gradle` (root)
+
+17. **Never use `android.util.Log` directly.** Use the internal `Logger` object for operational logging. Evidence: `widgetssdk/src/main/java/com/glia/widgets/helper/Logger.kt`
+
+18. **Never log PII.** No user input, operator names, message content, or any personally identifiable data may appear in any log channel.
+
+---
+
+## Gotchas
+
+**ContentProvider auto-init ordering is rigid.** `InitializationProvider.onCreate` has already registered lifecycle watchers before the integrator calls `GliaWidgets.init()`. Moving initialization work between `Dependencies.onAppCreate` (called from the provider) and `Dependencies.onSdkInit` (called from `init()`) causes watchers to miss early app lifecycle events or to run without applied configuration.
+
+**Retained controllers survive Activity recreation with full state.** `ChatController` and `CallController` state — timers, subscriptions, chat history position, media upgrade state — must remain valid after `onDestroy(retain=true)`. Clearing too aggressively during `retain=true` loses in-progress state across rotation; not clearing on `retain=false` leaks memory.
+
+**`destroyControllers()` does NOT reset repositories.** `SecureConversationsRepository`, `QueueRepository`, and `FileAttachmentRepository` are process-global static singletons in `RepositoryFactory`. They persist across controller teardown. Stale repository state can resurface on the next engagement session.
+
+**Snapshot build type cannot use `includeBuild` composite for local Core SDK.** When iterating against an unreleased local Core SDK, run `./gradlew widgetssdk:publishCoreSdkToLocalMaven` first, then run any snapshot tasks.
+
+**`EntryWidget.getView(context)` returns a fresh instance every call.** `Dependencies.entryWidget` is a computed `get()` property, not `by lazy`. Caching the returned view externally causes double-parent attachment exceptions.
+
+**`./gradlew testSnapshotUnitTest` runs zero unit tests by design.** The `test.java.srcDirs = []` configuration removes the default test source set, then re-adds sources only to `testDebug` and `testRelease`. Use `./gradlew widgetssdk:test` for unit tests and `./gradlew widgetssdk:verifyPaparazziSnapshot` for snapshot verification.
+
+**Screen sharing in Widgets SDK was fully removed (MOB-4366).** It is not deprecated — it was deleted. Any residual references are dead ends. CallVisualizer retains screen sharing capability; that is a separate path.
+
+**Secure Conversations ↔ Live engagement transitions are a known regression area.** The bidirectional transition (GVA→SC and SC→Live upgrade) has produced multiple regressions: SC banner lingering after SC→Live transition, pre-engagement hint persisting after SC upgrades to Live. Regression-test both directions on any change touching `SecureConversationsRepository`, `EngagementRepository` state transitions, or the SC↔Live upgrade path.
+
+**Auth + engagement-end lifecycle boundary is fragile.** A fix for "engagement end during de-authentication" was deliberately reverted (commit `bdcf1895`). A flag was added separately to suppress the push notification permission dialog during authentication flow. Any change touching auth state, engagement end, or push notification permission timing in the same commit should be treated with heightened caution.
+
+**Gradle sync auto-installs Git hooks and requires local tooling.** `scripts/setup-git-hooks.sh` runs on every Gradle sync. It requires `gitleaks`, `trufflehog`, and `git-lfs`. Set `ANDROID_WIDGETS_SDK_SKIP_GIT_HOOKS=true` to bypass. Auto-bypassed when `BITRISE_IO=true`.
+
+**`LocaleString` view extensions register live listeners, not one-shot setters.** Calling `setLocaleText(R.string.glia_foo)` on a `TextView` registers a listener that re-resolves on every locale change. Directly assigning `text = getString(R.string.glia_foo)` does not update on locale change.
+
+**`new_strings.xml` is a backward-compat alias layer, not a file of new strings.** The file name is misleading. It maps old public string resource names to current `glia_`-prefixed names. New strings go in `strings.xml`. Evidence: `widgetssdk/src/main/res/values/new_strings.xml`
+
+**`Logger` routes to `android.util.Log` ONLY when `BuildConfig.DEBUG` is true.** In a release SDK loaded inside a non-debug integrator app, logs go through `LoggingAdapter` (Core-injected `ClientLoggerAdapter`).
+
+**`GliaActivity<T>` is an interface, not an abstract class.** Activities simultaneously extend `FadeTransitionActivity` AND implement `GliaActivity<ViewType>`. Do not refactor to a base class hierarchy — conflicts with single-inheritance and `FadeTransitionActivity`'s transition logic.
+
+**`PushNotificationsImpl` intercepts `SECURE_MESSAGING_TYPE` before Core sees it.** When debugging why Core does not process a particular push payload, check `PushNotificationsImpl` first.
+
+**Telemetry is initialized inside Core SDK via `InitializationProvider`.** There is no `TelemetryHelper.init` call in Widgets — removed as redundant after telemetry init moved to Core.
+
+**`SiteApiKey` is deprecated in favor of the `AuthorizationMethod` sealed interface (MOB-5010).** Code on `development` may reference the sealed interface. Do not add new callers using `SiteApiKey`.
+
+**The `use_overlay` bubble flag is deprecated and was reverted once.** The "display inside app" bubble behavior using `use_overlay` was reverted. Current flags: `enableBubbleOutsideApp` and `enableBubbleInsideApp`. Never propose reinstating `use_overlay`.
+
+**Rebasing a branch without re-recording Paparazzi snapshots is a recurring mistake.** After any rebase that touches layout, theme, or resource files, run `./gradlew widgetssdk:recordPaparazziSnapshot` before pushing.
+
+---
+
+## Stack Constraints
+
+### Version Pins With Rationale
+
+All of the following pins have WHY comments in `gradle/libs.versions.toml` and must not be changed without resolving the underlying issue:
+
+- `core-ktx 1.16.0` — version 1.17.0 requires `compileSdk 36`, which the SDK module does not use (demo app uses 36, SDK uses 35).
+- `coil-core` / `coil-network` `3.2.0` — versions above 3.2.0 require Kotlin 2.2.0 or higher; the project is on Kotlin 2.1.21.
+- `dokka 2.0.0` — Kotlin and Dokka versions must share the same minor version.
+- `paparazzi 1.3.5` — updating risks silently upgrading the Kotlin version for the entire project, not just the snapshot build type.
+
+### Forced Resolution Rules
+
+- `com.fasterxml.jackson.core:jackson-core:2.15.3` is forced project-wide via `resolutionStrategy` in root `build.gradle`. Reason: Dokka CVE workaround. Do not remove or change this pin to address Snyk alerts — it will break `dokkaGeneratePublicationJavadoc`.
+- `lint-api` version must equal AGP version plus the 23.0.0 offset (AGP 8.13.0 → lint-api 31.13.0). The custom `lint_checker/` module breaks silently on version mismatch.
+
+### Packaging Quirks
+
+- MockK introduces duplicate `META-INF/LICENSE` files. An explicit `merges` rule in `packagingOptions` resolves this — do not remove it.
+- Unit tests require `org.json:json:20250517` to fill gaps in Robolectric's stub coverage of Android JSON APIs.
+
+### Build Type and Variant Behavior
+
+- Core SDK is declared per build type: `releaseApi`, `debugApi`, `snapshotApi`. The `snapshot` build type cannot use `includeBuild` composite for local Core SDK substitution.
+- Firebase BOM and `firebase-messaging` are declared as `implementation` in the SDK module but stripped from the published POM via `excludeOptionalDependencies`.
+- Demo app targets `compileSdk 36`; SDK module targets `compileSdk 35`.
+- Paparazzi is applied only inside the `snapshot buildTypes` block — non-standard placement, intentional.
+- Gradle parallel execution is disabled. Modules are not guaranteed to be fully decoupled.
+- `resolutionStrategy.cacheChangingModulesFor 0, 'seconds'` forces a remote re-fetch of every `-SNAPSHOT` dependency on each build. Do not "optimize" this away.
+
+### JVM Configuration
+
+- Java 17 toolchain (Gradle toolchain API).
+- JVM unit test heap: `-Xmx4g`.
+- `android.enableBuildConfigAsBytecode=true`.
+
+---
+
+## Workflows and Commands
+
+### Common Gradle Tasks
+
+```
+./gradlew widgetssdk:test                                       # Unit tests (testDebug + testRelease)
+./gradlew widgetssdk:recordPaparazziSnapshot                    # Record/update Paparazzi snapshots
+./gradlew widgetssdk:verifyPaparazziSnapshot                    # Verify against stored snapshots
+./gradlew widgetssdk:lintDebug                                  # Lint SDK (includes custom lint_checker rules)
+./gradlew ktlintCheck                                           # KtLint check
+./gradlew ktlintFormat                                          # KtLint format + auto-fix
+./gradlew dokkaGeneratePublicationJavadoc                       # Dokka V2 Javadoc JAR (wired into Maven publishing)
+./gradlew -q printCurrentVersionName                            # Print current version string
+./gradlew saveWidgetsVersion --type=patch|minor|major           # Bump version in version.properties
+./gradlew saveCoreSdkVersion --sdkVersion=X.Y.Z                 # Update Core SDK version reference
+./gradlew widgetssdk:publishSnapshotPublicationToMavenLocal     # Publish SNAPSHOT to ~/.m2
+./gradlew widgetssdk:publishCoreSdkToLocalMaven                 # Publish local Core SDK to ~/.m2 (required before snapshot tasks with direct Core)
+./gradlew clean widgetssdk:publishMavenPublicationToMavenCentralRepository  # Release publish (CI only)
+```
+
+### Local Core SDK Substitution
+
+When iterating against an unreleased local Core SDK:
+
+1. Add `dependency.coreSdk.useDirect=true` to `local.properties` (overrides `CORE_SDK_USE_DIRECT` environment variable).
+2. Optionally set `dependency.coreSdk.path=<absolute path>` (defaults to `../android-sdk`).
+3. Debug and release build types use Gradle composite build (`includeBuild`) automatically.
+4. For snapshot build type (Paparazzi tests): run `./gradlew widgetssdk:publishCoreSdkToLocalMaven` FIRST, then any snapshot tasks. The snapshot build type does not support `includeBuild`.
+
+### Demo App Environment Variables
+
+Set in `local.properties` or as environment variables:
+
+- Required: `GLIA_REGION` (default: `beta`), `GLIA_API_KEY_SECRET`, `GLIA_API_KEY_ID`, `GLIA_SITE_ID`, `GLIA_QUEUE_ID`
+- Optional: `GLIA_JWT`, `FIREBASE_PROJECT_ID`, `FIREBASE_API_KEY`, `FIREBASE_APP_ID`, `FIREBASE_APP_ID_DEBUG`
+
+### Git Hooks
+
+Hooks live in `.git-hooks/` and are installed on every Gradle sync via `scripts/setup-git-hooks.sh`:
+
+- `pre-commit` — runs `gitleaks` and `trufflehog` for secret scanning. Delegates to `$HOME/.git-hooks/pre-commit` if present.
+- `pre-push` — enforces `git-lfs`.
+- Bypass: set `ANDROID_WIDGETS_SDK_SKIP_GIT_HOOKS=true`. Auto-bypassed when `BITRISE_IO=true`.
+- Install required tools: `brew install gitleaks trufflehog git-lfs`
+
+### Branch Strategy
+
+- `master` — release branch. Tagged on each release.
+- `development` — integration branch. All PRs target `development`.
+- Snyk bot opens PRs against `master`; a GitHub Actions workflow silently retargets them to `development`.
+
+### CI Pipeline
+
+All four GitHub Actions workflows are thin `curl` triggers to Bitrise (`workflow_dispatch` only). Real CI lives in `bitrise.yml`. Key Bitrise workflows:
+
+- `development` — runs on merge to `development`
+- `pull_request` — PR validation
+- `publish_to_nexus` — release publication; auto-increments patch version after successful publish
+- `_increment_project_version` — version bump helper
+- `upgrade_dependencies`, `upgrade_telemetry_dependency` — automated dependency PRs
+- `post_release` — post-publication steps (triggers Flutter/Ionic/RN wrapper dispatch + Cortex Financial app build)
+- `browserstack_upload` — demo app upload for device testing
+
+Maven Central signing: `ORG_GRADLE_PROJECT_signAllPublications=true` is set by Bitrise — it is not in any in-repo file.
+
+---
+
+## Git Intelligence
+
+### Hotspot Files
+
+- `widgetssdk/src/main/java/com/glia/widgets/di/ControllerFactory.java` — manual DI registry for every controller in the SDK. Touched by every new screen, controller, or major use case change. Still Java and not being migrated soon. Expect merge conflicts on feature branches that add screens.
+
+- `widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java` — moves in lockstep with `ControllerFactory.java`. Every new use case registration lands here. Same Java-retention caveat.
+
+- `widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt` — convergence point for Secure Conversations ↔ Live transitions, media upgrade logic, read tracking, and telemetry. Java→Kotlin migration history; accumulates targeted fixes for chat-related edge cases.
+
+### Recurring Fix Patterns
+
+- **Accessibility sweeps follow feature work.** Features ship, then a follow-up commit adds TalkBack hints, content descriptions, and accessibility roles. Most recent wave covered chat bubble, dialog buttons, survey titles, attachment popup. Treat accessibility as a mandatory second pass for every UI change.
+
+- **Push notification layers accumulate regressions.** PN functionality was built incrementally (initial → transcript-from-PN → secure-messaging PN → visitor ID in auth → permissions → dialog simplification). Each layer introduced regressions. The auth/engagement/PN triangle is the highest-risk area.
+
+- **Snapshot updates after rebase are a recurring commit pattern.** Before pushing any rebase, run `./gradlew widgetssdk:recordPaparazziSnapshot` and include resulting PNG changes.
+
+### Architectural Decisions — Never Revert
+
+- **Screen sharing removal from Widgets SDK (MOB-4366)** — deliberately deleted, not deprecated. Residual references are dead ends. CallVisualizer retains screen sharing as a separate code path. Never propose restoring Widgets-side screen sharing.
+
+- **`use_overlay` flag deprecation** — the "display bubble inside app" behavior was reverted once. Replacement flags are `enableBubbleOutsideApp` and `enableBubbleInsideApp`. Never propose reinstating `use_overlay`.
+
+- **"Fix engagement end during de-authentication" revert** — the auth/engagement lifecycle interaction at de-authentication is genuinely fragile. Any proposed fix requires careful isolation and regression testing of both auth and engagement-end paths simultaneously.
+
+- **Telemetry initialization moved to Core SDK** — `TelemetryHelper.init` was removed from Widgets as a no-op after Core SDK took over telemetry initialization in `InitializationProvider`. Do not add it back.
+
+- **`SiteApiKey` deprecation in favor of `AuthorizationMethod` sealed interface (MOB-5010)** — do not add new usages of `SiteApiKey`.
+
+- **`version.properties` timestamp field removal** — removed specifically to prevent bot-authored Bitrise version-bump PRs from conflicting with developer PRs. Do not add any auto-generated or timestamp-based field back.
+
+- **`resolutionStrategy.cacheChangingModulesFor 0, 'seconds'`** — forces SNAPSHOT re-fetch on every build. Do not add a caching duration to "optimize" CI build times.
+
+- **Snapshot PNGs routed through Git LFS** — binary PNG blobs committed to the regular object store caused a repo repair commit. The `.gitattributes` LFS routing for `widgetssdk/src/test/snapshots/**/*.png` is mandatory.

--- a/widgetssdk/CLAUDE.md
+++ b/widgetssdk/CLAUDE.md
@@ -1,0 +1,41 @@
+<!-- deep-research: completed 2026-04-24 | v: deep-research/1.7 | scope: widgetssdk -->
+# widgetssdk
+> The published SDK module — produces `com.glia:android-widgets` AAR for Maven Central
+
+See [root CLAUDE.md](../CLAUDE.md) for project-wide architecture, MVP pattern, DI rules, RxJava requirements, and language standards. See [docs/claude-reference.md](../docs/claude-reference.md) for full anti-patterns and gotchas.
+
+## Context Loading Order
+1. `build.gradle` — three build types, publishing config, Firebase POM stripping, Dokka wiring
+2. `src/main/AndroidManifest.xml` — activity launch modes, InitializationProvider override, GliaFileProvider
+3. `consumer-rules.pro` — the only ProGuard keep rules shipped to integrators; review before adding any
+4. `../version.properties` (repo root) — single source of truth for `versionCode`, `versionName`, Core SDK version, telemetry version
+
+## Where to Look
+| Task | File |
+|------|------|
+| Bump SDK version | `../version.properties` + `./gradlew saveWidgetsVersion --type=patch\|minor\|major` |
+| Publish to Maven Central | `build.gradle` → `mavenPublishing` block |
+| Publish snapshot | `./gradlew publishSnapshotPublicationToMavenCentralRepository` |
+| Add/change activity flags | `src/main/AndroidManifest.xml` |
+| Add integrator-visible ProGuard keep | `consumer-rules.pro` |
+| Add internal shrinking rule | `proguard-rules.pro` |
+| Run/record Paparazzi snapshots | `./gradlew widgetssdk:recordPaparazziSnapshot` (snapshot build type only) |
+| Regenerate Javadoc | `./gradlew dokkaGeneratePublicationJavadoc` (Dokka V2) |
+
+## Conventions
+- Version is owned entirely by `version.properties` at the repo root. Neither `gradle.properties` nor `defaultConfig.versionName` are authoritative — `build.gradle` reads `widgetsVersionName` injected via `scripts/version-updater.gradle`.
+- Paparazzi plugin is applied **inside** the `snapshot` buildTypes block, not at the top level. Tests in `src/test/java` are excluded from the `snapshot` variant by design — `test.java.srcDirs = []` with re-addition only for `testDebug`/`testRelease`. Evidence: `build.gradle` sourceSets block
+- Firebase Messaging is `implementation` but stripped from the published POM via `excludeOptionalDependencies()`. Integrators supply their own FCM service and call `PushNotifications.onNewMessage()`. Never promote `firebase-messaging` to `api`. Evidence: `build.gradle`
+- Paparazzi PNG files are tracked via Git LFS, routed by `.gitattributes` (`widgetssdk/src/test/snapshots/**/*.png`). Never commit raw PNGs.
+- Dokka task wired into Maven publishing is `dokkaGeneratePublicationJavadoc` (Dokka V2). The `dokkaHtml` task does not exist in this project.
+
+## Anti-Patterns
+- **Do not add ProGuard rules to `consumer-rules.pro` without explicit review.** Rules there ship to every integrator and affect their whole-app shrinking pass. Internal keep rules belong in `proguard-rules.pro`. Evidence: `consumer-rules.pro` currently has only `GliaFileProvider` and `WebViewViewHolder$JavaScriptInterface` entries.
+- **Do not register a new Activity in the manifest without reviewing all `ActivityLifecycleCallbacks` watchers registered in `Dependencies.onAppCreate`.** Activities are an implicit UI coordination bus; a new singleTask activity can silently disrupt lifecycle sequencing across the engagement flow.
+- **Do not add a new public API without tagging internal Java classes with `@hide` Javadoc.** Dokka publishes anything without `@hide`; unintended classes appear in the public Javadoc JAR shipped to Maven Central. Evidence: `InitializationProvider.kt` uses `@hide`.
+- **Do not run tests against the `snapshot` build variant expecting results.** The `snapshot` variant excludes `src/test/java` — it returns zero tests. Always use `testDebug` or `testRelease`. Evidence: `build.gradle` sourceSets
+
+## For AI Agents
+- Never call `GliaWidgets.onAppCreate()` in new code — it is deprecated and redundant because `InitializationProvider.onCreate()` already runs `super.onCreate()` → `Dependencies.onAppCreate(application)` → `GliaWidgets.setupRxErrorHandler()`. Calling it again re-invokes the init path.
+- Never remove the `tools:node="remove"` entry for `com.glia.androidsdk.InitializationProvider` in `AndroidManifest.xml`. It suppresses the Core SDK's own provider so the Widgets provider can extend and replace it. Removing it causes both providers to register under the same authority and crashes at install time.
+- Never rename or remove `dokkaGeneratePublicationJavadoc`. The `dokkaJavadocJar` task depends on it by name and it is wired into Maven publishing in the `afterEvaluate` block. Using the wrong task name silently omits the Javadoc JAR from the published artifact.

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/CLAUDE.md
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/CLAUDE.md
@@ -1,0 +1,45 @@
+<!-- deep-research: completed 2026-04-24 | v: deep-research/1.7 | scope: widgetssdk/src/main/java/com/glia/widgets/chat -->
+# Chat
+> Full-stack chat feature: live engagement and Secure Conversations (SC), converged in one MVP stack.
+
+Parent: [CLAUDE.md](../../../../../../../../CLAUDE.md) | [docs/claude-reference.md](../../../../../../../../docs/claude-reference.md)
+
+## Context Loading Order
+1. `ChatContract.kt` — full MVP interface pair; read before touching Controller or View
+2. `controller/ChatController.kt` — retained controller; three segregated `CompositeDisposable` fields at the top are load-bearing
+3. `ChatManager.kt` — owns message list state; `ChatController` delegates all list mutations here
+4. `ChatView.kt` — self-wires via `setupControllers()`; handles SC top-banner visibility and engagement banners
+
+## Where to Look
+| Task | File |
+|------|------|
+| Add Controller method | `ChatContract.kt` (both sides), `controller/ChatController.kt` |
+| SC ↔ Live transition logic | `controller/ChatController.kt` — `initChat()`, `initSecureMessaging()`, `initLiveChat()` |
+| Message list mutations | `ChatManager.kt` |
+| RecyclerView item types / view holders | `adapter/ChatAdapter.kt`, `adapter/holder/` |
+| Chat state shape | `model/ChatState.kt` |
+| SC top-banner visibility | `controller/ChatController.kt` — `observeTopBannerUseCase()` subscription |
+| Media upgrade offer | `controller/ChatController.kt` — `mediaUpgradeDisposable` block |
+| Read-tracking / unseen indicator | `../view/MessagesNotSeenHandler.java` |
+| Domain use cases | `domain/` |
+
+## Conventions
+- **Self-wiring**: `ChatView.setupControllers()` calls `Dependencies.controllerFactory.chatController` then `controller.setView(this)`. Activity does not inject or own the controller. Evidence: `ChatView.kt`
+- **Three segregated disposables**: `disposable` (main, cleared only when `retain=false` in `onDestroy`), `mediaUpgradeDisposable` (cleared `onPause`), `connectionDisposable` (cleared `onPause`). Each has distinct lifecycle. Evidence: `controller/ChatController.kt`
+- **`Intention` enum gates init path**: `initChat(intention)` dispatches to `initLiveChat()`, `initSecureMessaging()`, or leave-dialog flows. Adding a new entry point means adding an `Intention` variant. Evidence: `controller/ChatController.kt`
+- **`onDestroy(retain: Boolean)` is the real cleanup hook** — `onDestroy()` (no-arg) throws `RuntimeException("no op")` by design. Evidence: `controller/ChatController.kt`
+- **`emitViewState {}` is `@Synchronized`** and `view` is nulled inside a `synchronized(this)` block in `onDestroy` — keep UI mutation on the synchronized path. Evidence: `controller/ChatController.kt`
+- **`ChatAdapter` uses integer view-type constants** — the `dataObserver` in `ChatView` branches on `CUSTOM_CARD_TYPE` for scroll-delay behaviour. Match the existing `ChatAdapter.*_TYPE` constants when adding a new item type. Evidence: `adapter/ChatAdapter.kt`, `ChatView.kt`
+
+## Anti-Patterns
+- **Do NOT merge the three `CompositeDisposable` instances.** `mediaUpgradeDisposable` and `connectionDisposable` must be released on pause but the controller survives pause; `disposable` must survive pauses but release only on permanent destroy. Consolidating them causes either resource leaks or premature disposal during orientation change.
+- **Do NOT subscribe to `observeTopBannerUseCase()` conditionally on Activity re-attach.** The subscription lives inside `disposable`, which survives config changes. Resubscribing on re-attach doubles observers and produces duplicate banner-visibility events — the known regression pattern in SC↔Live boundary history.
+- **Do NOT emit view state from a non-`@Synchronized` path.** Direct `view?.emitState(...)` calls from a background thread race with `onDestroy`'s `synchronized(this) { view = null }`.
+- **Do NOT use `!!` for the view reference.** The view is nulled inside a `synchronized` block; unsafe non-null assertions crash on configuration change.
+
+## For AI Agents
+- Never consolidate `disposable`, `mediaUpgradeDisposable`, and `connectionDisposable` into a single `CompositeDisposable` — the three-way split is the memory-leak and pause-lifecycle contract.
+- Never call `onDestroy()` (no-arg) on `ChatController` — it throws intentionally. Always use `onDestroy(retain: Boolean)`.
+- Never inject or assign `ChatContract.Controller` from `ChatActivity` — `ChatView.setupControllers()` is the only wiring point; duplicating it creates double-subscription bugs.
+- Never remove `contentDescription` or accessibility roles from chat bubble views or the message `EditText` — TalkBack support was added deliberately and must be preserved on every edit to those layouts.
+- When touching SC↔Live transition code, manually verify: (1) SC top banner disappears after upgrade to Live, (2) pre-engagement hint does not reappear after upgrade, (3) banner does not linger after SC→Live hand-off. Each of these has caused a separate past regression.

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -437,9 +437,13 @@ internal class ChatManager(
 
     @VisibleForTesting
     fun mapTransferring(state: State): State = state.apply {
-        operatorStatusItem?.also { chatItems -= it }
-        operatorStatusItem = OperatorStatusItem.Transferring.also {
-            chatItems += it
+        val previous = operatorStatusItem
+        if (previous is OperatorStatusItem.InQueue) {
+            chatItems -= previous
+        }
+        operatorStatusItem = OperatorStatusItem.Transferring
+        if (!chatItems.contains(OperatorStatusItem.Transferring)) {
+            chatItems += OperatorStatusItem.Transferring
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatItems.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatItems.kt
@@ -170,22 +170,27 @@ internal object NewMessagesDividerItem : ChatItem(ChatAdapter.NEW_MESSAGES_DIVID
 }
 
 internal sealed class OperatorStatusItem : ChatItem(ChatAdapter.OPERATOR_STATUS_VIEW_TYPE) {
-    override val id: String = "operator_status_item"
     override val timestamp: Long = -1
 
-    data object InQueue : OperatorStatusItem()
+    data object InQueue : OperatorStatusItem() {
+        override val id: String = "operator_status_in_queue"
+    }
+
+    data object Transferring : OperatorStatusItem() {
+        override val id: String = "operator_status_transferring"
+    }
 
     data class Connected(
         val operatorName: String,
-        val profileImgUrl: String?
+        val profileImgUrl: String?,
+        override val id: String = UUID.randomUUID().toString()
     ) : OperatorStatusItem()
 
     data class Joined(
         val operatorName: String,
-        val profileImgUrl: String?
+        val profileImgUrl: String?,
+        override val id: String = UUID.randomUUID().toString()
     ) : OperatorStatusItem()
-
-    data object Transferring : OperatorStatusItem()
 }
 
 // Visitor

--- a/widgetssdk/src/main/java/com/glia/widgets/di/CLAUDE.md
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/CLAUDE.md
@@ -1,0 +1,51 @@
+<!-- deep-research: completed 2026-04-24 | v: deep-research/1.7 | scope: widgetssdk/src/main/java/com/glia/widgets/di -->
+# DI Layer
+> The wiring spine of the SDK — factories, lifecycle watchers, and the GliaCore testability seam
+
+Parent: [CLAUDE.md](../../../../../../../../CLAUDE.md) | [docs/claude-reference.md](../../../../../../../../docs/claude-reference.md)
+
+## Context Loading Order
+1. `Dependencies.kt` — Kotlin `object`; orchestration entry point, initialization order, lifecycle watcher registration
+2. `ControllerFactory.java` — retained controller semantics; central DI registry for every controller
+3. `UseCaseFactory.java` — use case registration; moves in lockstep with `ControllerFactory`
+
+## Where to Look
+| Task | File |
+|------|------|
+| Wire a new Controller | `ControllerFactory.java` |
+| Wire a new UseCase | `UseCaseFactory.java` |
+| Wire a new Repository | `RepositoryFactory.java` |
+| Substitute Core SDK in tests | `Dependencies.kt` — `gliaCore` has `@VisibleForTesting set` |
+| Substitute factories in tests | `Dependencies.kt` — `controllerFactory`, `useCaseFactory`, `repositoryFactory`, `schedulers` all expose `@VisibleForTesting set` |
+| Understand Activity-top access | `Dependencies.kt` `onAppCreate` — `registerActivityLifecycleCallbacks` calls |
+| Add/change the Core SDK wrapper | `GliaCore.kt` (interface), `GliaCoreImpl.kt` (delegates to `Glia.*`) |
+
+## Conventions
+
+**`by lazy` vs `get()` in `Dependencies.kt`**:
+- `by lazy` — initialized once on first access, cached for the process lifetime. Used for `activityLauncher`, `engagementLauncher`, `pushNotifications`, `liveObservation`, `secureConversations`. Safe only when the object is stateless or its dependencies are stable after `onAppCreate`.
+- `get()` computed property — returns a **new instance on every access**. Used for `entryWidget` (`EntryWidgetImpl`). Caching it externally causes double-parent attachment issues.
+
+**`@VisibleForTesting set`** is the sanctioned test injection seam. `gliaCore`, `controllerFactory`, `useCaseFactory`, `repositoryFactory`, `schedulers` all expose public setters guarded by `@VisibleForTesting`. Tests substitute via direct assignment — there is no DI framework, no `@Rule`, no helper.
+
+**Retained controllers** — `retainedChatController` and `retainedCallController` in `ControllerFactory.java` are instance fields, null-checked and lazily constructed. They survive Activity recreation; no `ViewModel` exists because of them. `destroyChatController()` / `destroyCallController()` call `onDestroy(false)` and null the reference. `destroyControllers()` runs both plus service/application chat-head controllers and `messagesNotSeenHandler`.
+
+**Java factories are intentional** — `ControllerFactory.java`, `UseCaseFactory.java`, `RepositoryFactory.java` are Java pseudo-singletons with static fields for selected cached instances (see the `private static` declarations near the top of `UseCaseFactory.java` — a small set of `get*` methods cache via those fields; most `get*` and all `create*` methods return fresh instances). Do not rewrite them to Kotlin objects without coordinating across active feature branches; these files are touched by most feature work.
+
+**Activity watchers share a coordination bus** — all watchers registered in `Dependencies.onAppCreate` (`CallVisualizerActivityWatcher`, `ActivityWatcherForChatHead`, `ActivityWatcherForLiveObservation`, `ActivityWatcherForPermissionsRequest`, `EngagementCompletionActivityWatcher`, `OperatorRequestActivityWatcher`, `UiComponentsActivityWatcher`) extend `BaseSingleActivityWatcher` and expose `resumedActivity: Flowable<WeakReference<Activity>>` (backed by a `PublishProcessor`). Route "top activity" access through one of these — never a static field.
+
+**Initialization is two-phase** — `onAppCreate(application)` must run first (registers watchers, creates factories). `onSdkInit(config)` runs later via `GliaWidgets.init(...)` and calls `gliaCore.init`, `controllerFactory.init()`, `repositoryFactory.initialize()`, `configurationManager.applyConfiguration(config)`, `gliaThemeManager.applyJsonConfig(...)`. Properties guarded by `lateinit` (e.g., `controllerFactory`, `useCaseFactory`) throw `UninitializedPropertyAccessException` if accessed before `onAppCreate`.
+
+**`RepositoryFactory` static fields** — `secureConversationsRepository`, `queueRepository`, `fileAttachmentRepository` etc. are `static` in `RepositoryFactory.java`. They survive `destroyControllers()` — repositories are process-global state, controllers are not.
+
+## Anti-Patterns
+
+- **Adding a `by lazy` property to `Dependencies.kt` that depends on `useCaseFactory` or `controllerFactory`** before confirming both `lateinit` fields are initialized — `by lazy` executes on first access, which may be before `onAppCreate`. Move such initialization inside `onAppCreate` or guard access.
+- **Adding a retained controller without a matching `destroy*Controller()` method and a call from `destroyControllers()`** — the retention pattern leaks memory without explicit cleanup.
+- **Mixing `create*` and `get*` semantics in `UseCaseFactory.java`** — the convention is that a handful of `get*` methods cache via the `private static` fields declared at the top of the class; other `get*` and all `create*` return fresh instances. Caching a stateful new use case accidentally silently shares mutable state across controllers.
+
+## For AI Agents
+- Never call `Dependencies.controllerFactory`, `Dependencies.useCaseFactory`, or `Dependencies.repositoryFactory` before `onAppCreate` has been called — they are `lateinit` and will throw `UninitializedPropertyAccessException`.
+- Never call `Glia.*` statics directly outside `GliaCoreImpl.kt` — they bypass the `GliaCore` testability seam and break tests that substitute `Dependencies.gliaCore`.
+- Never access the current Activity via a static field — route through a registered `ActivityLifecycleCallbacks` watcher.
+- When adding to `UseCaseFactory.java`, name new methods with `create*` if they return a fresh instance and `get*` only if you intentionally cache via a new `private static` field — mixing the convention hides shared state.

--- a/widgetssdk/src/main/java/com/glia/widgets/engagement/CLAUDE.md
+++ b/widgetssdk/src/main/java/com/glia/widgets/engagement/CLAUDE.md
@@ -1,0 +1,39 @@
+<!-- deep-research: completed 2026-04-24 | v: deep-research/1.7 | scope: widgetssdk/src/main/java/com/glia/widgets/engagement -->
+# Engagement
+> State machine backbone — single source of truth for every engagement lifecycle event in the SDK
+
+Parent: [CLAUDE.md](../../../../../../../../CLAUDE.md) | [docs/claude-reference.md](../../../../../../../../docs/claude-reference.md)
+
+## Context Loading Order
+1. `States.kt` — sealed `State` and `EndAction` hierarchies; read before touching any engagement logic
+2. `EngagementRepository.kt` — public contract surface subscribed to by every downstream controller
+3. `EngagementRepositoryImpl.kt` — Omnicore event bridge; where `BehaviorProcessor<State>` is driven
+4. `completion/EngagementCompletionController.kt` — consumes `State.EngagementEnded` and maps to UI commands
+
+## Where to Look
+| Task | File |
+|------|------|
+| Add or rename a State variant | `States.kt` |
+| Change how Omnicore events map to State | `EngagementRepositoryImpl.kt` |
+| Change what happens at engagement end | `completion/EngagementCompletionController.kt` |
+| End-of-engagement UI (dialogs, survey, finish) | `completion/EngagementCompletionActivityWatcher.kt` |
+| New use case over engagement state | `domain/` |
+| EndAction-to-UI mapping | `completion/EngagementCompletionController.kt` |
+
+## Conventions
+- All use cases in `domain/` expose `operator fun invoke(...)` as the single entry point; add a named method only if a second distinct operation is required (see `EndEngagementUseCase.silently()` as the exception pattern). Evidence: `domain/EndEngagementUseCase.kt`
+- `EngagementRepositoryImpl` sets `currentEngagement = engagement` before emitting any new `State` — downstream code that reads `currentEngagement` inside state handlers depends on this ordering. Evidence: `EngagementRepositoryImpl.kt`
+- `endEngagement()` is for visitor-initiated ends (log: "ended by:visitor") and checks `state.actionOnEnd.isSurvey`; `terminateEngagement()` is for integrator-initiated ends (log: "ended by:integrator") and does not check survey. Evidence: `EngagementRepositoryImpl.kt`
+- `BehaviorProcessor<State>` exposes `engagementState` via `.onBackpressureBuffer().distinctUntilChanged()` — consecutive identical states are swallowed. When a transient state must be observed (e.g., `QueueUnstaffed` → `NoEngagement`), both must be emitted as separate `onNext` calls.
+
+## Anti-Patterns
+- **Do NOT emit engagement state from anywhere except `EngagementRepositoryImpl`** — side channels break all downstream subscribers and violate the single-source-of-truth contract.
+- **Do NOT read `currentEngagement` before `EngagementRepositoryImpl` has updated it** — several handlers depend on the ordering; reordering causes stale-engagement bugs that are hard to reproduce.
+- **Do NOT remove the `ensureNotScTransferredEngagement` guard in `handleEngagementEnd`** — it protects against the reverted "fix engagement end during de-authentication" failure mode (commit `bdcf1895`). Removing it re-introduces that regression.
+- **Do NOT call `releaseResourcesUseCase()` when `EndAction` is `Retain`** — `EngagementCompletionController` explicitly returns early for `Retain`; releasing resources breaks the retained-engagement flow.
+
+## For AI Agents
+- Never add a new `State` or `EndAction` variant without grepping for all `when (state)` and `when (state.endAction)` branches across the codebase — unhandled variants silently fall to `else` and drop the event.
+- Never route engagement lifecycle events through a new repository, manager, or subject. All engagement state flows exclusively through `EngagementRepository.engagementState`.
+- Never call `reset()` on `EngagementRepository` during an active live engagement without verifying the auth/de-auth path — the engagement-end-during-de-authentication fix was reverted (`bdcf1895`); any change in this area must be paired with push-notification and authentication regression testing.
+- Never instantiate `EngagementCompletionController` outside the single wiring path (`ControllerFactory.getEndEngagementController()` consumed once in `Dependencies.onAppCreate`) — a second instance produces duplicate UI events.

--- a/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/CLAUDE.md
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/unifiedui/CLAUDE.md
@@ -1,0 +1,41 @@
+<!-- deep-research: completed 2026-04-24 | v: deep-research/1.7 | scope: widgetssdk/src/main/java/com/glia/widgets/view/unifiedui -->
+# Unified UI
+> Three-stage theme pipeline: JSON → RemoteConfiguration → UnifiedTheme applied by Views via extension functions
+
+Parent: [CLAUDE.md](../../../../../../../../../CLAUDE.md) | [docs/claude-reference.md](../../../../../../../../../docs/claude-reference.md)
+
+## Context Loading Order
+1. `config/RemoteConfiguration.kt` — stage 2 hub: owns all screen `@SerializedName` mappings and orchestrates `DefaultTheme merge unifiedTheme`
+2. `theme/UnifiedTheme.kt` — final data model; all screen themes and `isWhiteLabel` live here
+3. `UnifiedUiExtensions.kt` — how Views consume themes: `applyColorTheme`, `applyLayerTheme`, `applyButtonTheme`, `applyTextTheme`
+4. `parse/RemoteConfigurationParser.kt` — Gson setup; all custom deserializers registered here
+
+## Where to Look
+| Task | File |
+|------|------|
+| Add a screen theme field | `theme/UnifiedTheme.kt` + `config/RemoteConfiguration.kt` + `theme/defaulttheme/` |
+| Add a JSON key mapping | DTO inside `config/<screen>/` with `@SerializedName` |
+| Add a color/size deserializer | `parse/Deserializers.kt` — see `ColorDeserializer`, `DpDeserializer`, `SpDeserializer` |
+| Apply theme to a View | `UnifiedUiExtensions.kt` extension functions |
+| Change default fallback colors | `theme/defaulttheme/` top-level functions; `config/GlobalColorsConfig.kt` drives `ColorPallet` |
+| Suppress Glia branding | `isWhiteLabel` in `RemoteConfiguration` / `UnifiedTheme`; consumed via `applyWhiteLabel()` |
+
+## Conventions
+- **Three-stage pipeline**: JSON string → `RemoteConfigurationParser` (Gson + custom deserializers) → `RemoteConfiguration.toUnifiedTheme()` → `UnifiedThemeManager.theme`. Entry point: `UnifiedThemeManager.applyJsonConfig()`.
+- **Merge direction**: `defaultTheme merge unifiedTheme` — the remote overlay wins when non-null. Any field absent from JSON stays as `DefaultTheme` fallback; explicit `null` in remote also means "use default" under current semantics. Evidence: `Merge.kt`
+- **`DefaultTheme` is a top-level function**, not a class. Lives in `theme/defaulttheme/` under `@file:Suppress("FunctionName")` with a capital name. Treat it as a builder, not a singleton. Evidence: `theme/defaulttheme/Base.kt`
+- **Views read theme directly**: `Dependencies.gliaThemeManager.theme?.<screenTheme>` in View `onAttach`/`init`. Theme is a View-layer concern — never pass it through MVP Contracts or Controllers.
+- **Custom Gson deserializers** handle type coercion: `ColorRemoteConfig` (`@JvmInline internal value class` wrapping `@ColorInt Int`), `SizeDpRemoteConfig`, `SizeSpRemoteConfig`. New primitive remote types always need a matching deserializer registered in `RemoteConfigurationParser`. Evidence: `parse/Deserializers.kt`, `config/base/ColorRemoteConfig.kt`, `config/base/Size.kt`
+- `isWhiteLabel` propagates from JSON → `RemoteConfiguration` → `UnifiedTheme`; Views call `applyWhiteLabel(isWhiteLabel)` to hide Glia branding elements.
+
+## Anti-Patterns
+- **Adding a theme property to only one side of the pipeline** — adding to `RemoteConfiguration` without updating the `DefaultTheme` function (or vice versa) silently yields `null` everywhere. Both sides are required.
+- **New screen theme not wired into `UnifiedTheme`** — a `FooTheme` data class that isn't added to `UnifiedTheme` and `RemoteConfiguration.toUnifiedTheme()` is unreachable at runtime.
+- **Hardcoding colors or dimensions in Views** — all values must flow from `GlobalColorsConfig` / theme overlay. Hardcoded values break white-label and operator-configured theming silently.
+- **Extending `UiTheme.kt`** — that class is `@Parcelize` and deprecated. New themeable properties go exclusively through the JSON remote config path.
+- **Skipping snapshot test updates** — every change in this package has visual impact. Run `./gradlew widgetssdk:recordPaparazziSnapshot` and commit updated snapshots.
+
+## For AI Agents
+- Never add a new theme property to only `RemoteConfiguration` or only `DefaultTheme` — both files must be edited together or the property is null at runtime with no error.
+- Never pass `UnifiedTheme` or any screen theme through a Controller or Contract interface — Views read theme directly from `Dependencies.gliaThemeManager`.
+- Never add a new remote primitive type (color, size, alignment) without registering a corresponding custom deserializer in `RemoteConfigurationParser` — Gson will silently produce null or throw for unregistered inline value classes.

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -286,6 +286,63 @@ class ChatManagerTest {
     }
 
     @Test
+    fun `multi-transfer sequence preserves all Connected and Joined items with unique stable ids`() {
+        val connectedA = ChatManager.Action.OperatorConnected("operator_a", "image_a")
+        val joinedA = ChatManager.Action.OperatorJoined("operator_a", "image_a")
+        val connectedB = ChatManager.Action.OperatorConnected("operator_b", "image_b")
+        val joinedB = ChatManager.Action.OperatorJoined("operator_b", "image_b")
+
+        subjectUnderTest.mapInQueue(state)
+        subjectUnderTest.mapOperatorConnected(connectedA, state)
+        subjectUnderTest.mapOperatorJoined(joinedA, state)
+        subjectUnderTest.mapTransferring(state)
+        subjectUnderTest.mapOperatorConnected(connectedB, state)
+        subjectUnderTest.mapOperatorJoined(joinedB, state)
+
+        val statusItems = state.chatItems.filterIsInstance<OperatorStatusItem>()
+        assertEquals(4, statusItems.size)
+        val first = statusItems[0] as OperatorStatusItem.Connected
+        val second = statusItems[1] as OperatorStatusItem.Joined
+        val third = statusItems[2] as OperatorStatusItem.Connected
+        val fourth = statusItems[3] as OperatorStatusItem.Joined
+        assertEquals("operator_a", first.operatorName)
+        assertEquals("operator_a", second.operatorName)
+        assertEquals("operator_b", third.operatorName)
+        assertEquals("operator_b", fourth.operatorName)
+
+        val stableIds = statusItems.map { it.stableId }
+        assertEquals(stableIds.size, stableIds.toSet().size)
+        assertFalse(state.chatItems.contains(OperatorStatusItem.Transferring))
+        assertFalse(state.chatItems.contains(OperatorStatusItem.InQueue))
+    }
+
+    @Test
+    fun `mapTransferring does not remove preceding Connected or Joined items`() {
+        val connectedAction = ChatManager.Action.OperatorConnected("operator_a", "image_a")
+        val joinedAction = ChatManager.Action.OperatorJoined("operator_a", "image_a")
+
+        subjectUnderTest.mapOperatorConnected(connectedAction, state)
+        subjectUnderTest.mapOperatorJoined(joinedAction, state)
+        val connectedBefore = state.chatItems[0] as OperatorStatusItem.Connected
+        val joinedBefore = state.chatItems[1] as OperatorStatusItem.Joined
+
+        subjectUnderTest.mapTransferring(state)
+
+        assertEquals(3, state.chatItems.size)
+        assertEquals(connectedBefore, state.chatItems[0])
+        assertEquals(joinedBefore, state.chatItems[1])
+        assertEquals(OperatorStatusItem.Transferring, state.chatItems[2])
+    }
+
+    @Test
+    fun `mapTransferring is idempotent when called repeatedly`() {
+        subjectUnderTest.mapTransferring(state)
+        subjectUnderTest.mapTransferring(state)
+
+        assertEquals(1, state.chatItems.count { it is OperatorStatusItem.Transferring })
+    }
+
+    @Test
     fun `mapMediaUpgrade adds MediaUpgradeStartedTimerItem_Video to chatItems when video is true`() {
         subjectUnderTest.mapMediaUpgrade(true, state).apply {
             assertTrue(chatItems.count() == 1)

--- a/widgetssdk/src/testSnapshot/CLAUDE.md
+++ b/widgetssdk/src/testSnapshot/CLAUDE.md
@@ -1,0 +1,39 @@
+<!-- deep-research: completed 2026-04-24 | v: deep-research/1.7 | scope: widgetssdk/src/testSnapshot -->
+# testSnapshot
+> Paparazzi snapshot tests — isolated `snapshot` build type, PNG outputs tracked by Git LFS
+
+Parent: [CLAUDE.md](../../../CLAUDE.md) | [docs/claude-reference.md](../../../docs/claude-reference.md)
+
+## Context Loading Order
+1. `java/com/glia/widgets/SnapshotTest.kt` — base class; all defaults live here (device, theme, pixel diff, `_paparazzi` rule)
+2. `../../build.gradle` — `snapshot` buildTypes block where Paparazzi plugin is applied; also shows `test.java.srcDirs = []` exclusion
+3. `../../../.gitattributes` (repo root) — LFS filter for `widgetssdk/src/test/snapshots/**/*.png`
+
+## Where to Look
+| Task | File/Location |
+|------|---------------|
+| Add a new snapshot test | New class extending `SnapshotTest`; implement relevant `Snapshot*` interface |
+| Change default device/theme/diff | `SnapshotTest.kt` constructor defaults |
+| Paparazzi plugin config | `widgetssdk/build.gradle` — `snapshot { apply plugin: 'app.cash.paparazzi' }` |
+| Theme helpers | `java/com/glia/widgets/snapshotutils/SnapshotTheme.kt`, `SnapshotThemeConfiguration.kt` |
+| Locale-flake fix | `_paparazzi` rule constructor parameters in `SnapshotTest.kt` |
+| PNG outputs | `widgetssdk/src/test/snapshots/` (Git LFS) |
+
+## Conventions
+- Extend `SnapshotTest` and implement one or more `Snapshot*` interfaces (`SnapshotTheme`, `SnapshotContent`, `SnapshotStrings`, `SnapshotProviders`, etc.) — never duplicate what the base class provides.
+- The Paparazzi JUnit rule is named `_paparazzi` (leading underscore) — this is intentional; do not rename it.
+- Default device `DeviceConfig.PIXEL_4A`, theme `"ThemeOverlay_Glia_Chat_Material"`, max pixel diff `0.001` — override only via the `SnapshotTest` constructor, never by patching globals.
+- Full-width views use the `SnapshotTest.fullWidthRenderMode` companion val (itself a Mockito mock of `RenderingMode`) — do not roll your own per-test `RenderingMode` substitute.
+- After rebasing onto UI changes, always re-run `./gradlew widgetssdk:recordPaparazziSnapshot` — stale PNGs cause false failures in CI.
+
+## Anti-Patterns
+- **Do NOT add Paparazzi to `debug` or `release` buildTypes** — the plugin injects Kotlin classpaths; moving it out of `snapshot {}` breaks those build types.
+- **Do NOT use `dependency.coreSdk.useDirect=true` (includeBuild) for snapshot runs** — composite substitution does not resolve for custom build types. Run `./gradlew widgetssdk:publishCoreSdkToLocalMaven` first, then execute snapshot tasks.
+- **Do NOT commit PNG files without confirming LFS pointers** — without `git lfs install` the files land as binary blobs; verify with `git lfs status` before pushing.
+- **Do NOT place unit-test scaffolding here** — `test.java.srcDirs = []` excludes the default test source set from the `snapshot` build type entirely; unit-test helpers will not compile.
+
+## For AI Agents
+- Never add `apply plugin: 'app.cash.paparazzi'` anywhere except inside the `snapshot {}` buildTypes block in `widgetssdk/build.gradle`.
+- Never write a snapshot test class that does not extend `SnapshotTest` — the `_paparazzi` rule and lifecycle wiring are only present in that base class.
+- Never rename the `_paparazzi` rule — the leading underscore is part of the base-class contract.
+- When a locale-sensitive screen causes flaky diffs, adjust `_paparazzi` constructor parameters (locale, device config) — do not bump `maxPercentDifference` as a workaround.


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5174

**What was solved?**
Replace the legacy single .claude/CLAUDE.md with a progressive-disclosure layout: a lean root CLAUDE.md, an on-demand docs/claude-reference.md, and six subdirectory guides covering the SDK module, DI layer, chat, engagement, unified UI, and snapshot tests. Each file is grounded in actual code with verified file-path citations.

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
