### PR TITLE
Fix IllegalStateException on operator transfer in ChatRecyclerView

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -437,9 +437,13 @@ internal class ChatManager(
 
     @VisibleForTesting
     fun mapTransferring(state: State): State = state.apply {
-        operatorStatusItem?.also { chatItems -= it }
-        operatorStatusItem = OperatorStatusItem.Transferring.also {
-            chatItems += it
+        val previous = operatorStatusItem
+        if (previous is OperatorStatusItem.InQueue) {
+            chatItems -= previous
+        }
+        operatorStatusItem = OperatorStatusItem.Transferring
+        if (!chatItems.contains(OperatorStatusItem.Transferring)) {
+            chatItems += OperatorStatusItem.Transferring
         }
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatItems.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/ChatItems.kt
@@ -170,22 +170,27 @@ internal object NewMessagesDividerItem : ChatItem(ChatAdapter.NEW_MESSAGES_DIVID
 }
 
 internal sealed class OperatorStatusItem : ChatItem(ChatAdapter.OPERATOR_STATUS_VIEW_TYPE) {
-    override val id: String = "operator_status_item"
     override val timestamp: Long = -1
 
-    data object InQueue : OperatorStatusItem()
+    data object InQueue : OperatorStatusItem() {
+        override val id: String = "operator_status_in_queue"
+    }
+
+    data object Transferring : OperatorStatusItem() {
+        override val id: String = "operator_status_transferring"
+    }
 
     data class Connected(
         val operatorName: String,
-        val profileImgUrl: String?
+        val profileImgUrl: String?,
+        override val id: String = UUID.randomUUID().toString()
     ) : OperatorStatusItem()
 
     data class Joined(
         val operatorName: String,
-        val profileImgUrl: String?
+        val profileImgUrl: String?,
+        override val id: String = UUID.randomUUID().toString()
     ) : OperatorStatusItem()
-
-    data object Transferring : OperatorStatusItem()
 }
 
 // Visitor

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -286,6 +286,63 @@ class ChatManagerTest {
     }
 
     @Test
+    fun `multi-transfer sequence preserves all Connected and Joined items with unique stable ids`() {
+        val connectedA = ChatManager.Action.OperatorConnected("operator_a", "image_a")
+        val joinedA = ChatManager.Action.OperatorJoined("operator_a", "image_a")
+        val connectedB = ChatManager.Action.OperatorConnected("operator_b", "image_b")
+        val joinedB = ChatManager.Action.OperatorJoined("operator_b", "image_b")
+
+        subjectUnderTest.mapInQueue(state)
+        subjectUnderTest.mapOperatorConnected(connectedA, state)
+        subjectUnderTest.mapOperatorJoined(joinedA, state)
+        subjectUnderTest.mapTransferring(state)
+        subjectUnderTest.mapOperatorConnected(connectedB, state)
+        subjectUnderTest.mapOperatorJoined(joinedB, state)
+
+        val statusItems = state.chatItems.filterIsInstance<OperatorStatusItem>()
+        assertEquals(4, statusItems.size)
+        val first = statusItems[0] as OperatorStatusItem.Connected
+        val second = statusItems[1] as OperatorStatusItem.Joined
+        val third = statusItems[2] as OperatorStatusItem.Connected
+        val fourth = statusItems[3] as OperatorStatusItem.Joined
+        assertEquals("operator_a", first.operatorName)
+        assertEquals("operator_a", second.operatorName)
+        assertEquals("operator_b", third.operatorName)
+        assertEquals("operator_b", fourth.operatorName)
+
+        val stableIds = statusItems.map { it.stableId }
+        assertEquals(stableIds.size, stableIds.toSet().size)
+        assertFalse(state.chatItems.contains(OperatorStatusItem.Transferring))
+        assertFalse(state.chatItems.contains(OperatorStatusItem.InQueue))
+    }
+
+    @Test
+    fun `mapTransferring does not remove preceding Connected or Joined items`() {
+        val connectedAction = ChatManager.Action.OperatorConnected("operator_a", "image_a")
+        val joinedAction = ChatManager.Action.OperatorJoined("operator_a", "image_a")
+
+        subjectUnderTest.mapOperatorConnected(connectedAction, state)
+        subjectUnderTest.mapOperatorJoined(joinedAction, state)
+        val connectedBefore = state.chatItems[0] as OperatorStatusItem.Connected
+        val joinedBefore = state.chatItems[1] as OperatorStatusItem.Joined
+
+        subjectUnderTest.mapTransferring(state)
+
+        assertEquals(3, state.chatItems.size)
+        assertEquals(connectedBefore, state.chatItems[0])
+        assertEquals(joinedBefore, state.chatItems[1])
+        assertEquals(OperatorStatusItem.Transferring, state.chatItems[2])
+    }
+
+    @Test
+    fun `mapTransferring is idempotent when called repeatedly`() {
+        subjectUnderTest.mapTransferring(state)
+        subjectUnderTest.mapTransferring(state)
+
+        assertEquals(1, state.chatItems.count { it is OperatorStatusItem.Transferring })
+    }
+
+    @Test
     fun `mapMediaUpgrade adds MediaUpgradeStartedTimerItem_Video to chatItems when video is true`() {
         subjectUnderTest.mapMediaUpgrade(true, state).apply {
             assertTrue(chatItems.count() == 1)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5208

**What was solved?**
During an engagement transfer in chat, the previous operator's Connected and Joined chat history items are removed when the Transferring status is inserted. Additionally, all OperatorStatusItem subtypes share the same stable id (operator_status_item) crashes application with the IllegalStateExecption.

- Added UUIDs for OperatorStatusItems
- Now the old OperatorStatusItems preserve in chat when the "TransFerring" appears. 

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
