### PR TITLE
Add CallForegroundService to protect active call media process in background

### DIFF
--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
     <uses-permission
         android:name="android.permission.CAMERA"
         android:required="false" />
@@ -91,6 +93,13 @@
             android:stopWithTask="true" />
 
         <service android:name=".core.notification.NotificationRemovalService" />
+
+        <service
+            android:name=".internal.notification.device.CallForegroundService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="microphone|camera"
+            android:stopWithTask="false" />
 
         <provider
             android:name=".core.fileupload.GliaFileProvider"

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/notification/device/CallForegroundService.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/notification/device/CallForegroundService.kt
@@ -1,0 +1,123 @@
+package com.glia.widgets.internal.notification.device
+
+import android.annotation.SuppressLint
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TAG
+import com.glia.widgets.internal.notification.NotificationFactory
+
+private const val EXTRA_CALL_TYPE = "call_type"
+private const val EXTRA_HAS_AUDIO = "has_audio"
+
+private const val CALL_TYPE_AUDIO = 0
+private const val CALL_TYPE_ONE_WAY_VIDEO = 1
+private const val CALL_TYPE_TWO_WAY_VIDEO = 2
+
+// ServiceInfo constants are compile-time inlined, so safe on minSdk 24.
+// ServiceCompat.startForeground ignores the type param on API < 29.
+@SuppressLint("InlinedApi")
+private val FOREGROUND_TYPE_MICROPHONE = ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+
+@SuppressLint("InlinedApi")
+private val FOREGROUND_TYPE_CAMERA = ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+
+/**
+ * Glia internal class.
+ *
+ * It will be automatically added to the integrator's manifest file by the manifest merger during compilation.
+ *
+ * Runs as a foreground service during active audio/video calls to prevent the OS from killing
+ * the media process when the app is backgrounded.
+ */
+internal class CallForegroundService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val callType = intent?.getIntExtra(EXTRA_CALL_TYPE, CALL_TYPE_AUDIO) ?: CALL_TYPE_AUDIO
+        val hasAudio = intent?.getBooleanExtra(EXTRA_HAS_AUDIO, true) ?: true
+
+        val notification = when (callType) {
+            CALL_TYPE_TWO_WAY_VIDEO -> NotificationFactory.createVideoCallNotification(
+                context = this,
+                isTwoWayVideo = true,
+                hasAudio = hasAudio
+            )
+            CALL_TYPE_ONE_WAY_VIDEO -> NotificationFactory.createVideoCallNotification(
+                context = this,
+                isTwoWayVideo = false,
+                hasAudio = hasAudio
+            )
+            else -> NotificationFactory.createAudioCallNotification(this)
+        }
+
+        // Two-way video: visitor has both microphone and camera active.
+        // All other call types: visitor has microphone only.
+        val serviceType = if (callType == CALL_TYPE_TWO_WAY_VIDEO) {
+            FOREGROUND_TYPE_MICROPHONE or FOREGROUND_TYPE_CAMERA
+        } else {
+            FOREGROUND_TYPE_MICROPHONE
+        }
+
+        try {
+            ServiceCompat.startForeground(
+                this,
+                NotificationFactory.CALL_NOTIFICATION_ID,
+                notification,
+                serviceType
+            )
+        } catch (error: Throwable) {
+            Logger.e(TAG, "Failed to promote call service to foreground", error)
+        }
+
+        return START_NOT_STICKY
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        getSystemService(NotificationManager::class.java)
+            .cancel(NotificationFactory.CALL_NOTIFICATION_ID)
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
+    override fun onDestroy() {
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    internal companion object {
+        private const val TAG = "CallForegroundService"
+
+        fun startAudio(context: Context) {
+            start(context, CALL_TYPE_AUDIO, hasAudio = true)
+        }
+
+        fun startVideo(context: Context, isTwoWayVideo: Boolean, hasAudio: Boolean) {
+            val callType = if (isTwoWayVideo) CALL_TYPE_TWO_WAY_VIDEO else CALL_TYPE_ONE_WAY_VIDEO
+            start(context, callType, hasAudio = hasAudio)
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, CallForegroundService::class.java))
+        }
+
+        private fun start(context: Context, callType: Int, hasAudio: Boolean) {
+            val intent = Intent(context, CallForegroundService::class.java).apply {
+                putExtra(EXTRA_CALL_TYPE, callType)
+                putExtra(EXTRA_HAS_AUDIO, hasAudio)
+            }
+            try {
+                ContextCompat.startForegroundService(context, intent)
+            } catch (error: Throwable) {
+                Logger.e(TAG, "Failed to start CallForegroundService", error)
+            }
+        }
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/notification/device/NotificationManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/notification/device/NotificationManager.kt
@@ -56,31 +56,11 @@ internal class NotificationManager(
     }
 
     override fun showAudioCallNotification() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            // Android APIs 31+ have built in privacy indicators for microphone and camera
-            // See https://source.android.com/docs/core/permissions/privacy-indicators
-            return
-        }
-        if (areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID)) {
-            notificationManager.notify(
-                NotificationFactory.CALL_NOTIFICATION_ID,
-                NotificationFactory.createAudioCallNotification(applicationContext)
-            )
-        }
+        CallForegroundService.startAudio(applicationContext)
     }
 
     override fun showVideoCallNotification(isTwoWayVideo: Boolean, hasAudio: Boolean) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            // Android APIs 31+ have built in privacy indicators for microphone and camera
-            // See https://source.android.com/docs/core/permissions/privacy-indicators
-            return
-        }
-        if (areNotificationsEnabledForChannel(NotificationFactory.NOTIFICATION_CALL_CHANNEL_ID)) {
-            notificationManager.notify(
-                NotificationFactory.CALL_NOTIFICATION_ID,
-                NotificationFactory.createVideoCallNotification(applicationContext, isTwoWayVideo, hasAudio)
-            )
-        }
+        CallForegroundService.startVideo(applicationContext, isTwoWayVideo, hasAudio)
     }
 
     override fun startNotificationRemovalService() {
@@ -95,6 +75,7 @@ internal class NotificationManager(
     }
 
     override fun removeCallNotification() {
+        CallForegroundService.stop(applicationContext)
         notificationManager.cancel(NotificationFactory.CALL_NOTIFICATION_ID)
         applicationContext.stopService(notificationRemovalServiceIntent)
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/notification/device/CallForegroundServiceTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/notification/device/CallForegroundServiceTest.kt
@@ -1,0 +1,162 @@
+package com.glia.widgets.internal.notification.device
+
+import android.app.Application
+import android.mock
+import android.os.Build
+import android.unMock
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.internal.notification.NotificationFactory
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class CallForegroundServiceTest {
+    private lateinit var application: Application
+
+    @Before
+    fun setUp() {
+        Logger.mock()
+        application = RuntimeEnvironment.getApplication()
+        setupLocaleProvider()
+    }
+
+    @After
+    fun tearDown() {
+        Logger.unMock()
+    }
+
+    @Test
+    fun `startAudio enqueues a start intent for CallForegroundService`() {
+        CallForegroundService.startAudio(application)
+
+        val started = shadowOf(application).nextStartedService
+        assertNotNull(started)
+        assertEquals(CallForegroundService::class.java.name, started?.component?.className)
+    }
+
+    @Test
+    fun `startVideo enqueues a start intent for CallForegroundService`() {
+        CallForegroundService.startVideo(application, isTwoWayVideo = true, hasAudio = true)
+
+        val started = shadowOf(application).nextStartedService
+        assertNotNull(started)
+        assertEquals(CallForegroundService::class.java.name, started?.component?.className)
+    }
+
+    @Test
+    fun `stop enqueues a stop intent for CallForegroundService`() {
+        CallForegroundService.stop(application)
+
+        val stopped = shadowOf(application).nextStoppedService
+        assertNotNull(stopped)
+        assertEquals(CallForegroundService::class.java.name, stopped?.component?.className)
+    }
+
+    @Test
+    fun `audio call promotes service to foreground`() {
+        CallForegroundService.startAudio(application)
+        val intent = shadowOf(application).nextStartedService
+
+        val controller = Robolectric.buildService(CallForegroundService::class.java, intent)
+            .create()
+            .startCommand(0, 0)
+        val shadow = shadowOf(controller.get())
+
+        assertNotNull("Foreground notification should be set for audio call", shadow.lastForegroundNotification)
+        assertEquals(NotificationFactory.CALL_NOTIFICATION_ID, shadow.lastForegroundNotificationId)
+    }
+
+    @Test
+    fun `two-way video call promotes service to foreground`() {
+        CallForegroundService.startVideo(application, isTwoWayVideo = true, hasAudio = true)
+        val intent = shadowOf(application).nextStartedService
+
+        val controller = Robolectric.buildService(CallForegroundService::class.java, intent)
+            .create()
+            .startCommand(0, 0)
+        val shadow = shadowOf(controller.get())
+
+        assertNotNull("Foreground notification should be set for two-way video", shadow.lastForegroundNotification)
+        assertEquals(NotificationFactory.CALL_NOTIFICATION_ID, shadow.lastForegroundNotificationId)
+    }
+
+    @Test
+    fun `one-way video call promotes service to foreground`() {
+        CallForegroundService.startVideo(application, isTwoWayVideo = false, hasAudio = true)
+        val intent = shadowOf(application).nextStartedService
+
+        val controller = Robolectric.buildService(CallForegroundService::class.java, intent)
+            .create()
+            .startCommand(0, 0)
+        val shadow = shadowOf(controller.get())
+
+        assertNotNull("Foreground notification should be set for one-way video", shadow.lastForegroundNotification)
+        assertEquals(NotificationFactory.CALL_NOTIFICATION_ID, shadow.lastForegroundNotificationId)
+    }
+
+    @Test
+    fun `onTaskRemoved removes the foreground notification`() {
+        CallForegroundService.startAudio(application)
+        val intent = shadowOf(application).nextStartedService
+
+        val controller = Robolectric.buildService(CallForegroundService::class.java, intent)
+            .create()
+            .startCommand(0, 0)
+        val service = controller.get()
+
+        service.onTaskRemoved(null)
+        controller.destroy()
+
+        assertTrue(
+            "Foreground should be stopped after onTaskRemoved",
+            shadowOf(service).isForegroundStopped
+        )
+    }
+
+    @Test
+    fun `startForeground failure is swallowed without crashing`() {
+        CallForegroundService.startAudio(application)
+        val intent = shadowOf(application).nextStartedService
+
+        val controller = Robolectric.buildService(CallForegroundService::class.java, intent).create()
+        shadowOf(controller.get()).setThrowInStartForeground(RuntimeException("simulated failure"))
+
+        // Should not throw
+        controller.startCommand(0, 0)
+
+        assertNull("Foreground notification should be null after failure", shadowOf(controller.get()).lastForegroundNotification)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun `audio call promotes service to foreground on API 31`() {
+        CallForegroundService.startAudio(application)
+        val intent = shadowOf(application).nextStartedService
+
+        val controller = Robolectric.buildService(CallForegroundService::class.java, intent)
+            .create()
+            .startCommand(0, 0)
+        val shadow = shadowOf(controller.get())
+
+        assertNotNull("Foreground notification should be set on API 31", shadow.lastForegroundNotification)
+        assertEquals(NotificationFactory.CALL_NOTIFICATION_ID, shadow.lastForegroundNotificationId)
+    }
+
+    private fun setupLocaleProvider() {
+        com.glia.widgets.di.Dependencies.localeProvider =
+            mockk<com.glia.widgets.locale.LocaleProvider>(relaxed = true)
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/notification/device/NotificationManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/notification/device/NotificationManagerTest.kt
@@ -1,0 +1,97 @@
+package com.glia.widgets.internal.notification.device
+
+import android.app.Application
+import android.mock
+import android.os.Build
+import android.unMock
+import com.glia.widgets.helper.Logger
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class NotificationManagerTest {
+    private lateinit var application: Application
+    private lateinit var manager: NotificationManager
+
+    @Before
+    fun setUp() {
+        Logger.mock()
+        application = RuntimeEnvironment.getApplication()
+        manager = NotificationManager(application)
+    }
+
+    @After
+    fun tearDown() {
+        Logger.unMock()
+    }
+
+    @Test
+    fun `showAudioCallNotification starts CallForegroundService`() {
+        manager.showAudioCallNotification()
+
+        val intent = shadowOf(application).nextStartedService
+        assertNotNull("Expected CallForegroundService to be started", intent)
+        assertEquals(
+            CallForegroundService::class.java.name,
+            intent?.component?.className
+        )
+    }
+
+    @Test
+    fun `showVideoCallNotification starts CallForegroundService`() {
+        manager.showVideoCallNotification(isTwoWayVideo = true, hasAudio = true)
+
+        val intent = shadowOf(application).nextStartedService
+        assertNotNull("Expected CallForegroundService to be started", intent)
+        assertEquals(
+            CallForegroundService::class.java.name,
+            intent?.component?.className
+        )
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun `showAudioCallNotification starts CallForegroundService on API 31`() {
+        manager.showAudioCallNotification()
+
+        val intent = shadowOf(application).nextStartedService
+        assertNotNull("Expected CallForegroundService to be started on API 31+", intent)
+        assertEquals(
+            CallForegroundService::class.java.name,
+            intent?.component?.className
+        )
+    }
+
+    @Test
+    fun `removeCallNotification stops CallForegroundService`() {
+        manager.removeCallNotification()
+
+        val stopped = shadowOf(application).nextStoppedService
+        assertNotNull("Expected CallForegroundService to be stopped", stopped)
+        assertEquals(
+            CallForegroundService::class.java.name,
+            stopped?.component?.className
+        )
+    }
+
+    @Test
+    fun `showVideoCallNotification one-way starts CallForegroundService`() {
+        manager.showVideoCallNotification(isTwoWayVideo = false, hasAudio = true)
+
+        val intent = shadowOf(application).nextStartedService
+        assertNotNull("Expected CallForegroundService to be started for one-way video", intent)
+        assertEquals(
+            CallForegroundService::class.java.name,
+            intent?.component?.className
+        )
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/notification/domain/CallNotificationUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/notification/domain/CallNotificationUseCaseTest.kt
@@ -1,0 +1,114 @@
+package com.glia.widgets.internal.notification.domain
+
+import android.mock
+import android.unMock
+import com.glia.androidsdk.comms.Audio
+import com.glia.androidsdk.comms.MediaState
+import com.glia.androidsdk.comms.Video
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.internal.notification.device.INotificationManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class CallNotificationUseCaseTest {
+    private lateinit var notificationManager: INotificationManager
+    private lateinit var useCase: CallNotificationUseCase
+
+    @Before
+    fun setUp() {
+        Logger.mock()
+        notificationManager = mockk(relaxUnitFun = true)
+        useCase = CallNotificationUseCase(notificationManager)
+    }
+
+    @After
+    fun tearDown() {
+        Logger.unMock()
+    }
+
+    @Test
+    fun `shows audio notification when both sides have audio but no video`() {
+        val visitorMedia = mediaState(audio = mockk(), video = null)
+        val operatorMedia = mediaState(audio = mockk(), video = null)
+
+        useCase(visitorMedia, operatorMedia)
+
+        verify { notificationManager.showAudioCallNotification() }
+    }
+
+    @Test
+    fun `shows one-way video notification when operator has video and visitor does not`() {
+        val visitorMedia = mediaState(audio = mockk(), video = null)
+        val operatorMedia = mediaState(audio = mockk(), video = mockk())
+
+        useCase(visitorMedia, operatorMedia)
+
+        verify { notificationManager.showVideoCallNotification(isTwoWayVideo = false, hasAudio = true) }
+    }
+
+    @Test
+    fun `shows two-way video notification when both sides have video`() {
+        val visitorMedia = mediaState(audio = mockk(), video = mockk())
+        val operatorMedia = mediaState(audio = mockk(), video = mockk())
+
+        useCase(visitorMedia, operatorMedia)
+
+        verify { notificationManager.showVideoCallNotification(isTwoWayVideo = true, hasAudio = true) }
+    }
+
+    @Test
+    fun `shows two-way video without audio when both have video but no audio`() {
+        val visitorMedia = mediaState(audio = null, video = mockk())
+        val operatorMedia = mediaState(audio = null, video = mockk())
+
+        useCase(visitorMedia, operatorMedia)
+
+        verify { notificationManager.showVideoCallNotification(isTwoWayVideo = true, hasAudio = false) }
+    }
+
+    @Test
+    fun `removes notification when both sides have no media`() {
+        useCase(null, null)
+
+        verify { notificationManager.removeCallNotification() }
+    }
+
+    @Test
+    fun `removes notification when both have no audio and no video`() {
+        val visitorMedia = mediaState(audio = null, video = null)
+        val operatorMedia = mediaState(audio = null, video = null)
+
+        useCase(visitorMedia, operatorMedia)
+
+        verify { notificationManager.removeCallNotification() }
+    }
+
+    @Test
+    fun `removeAllNotifications removes notification`() {
+        useCase.removeAllNotifications()
+
+        verify { notificationManager.removeCallNotification() }
+    }
+
+    @Test
+    fun `does not crash on unsupported one-way visitor video`() {
+        val visitorMedia = mediaState(audio = null, video = mockk())
+        val operatorMedia = mediaState(audio = null, video = null)
+
+        // Should not throw — logs and returns early
+        useCase(visitorMedia, operatorMedia)
+
+        verify(exactly = 0) { notificationManager.showVideoCallNotification(any(), any()) }
+        verify(exactly = 0) { notificationManager.showAudioCallNotification() }
+        verify(exactly = 0) { notificationManager.removeCallNotification() }
+    }
+
+    private fun mediaState(audio: Audio?, video: Video?): MediaState = mockk<MediaState>().also {
+        every { it.audio } returns audio
+        every { it.video } returns video
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5356

**What was solved?**
Removes the API 31+ early-return from showAudioCallNotification/showVideoCallNotification (introduced in ee596aca as a crash workaround for MOB-3358) and replaces it with CallForegroundService — a foreground service with type microphone|camera that starts when a call connects and stops when it ends. This keeps the media process alive when the app is backgrounded, fixing audio cutout on Samsung and other aggressive OEM devices.

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
