### PR TITLE
Migrate widgets chat send to the new unified Core API

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -2,9 +2,7 @@ package com.glia.widgets.chat
 
 import android.text.format.DateUtils
 import androidx.annotation.VisibleForTesting
-import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.OperatorMessage
-import com.glia.androidsdk.chat.SendMessagePayload
 import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.androidsdk.chat.SystemMessage
 import com.glia.androidsdk.chat.VisitorMessage
@@ -23,12 +21,12 @@ import com.glia.widgets.chat.model.ChatItem
 import com.glia.widgets.chat.model.CustomCardChatItem
 import com.glia.widgets.chat.model.GvaButton
 import com.glia.widgets.chat.model.GvaQuickReplies
-import com.glia.widgets.chat.model.LocalAttachmentItem
 import com.glia.widgets.chat.model.MediaUpgradeStartedTimerItem
 import com.glia.widgets.chat.model.NewMessagesDividerItem
 import com.glia.widgets.chat.model.OperatorChatItem
 import com.glia.widgets.chat.model.OperatorMessageItem
 import com.glia.widgets.chat.model.OperatorStatusItem
+import com.glia.widgets.chat.model.OutgoingMessage
 import com.glia.widgets.chat.model.RemoteAttachmentItem
 import com.glia.widgets.chat.model.TapToRetryItem
 import com.glia.widgets.chat.model.VisitorAttachmentItem
@@ -47,6 +45,7 @@ import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.processors.BehaviorProcessor
+import io.reactivex.rxjava3.processors.FlowableProcessor
 import io.reactivex.rxjava3.schedulers.Schedulers
 
 internal class ChatManager(
@@ -68,6 +67,10 @@ internal class ChatManager(
     private val action: BehaviorProcessor<Action> = BehaviorProcessor.create(),
     private val historyLoaded: BehaviorProcessor<Boolean> = BehaviorProcessor.createDefault(false)
 ) {
+    // Send callbacks invoke onChatAction from Core's background threads - BehaviorProcessor.onNext
+    // is not thread-safe, so emissions must go through this serialized wrapper.
+    private val serializedAction: FlowableProcessor<Action> = action.toSerialized()
+
     fun initialize(
         onHistoryLoaded: (hasHistory: Boolean) -> Unit,
         onQuickReplyReceived: (List<GvaButton>) -> Unit,
@@ -104,7 +107,7 @@ internal class ChatManager(
     }
 
     fun onChatAction(action: Action) {
-        this.action.onNext(action)
+        serializedAction.onNext(action)
     }
 
     @VisibleForTesting
@@ -148,11 +151,19 @@ internal class ChatManager(
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe { onQuickReplyReceived(it) }
 
+    // Core invokes send callbacks and emits CHAT_MESSAGE events on background threads, so the
+    // send-success path and the message-stream echo can arrive concurrently. State is mutable and
+    // not thread-safe - hop to the main thread before mapping so `isNew` reconciliation never
+    // processes the same message twice (which duplicated delivered messages).
     @VisibleForTesting
-    fun onMessage(): Flowable<State> = onMessageUseCase().toFlowable(BackpressureStrategy.BUFFER).withLatestFrom(state, ::mapNewMessage)
+    fun onMessage(): Flowable<State> = onMessageUseCase().toFlowable(BackpressureStrategy.BUFFER)
+        .observeOn(AndroidSchedulers.mainThread())
+        .withLatestFrom(state, ::mapNewMessage)
 
     @VisibleForTesting
-    fun onAction(): Flowable<State> = action.withLatestFrom(state, ::mapAction)
+    fun onAction(): Flowable<State> = action
+        .observeOn(AndroidSchedulers.mainThread())
+        .withLatestFrom(state, ::mapAction)
 
     @VisibleForTesting
     fun checkUnsentMessages(state: State) {
@@ -163,9 +174,9 @@ internal class ChatManager(
         sendMessage(payload)
     }
 
-    private fun sendMessage(payload: SendMessagePayload) {
+    private fun sendMessage(payload: OutgoingMessage) {
         sendUnsentMessagesUseCase(payload, {
-            onChatAction(Action.OnMessageSent(it))
+            onChatAction(Action.OnMessageSent(payload.messageId))
         }, {
             onChatAction(Action.OnSendMessageError(payload.messageId))
         })
@@ -179,7 +190,7 @@ internal class ChatManager(
 
         for (index in rawItems.indices.reversed()) {
             val rawMessage = rawItems[index]
-            if (state.isNew(rawMessage)) {
+            if (state.isNew(rawMessage.chatMessage.id)) {
                 appendHistoryChatMessageUseCase(chatItems, rawMessage, index == rawItems.lastIndex)
             }
         }
@@ -196,11 +207,26 @@ internal class ChatManager(
         return state
     }
 
+    /**
+     * Handles a send-API success confirmation: marks the optimistic item with [messageId] as
+     * delivered and tries the next unsent message. Skipped when the message was already
+     * reconciled through the incoming message stream.
+     */
+    @VisibleForTesting
+    fun mapMessageSent(messageId: String, messagesState: State): State {
+        if (messagesState.isNew(messageId)) {
+            appendNewChatMessageUseCase.markMessageDelivered(messageId, messagesState)
+            checkUnsentMessages(messagesState)
+        }
+
+        return messagesState
+    }
+
     @VisibleForTesting
     fun mapNewMessage(chatMessage: ChatMessageInternal, messagesState: State): State {
         check(chatMessage.chatMessage.isValid()) { "Invalid chat message passed -> ${chatMessage.chatMessage}" }
 
-        if (messagesState.isNew(chatMessage)) {
+        if (messagesState.isNew(chatMessage.chatMessage.id)) {
             appendNewChatMessageUseCase(messagesState, chatMessage)
             if (chatMessage.chatMessage is VisitorMessage) {
                 checkUnsentMessages(messagesState)
@@ -238,9 +264,9 @@ internal class ChatManager(
             is Action.OnMediaUpgradeTimerUpdated -> mapMediaUpgradeTimerUpdated(action.formattedValue, state)
             is Action.CustomCardClicked -> mapCustomCardClicked(action, state)
             Action.ChatRestored, Action.None -> state
-            is Action.AttachmentPreviewAdded -> mapAttachmentPreviewAdded(action.attachments, action.payload, state)
+            is Action.AttachmentPreviewAdded -> mapAttachmentPreviewAdded(action.attachment, action.outgoingMessage, state)
             is Action.MessagePreviewAdded -> mapMessagePreviewAdded(action.visitorChatItem, action.payload, state)
-            is Action.OnMessageSent -> mapNewMessage(ChatMessageInternal(action.message), state)
+            is Action.OnMessageSent -> mapMessageSent(action.messageId, state)
             is Action.OnSendMessageError -> mapSendMessageFailed(action.messageId, state)
             is Action.OnRetryClicked -> mapRetryClicked(action.messageId, state)
             is Action.OnSendMessageOperatorOffline -> mapSendMessageOperatorOffline(action.messageId, state)
@@ -289,18 +315,10 @@ internal class ChatManager(
             .takeIf { it != -1 }
             ?.also { chatItems.removeAt(it) }
 
-        val files = (payload.attachment as? FilesAttachment)?.files
-
         val messageIndex = chatItems.indexOfLast { it.id == payload.messageId }
 
         if (messageIndex != -1) {
             chatItems[messageIndex] = (chatItems[messageIndex] as VisitorChatItem).copyWithError(false)
-        }
-
-        files?.forEach { attachment ->
-            val index = chatItems.indexOfLast { it.id == attachment.id }
-
-            chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(false)
         }
     }
 
@@ -308,40 +326,26 @@ internal class ChatManager(
     fun mapSendMessageFailed(messageId: String, state: State): State = state.apply {
         val payload = messagePreviews[messageId] ?: return@apply
 
-        val files = (payload.attachment as? FilesAttachment)?.files.orEmpty()
-
         val messageIndex = chatItems.indexOfLast { it.id == payload.messageId }
 
         if (messageIndex != -1) {
             chatItems[messageIndex] = (chatItems[messageIndex] as VisitorChatItem).copyWithError(true)
         }
 
-        files.forEach { attachment ->
-            val index = chatItems.indexOfLast { it.id == attachment.id }
-
-            chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(true)
-        }
-
-        val lastItemIndex = if (files.isNotEmpty()) {
-            chatItems.indexOfLast { (it as? LocalAttachmentItem)?.messageId == payload.messageId }
-        } else {
-            messageIndex
-        }
-
-        chatItems.add(lastItemIndex + 1, TapToRetryItem(messageId = payload.messageId))
+        chatItems.add(messageIndex + 1, TapToRetryItem(messageId = payload.messageId))
     }
 
     @VisibleForTesting
-    fun mapMessagePreviewAdded(visitorChatItem: VisitorChatItem, payload: SendMessagePayload, state: State): State = state.apply {
+    fun mapMessagePreviewAdded(visitorChatItem: VisitorChatItem, payload: OutgoingMessage, state: State): State = state.apply {
         val index = indexForMessageItem(chatItems)
         chatItems.add(index, visitorChatItem)
         messagePreviews[payload.messageId] = payload
     }
 
     @VisibleForTesting
-    fun mapAttachmentPreviewAdded(attachments: List<VisitorAttachmentItem>, payload: SendMessagePayload?, state: State): State = state.apply {
-        payload?.also { messagePreviews[it.messageId] = it }
-        chatItems.addAll(attachments)
+    fun mapAttachmentPreviewAdded(attachment: VisitorAttachmentItem, outgoingMessage: OutgoingMessage, state: State): State = state.apply {
+        messagePreviews[attachment.id] = outgoingMessage
+        chatItems.add(attachment)
     }
 
     @VisibleForTesting
@@ -485,7 +489,7 @@ internal class ChatManager(
         val chatItems: MutableList<ChatItem> = mutableListOf(),
         val chatItemIds: MutableSet<String> = mutableSetOf(),
         val preEngagementChatItemIds: LinkedHashSet<String> = linkedSetOf(),
-        val messagePreviews: LinkedHashMap<String, SendMessagePayload> = LinkedHashMap(),
+        val messagePreviews: LinkedHashMap<String, OutgoingMessage> = LinkedHashMap(),
         var lastMessageWithVisibleOperatorImage: OperatorChatItem? = null,
         var operatorStatusItem: OperatorStatusItem? = null,
         var mediaUpgradeTimerItem: MediaUpgradeStartedTimerItem? = null,
@@ -493,7 +497,7 @@ internal class ChatManager(
     ) {
         val immutableChatItems: List<ChatItem> get() = chatItems.toList()
 
-        fun isNew(chatMessageInternal: ChatMessageInternal): Boolean = chatItemIds.add(chatMessageInternal.chatMessage.id)
+        fun isNew(messageId: String): Boolean = chatItemIds.add(messageId)
 
         fun isOperatorChanged(operatorChatItem: OperatorChatItem): Boolean = lastMessageWithVisibleOperatorImage.let {
             lastMessageWithVisibleOperatorImage = operatorChatItem
@@ -518,9 +522,9 @@ internal class ChatManager(
         data class CustomCardClicked(val customCard: CustomCardChatItem, val attachment: SingleChoiceAttachment) : Action
         data object ChatRestored : Action
         data object None : Action
-        data class MessagePreviewAdded(val visitorChatItem: VisitorChatItem, val payload: SendMessagePayload) : Action
-        data class AttachmentPreviewAdded(val attachments: List<VisitorAttachmentItem>, val payload: SendMessagePayload?) : Action
-        data class OnMessageSent(val message: VisitorMessage) : Action
+        data class MessagePreviewAdded(val visitorChatItem: VisitorChatItem, val payload: OutgoingMessage) : Action
+        data class AttachmentPreviewAdded(val attachment: VisitorAttachmentItem, val outgoingMessage: OutgoingMessage) : Action
+        data class OnMessageSent(val messageId: String) : Action
         data class OnSendMessageError(val messageId: String) : Action
         data class OnRetryClicked(val messageId: String) : Action
         data class OnSendMessageOperatorOffline(val messageId: String) : Action

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/controller/ChatController.kt
@@ -6,10 +6,8 @@ import com.glia.androidsdk.Engagement
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.Operator
 import com.glia.androidsdk.chat.AttachmentFile
-import com.glia.androidsdk.chat.SendMessagePayload
 import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.androidsdk.chat.SingleChoiceOption
-import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.androidsdk.comms.MediaState
 import com.glia.androidsdk.engagement.EngagementFile
 import com.glia.telemetry_lib.ButtonNames
@@ -39,6 +37,7 @@ import com.glia.widgets.chat.model.CustomCardChatItem
 import com.glia.widgets.chat.model.Gva
 import com.glia.widgets.chat.model.GvaButton
 import com.glia.widgets.chat.model.OperatorMessageItem
+import com.glia.widgets.chat.model.OutgoingMessage
 import com.glia.widgets.chat.model.VisitorAttachmentItem
 import com.glia.widgets.chat.model.VisitorChatItem
 import com.glia.widgets.di.Dependencies
@@ -66,7 +65,6 @@ import com.glia.widgets.helper.TimeCounter.FormattedTimerStatusListener
 import com.glia.widgets.helper.exists
 import com.glia.widgets.helper.formattedName
 import com.glia.widgets.helper.imageUrl
-import com.glia.widgets.helper.isValid
 import com.glia.widgets.internal.dialog.DialogContract
 import com.glia.widgets.internal.dialog.domain.ConfirmationDialogLinksUseCase
 import com.glia.widgets.internal.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
@@ -161,9 +159,9 @@ internal class ChatController(
     private var allowedMediaTypes: List<String> = listOf(Constants.MIME_TYPE_IMAGES)
 
     private val sendMessageCallback: GliaSendMessageUseCase.Listener = object : GliaSendMessageUseCase.Listener {
-        override fun messageSent(message: VisitorMessage?) {
-            Logger.d(TAG, "messageSent: $message, id: ${message?.id}")
-            onMessageSent(message)
+        override fun messageSent(messageId: String) {
+            Logger.d(TAG, "message sent id=$messageId")
+            onMessageSent(messageId)
         }
 
         override fun onMessageValidated() {
@@ -176,13 +174,13 @@ internal class ChatController(
             onSendMessageOperatorOffline()
         }
 
-        override fun onMessagePrepared(visitorChatItem: VisitorChatItem, payload: SendMessagePayload) {
+        override fun onMessagePrepared(visitorChatItem: VisitorChatItem, payload: OutgoingMessage) {
             addMessagePreview(visitorChatItem, payload)
             scrollChatToBottom()
         }
 
-        override fun onAttachmentsPrepared(items: List<VisitorAttachmentItem>, payload: SendMessagePayload?) {
-            addAttachmentPreview(items, payload)
+        override fun onAttachmentPrepared(attachment: VisitorAttachmentItem, outgoingMessage: OutgoingMessage) {
+            chatManager.onChatAction(ChatManager.Action.AttachmentPreviewAdded(attachment, outgoingMessage))
             scrollChatToBottom()
         }
 
@@ -441,17 +439,12 @@ internal class ChatController(
         }
     }
 
-    private fun onMessageSent(message: VisitorMessage?) {
-        message?.takeIf { it.isValid() }?.also { chatManager.onChatAction(ChatManager.Action.OnMessageSent(it)) }
+    private fun onMessageSent(messageId: String) {
+        chatManager.onChatAction(ChatManager.Action.OnMessageSent(messageId))
     }
 
-    private fun addMessagePreview(visitorChatItem: VisitorChatItem, payload: SendMessagePayload) {
+    private fun addMessagePreview(visitorChatItem: VisitorChatItem, payload: OutgoingMessage) {
         chatManager.onChatAction(ChatManager.Action.MessagePreviewAdded(visitorChatItem, payload))
-        scrollChatToBottom()
-    }
-
-    private fun addAttachmentPreview(items: List<VisitorAttachmentItem>, payload: SendMessagePayload?) {
-        chatManager.onChatAction(ChatManager.Action.AttachmentPreviewAdded(items, payload))
         scrollChatToBottom()
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/data/GliaChatRepository.kt
@@ -2,11 +2,9 @@ package com.glia.widgets.chat.data
 
 import com.glia.androidsdk.Glia
 import com.glia.androidsdk.GliaException
-import com.glia.androidsdk.RequestCallback
+import com.glia.androidsdk.chat.Chat
 import com.glia.androidsdk.chat.ChatMessage
-import com.glia.androidsdk.chat.SendMessagePayload
-import com.glia.androidsdk.chat.VisitorMessage
-import com.glia.widgets.chat.domain.GliaSendMessageUseCase.Listener
+import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.widgets.di.GliaCore
 import java.util.function.Consumer
 
@@ -36,31 +34,27 @@ internal class GliaChatRepository(private val gliaCore: GliaCore) {
 
     fun sendMessagePreview(message: String?) {
         message ?: return
-        gliaCore.currentEngagement.ifPresent { it.chat.sendMessagePreview(message) }
+        withChat { it.sendMessagePreview(message) }
     }
 
-    fun sendMessage(payload: SendMessagePayload, callback: RequestCallback<VisitorMessage?>) {
-        gliaCore.currentEngagement.ifPresent { engagement ->
-            engagement.chat.sendMessage(payload) { visitorMessage, ex -> callback.onResult(visitorMessage, ex) }
-        }
+    fun sendMessage(content: String, messageId: String, onSuccess: () -> Unit, onFailure: (GliaException) -> Unit) {
+        withChat { it.sendMessage(content, messageId, onSuccess, onFailure) }
     }
 
-    fun sendMessage(payload: SendMessagePayload, listener: Listener) {
-        sendMessage(payload) { visitorMessage, ex -> onMessageReceived(visitorMessage, ex, listener, payload.messageId) }
-    }
-
-    private fun onMessageReceived(
-        visitorMessage: VisitorMessage?,
-        ex: GliaException?,
-        listener: Listener?,
-        messageId: String
+    fun sendSingleChoiceAttachment(
+        singleChoiceAttachment: SingleChoiceAttachment,
+        messageId: String,
+        onSuccess: () -> Unit,
+        onFailure: (GliaException) -> Unit
     ) {
-        if (listener != null) {
-            if (ex != null) {
-                listener.error(ex, messageId)
-            } else {
-                listener.messageSent(visitorMessage)
-            }
-        }
+        withChat { it.sendSingleChoiceAttachment(singleChoiceAttachment, messageId, onSuccess, onFailure) }
+    }
+
+    fun sendFileAttachment(fileId: String, onSuccess: () -> Unit, onFailure: (GliaException) -> Unit) {
+        withChat { it.sendFileAttachment(fileId, onSuccess, onFailure) }
+    }
+
+    private fun withChat(block: (Chat) -> Unit) {
+        gliaCore.currentEngagement.ifPresent { block(it.chat) }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
@@ -13,7 +13,6 @@ import com.glia.widgets.chat.ChatManager
 import com.glia.widgets.chat.domain.gva.IsGvaUseCase
 import com.glia.widgets.chat.model.ChatItem
 import com.glia.widgets.chat.model.DeliveredItem
-import com.glia.widgets.chat.model.LocalAttachmentItem
 import com.glia.widgets.chat.model.OperatorChatItem
 import com.glia.widgets.chat.model.VisitorChatItem
 import com.glia.widgets.chat.model.VisitorMessageItem
@@ -49,6 +48,19 @@ internal class AppendNewChatMessageUseCase(
 
             else -> Logger.d(TAG, "Unexpected type of message received -> $message")
         }
+    }
+
+    /**
+     * Marks the optimistically rendered visitor message with [messageId] as delivered once the
+     * send API reports success. Does nothing when the message was already reconciled through the
+     * incoming message stream (its preview is gone by then).
+     */
+    fun markMessageDelivered(messageId: String, state: ChatManager.State) {
+        if (state.messagePreviews.remove(messageId) != null) {
+            state.preEngagementChatItemIds.remove(messageId)
+            appendNewVisitorMessageUseCase.markMessageDelivered(state, messageId)
+        }
+        state.resetOperator()
     }
 }
 
@@ -160,7 +172,7 @@ internal class AppendNewVisitorMessageUseCase(private val mapVisitorAttachmentUs
 
         if (state.messagePreviews.remove(message.id) != null) {
             state.preEngagementChatItemIds.remove(message.id)
-            markMessageDelivered(state, message)
+            markMessageDelivered(state, message.id)
             return
         }
 
@@ -195,38 +207,21 @@ internal class AppendNewVisitorMessageUseCase(private val mapVisitorAttachmentUs
         }
     }
 
-    private fun markMessageDelivered(state: ChatManager.State, message: VisitorMessage) {
+    fun markMessageDelivered(state: ChatManager.State, messageId: String) {
         markLastDeliveredItemAsDelivered(state)
 
         val chatItems = state.chatItems
 
-        val files = (message.attachment as? FilesAttachment)?.files.orEmpty()
-
-        val messageIndex = chatItems.indexOfLast { it.id == message.id }
+        val messageIndex = chatItems.indexOfLast { it.id == messageId }
 
         if (messageIndex != -1) {
-            chatItems[messageIndex] = VisitorMessageItem(message.content, message.id, false, message.timestamp)
+            chatItems[messageIndex] = (chatItems[messageIndex] as VisitorChatItem).copyWithError(false)
         }
 
-        files.forEach { attachment ->
-            val index = chatItems.indexOfLast { it.id == attachment.id }
-            val visitorChatItem = chatItems[index] as VisitorChatItem
-
-            chatItems[index] = visitorChatItem.copyWithError(false)
-        }
-
-        val lastDeliveredIndex = if (files.isNotEmpty()) {
-            chatItems.indexOfLast { (it as? LocalAttachmentItem)?.messageId == message.id }
-        } else {
-            messageIndex
-        }
-
-        val deliveredItem = DeliveredItem(messageId = message.id, timestamp = message.timestamp).also {
+        val deliveredItem = DeliveredItem(messageId = messageId).also {
             lastDeliveredItem = it
         }
 
-        chatItems.add(lastDeliveredIndex + 1, deliveredItem)
-
+        chatItems.add(messageIndex + 1, deliveredItem)
     }
-
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaSendMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/GliaSendMessageUseCase.kt
@@ -1,20 +1,26 @@
 package com.glia.widgets.chat.domain
 
 import com.glia.androidsdk.GliaException
-import com.glia.androidsdk.chat.FilesAttachment
-import com.glia.androidsdk.chat.SendMessagePayload
 import com.glia.androidsdk.chat.SingleChoiceAttachment
-import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.data.GliaChatRepository
+import com.glia.widgets.chat.model.OutgoingMessage
 import com.glia.widgets.chat.model.VisitorAttachmentItem
 import com.glia.widgets.chat.model.VisitorChatItem
 import com.glia.widgets.chat.model.VisitorMessageItem
 import com.glia.widgets.engagement.domain.IsOperatorPresentUseCase
 import com.glia.widgets.internal.fileupload.FileAttachmentRepository
-import com.glia.widgets.internal.fileupload.model.LocalAttachment
 import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
 import com.glia.widgets.internal.secureconversations.domain.ManageSecureMessagingStatusUseCase
 
+/**
+ * Use case for sending visitor chat input as [OutgoingMessage]s.
+ *
+ * Text and each ready-to-send file attachment are sent as separate messages: the text (when
+ * non-blank) as [OutgoingMessage.Text] and every attachment as its own [OutgoingMessage.File].
+ * Each message is announced to the [Listener] for optimistic rendering before it is routed to
+ * the live chat or secure messaging endpoints; when neither is available, the listener is
+ * notified that the operator is offline so the message can be queued as unsent.
+ */
 internal class GliaSendMessageUseCase(
     private val chatRepository: GliaChatRepository,
     private val fileAttachmentRepository: FileAttachmentRepository,
@@ -23,10 +29,10 @@ internal class GliaSendMessageUseCase(
     private val shouldUseSecureMessagingApis: ManageSecureMessagingStatusUseCase
 ) {
     interface Listener {
-        fun messageSent(message: VisitorMessage?)
+        fun messageSent(messageId: String)
         fun onMessageValidated()
-        fun onMessagePrepared(visitorChatItem: VisitorChatItem, payload: SendMessagePayload)
-        fun onAttachmentsPrepared(items: List<VisitorAttachmentItem>, payload: SendMessagePayload?)
+        fun onMessagePrepared(visitorChatItem: VisitorChatItem, payload: OutgoingMessage)
+        fun onAttachmentPrepared(attachment: VisitorAttachmentItem, outgoingMessage: OutgoingMessage)
         fun errorOperatorOffline(messageId: String)
         fun error(ex: GliaException, messageId: String)
     }
@@ -34,55 +40,84 @@ internal class GliaSendMessageUseCase(
     private val isSecureEngagement: Boolean
         get() = shouldUseSecureMessagingApis.shouldUseSecureMessagingEndpoints
 
-    private fun sendMessage(payload: SendMessagePayload, listener: Listener) {
-        if (isSecureEngagement) {
-            secureConversationsRepository.send(payload, listener)
-        } else {
-            chatRepository.sendMessage(payload, listener)
-        }
-    }
-
     fun execute(message: String, listener: Listener) {
-        val localAttachments: List<LocalAttachment>? = fileAttachmentRepository
+        val localAttachments = fileAttachmentRepository
             .getReadyToSendFileAttachments()
             .filter { it.engagementFile != null }
-            .takeIf { it.isNotEmpty() }
 
-        if (message.isNotBlank() || localAttachments != null) {
+        val attachments: List<VisitorAttachmentItem> = localAttachments
+            .mapNotNull { it.toVisitorAttachmentItem() }
+
+        if (message.isNotBlank()) {
             listener.onMessageValidated()
+            val messagePayload = OutgoingMessage.Text(message)
+            listener.onMessagePrepared(VisitorMessageItem(message, messagePayload.messageId), messagePayload)
 
-            val messageAttachments = localAttachments
-                ?.map { it.engagementFile!! }
-                ?.run { FilesAttachment.from(toTypedArray()) }
-
-            val payload = SendMessagePayload(content = message, messageAttachments)
-
-            if (message.isNotBlank()) {
-                listener.onMessagePrepared(VisitorMessageItem(message, payload.messageId), payload)
+            val onSuccess: () -> Unit = {
+                listener.messageSent(messagePayload.messageId)
             }
 
-            localAttachments?.map { it.toVisitorAttachmentItem(payload.messageId) }?.also {
-                listener.onAttachmentsPrepared(it, payload.takeIf { message.isBlank() })
+            val onFailure: (GliaException) -> Unit = {
+                listener.error(it, messagePayload.messageId)
             }
 
-            if (isOperatorOnline || isSecureEngagement) {
-                sendMessage(payload, listener)
-            } else {
-                listener.errorOperatorOffline(payload.messageId)
-            }
+            when {
+                isOperatorOnline -> chatRepository.sendMessage(messagePayload.content, messagePayload.messageId, onSuccess, onFailure)
+                isSecureEngagement -> secureConversationsRepository.sendMessage(
+                    messagePayload.content,
+                    messagePayload.messageId,
+                    onSuccess,
+                    onFailure
+                )
 
-            fileAttachmentRepository.detachFiles(localAttachments ?: return)
+                else -> listener.errorOperatorOffline(messagePayload.messageId)
+            }
         }
+
+        attachments.forEach {
+            val filePayload = OutgoingMessage.File(it.id)
+            listener.onAttachmentPrepared(it, filePayload)
+
+            val onSuccess: () -> Unit = {
+                listener.messageSent(filePayload.messageId)
+            }
+
+            val onFailure: (GliaException) -> Unit = {
+                listener.error(it, filePayload.messageId)
+            }
+
+            when {
+                isOperatorOnline -> chatRepository.sendFileAttachment(filePayload.fileId, onSuccess, onFailure)
+                isSecureEngagement -> secureConversationsRepository.sendFileAttachment(filePayload.fileId, onSuccess, onFailure)
+                else -> listener.errorOperatorOffline(filePayload.messageId)
+            }
+        }
+
+        fileAttachmentRepository.detachFiles(localAttachments)
     }
 
     fun execute(singleChoiceAttachment: SingleChoiceAttachment, listener: Listener) {
-        val payload = SendMessagePayload(attachment = singleChoiceAttachment)
-        val messageItem = VisitorMessageItem(payload.content, payload.messageId)
+        val payload = OutgoingMessage.SingleChoice(singleChoiceAttachment)
+        val messageItem = VisitorMessageItem(singleChoiceAttachment.selectedOptionText, payload.messageId)
         listener.onMessagePrepared(messageItem, payload)
-        when {
-            isSecureEngagement -> secureConversationsRepository.send(payload, listener)
 
-            isOperatorOnline -> chatRepository.sendMessage(payload, listener)
+        val onSuccess: () -> Unit = {
+            listener.messageSent(payload.messageId)
+        }
+
+        val onFailure: (GliaException) -> Unit = {
+            listener.error(it, payload.messageId)
+        }
+
+        when {
+            isSecureEngagement -> secureConversationsRepository.sendSingleChoiceAttachment(
+                singleChoiceAttachment,
+                payload.messageId,
+                onSuccess,
+                onFailure
+            )
+
+            isOperatorOnline -> chatRepository.sendSingleChoiceAttachment(singleChoiceAttachment, payload.messageId, onSuccess, onFailure)
 
             else -> listener.errorOperatorOffline(payload.messageId)
         }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/SendUnsentMessagesUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/SendUnsentMessagesUseCase.kt
@@ -1,39 +1,50 @@
 package com.glia.widgets.chat.domain
 
 import com.glia.androidsdk.GliaException
-import com.glia.androidsdk.RequestCallback
-import com.glia.androidsdk.chat.SendMessagePayload
-import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.data.GliaChatRepository
+import com.glia.widgets.chat.model.OutgoingMessage
 import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
 import com.glia.widgets.internal.secureconversations.domain.ManageSecureMessagingStatusUseCase
 
-
+/**
+ * Use case for re-sending an [OutgoingMessage] that could not be delivered earlier
+ * (operator was offline or a previous attempt failed).
+ *
+ * Routes the message to the secure messaging or live chat endpoint matching the current
+ * engagement state and reports completion through the success/failure callbacks.
+ */
 internal class SendUnsentMessagesUseCase(
     private val chatRepository: GliaChatRepository,
     private val secureConversationsRepository: SecureConversationsRepository,
     private val shouldUseSecureMessagingApis: ManageSecureMessagingStatusUseCase
 ) {
-    operator fun invoke(
-        payload: SendMessagePayload,
-        onSuccess: (VisitorMessage) -> Unit,
-        onFailure: (ex: GliaException) -> Unit
-    ) {
-        sendMessage(payload) { response, exception ->
-            if (exception != null) {
-                onFailure(exception)
-            }
-            if (response != null) {
-                onSuccess(response)
-            }
+    operator fun invoke(payload: OutgoingMessage, onSuccess: () -> Unit, onFailure: (ex: GliaException) -> Unit) {
+        if (shouldUseSecureMessagingApis.shouldUseSecureMessagingEndpoints) {
+            sendScMessage(payload, onSuccess, onFailure)
+        } else {
+            sendMessage(payload, onSuccess, onFailure)
         }
     }
 
-    private fun sendMessage(payload: SendMessagePayload, callback: RequestCallback<VisitorMessage?>) {
-        if (shouldUseSecureMessagingApis.shouldUseSecureMessagingEndpoints) {
-            secureConversationsRepository.send(payload, callback)
-        } else {
-            chatRepository.sendMessage(payload, callback)
+    private fun sendMessage(payload: OutgoingMessage, onSuccess: () -> Unit, onFailure: (ex: GliaException) -> Unit) {
+        when (payload) {
+            is OutgoingMessage.File -> chatRepository.sendFileAttachment(payload.fileId, onSuccess, onFailure)
+            is OutgoingMessage.SingleChoice -> chatRepository.sendSingleChoiceAttachment(payload.attachment, payload.messageId, onSuccess, onFailure)
+            is OutgoingMessage.Text -> chatRepository.sendMessage(payload.content, payload.messageId, onSuccess, onFailure)
+        }
+    }
+
+    private fun sendScMessage(payload: OutgoingMessage, onSuccess: () -> Unit, onFailure: (ex: GliaException) -> Unit) {
+        when (payload) {
+            is OutgoingMessage.File -> secureConversationsRepository.sendFileAttachment(payload.fileId, onSuccess, onFailure)
+            is OutgoingMessage.SingleChoice -> secureConversationsRepository.sendSingleChoiceAttachment(
+                payload.attachment,
+                payload.messageId,
+                onSuccess,
+                onFailure
+            )
+
+            is OutgoingMessage.Text -> secureConversationsRepository.sendMessage(payload.content, payload.messageId, onSuccess, onFailure)
         }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/model/OutgoingMessage.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/model/OutgoingMessage.kt
@@ -1,0 +1,30 @@
+package com.glia.widgets.chat.model
+
+import com.glia.androidsdk.chat.SingleChoiceAttachment
+import java.util.UUID
+
+/**
+ * Widgets-internal descriptor of a message the visitor is sending.
+ *
+ * Used to render the message optimistically, to key it in `ChatManager.State.messagePreviews`,
+ * and to re-send it on retry. Each instance maps to exactly one outgoing message routed to the
+ * unified Core send API (`Chat` / `SecureConversations`).
+ *
+ * The [messageId] is the client-generated id used to reconcile the optimistic item with the echoed
+ * message from the incoming message stream. For a [File] the uploaded file id doubles as the
+ * [messageId], because the live `Chat.sendFileAttachment` carries no message id and the file id is
+ * the only correlation key available on the incoming message.
+ *
+ * @hide
+ */
+internal sealed interface OutgoingMessage {
+    val messageId: String
+
+    data class Text(val content: String, override val messageId: String = UUID.randomUUID().toString()) : OutgoingMessage
+
+    data class SingleChoice(val attachment: SingleChoiceAttachment, override val messageId: String = UUID.randomUUID().toString()) : OutgoingMessage
+
+    data class File(val fileId: String) : OutgoingMessage {
+        override val messageId: String get() = fileId
+    }
+}

--- a/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
+++ b/widgetssdk/src/main/java/com/glia/widgets/di/UseCaseFactory.java
@@ -519,9 +519,7 @@ public class UseCaseFactory {
         return new SendSecureMessageUseCase(
             repositoryFactory.getSendMessageRepository(),
             repositoryFactory.getSecureConversationsRepository(),
-            repositoryFactory.getGliaFileAttachmentRepository(),
-            repositoryFactory.getGliaMessageRepository(),
-            getIsQueueingOrEngagementUseCase()
+            repositoryFactory.getGliaFileAttachmentRepository()
         );
     }
 

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/fileupload/model/LocalAttachment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/fileupload/model/LocalAttachment.kt
@@ -21,10 +21,16 @@ internal data class LocalAttachment(
     val id: String
         get() = engagementFile?.id ?: UUID.randomUUID().toString()
 
-    fun toVisitorAttachmentItem(messageId: String): VisitorAttachmentItem = if (isImage) {
-        VisitorAttachmentItem.LocalImage(id, messageId, this)
-    } else {
-        VisitorAttachmentItem.LocalFile(id, messageId, this)
+    /**
+     * Maps this attachment to its optimistic chat item, or `null` when the file has not been
+     * uploaded yet. The uploaded file id is used as both the item id and the message id because
+     * each file is sent as a separate message and the file id is the only key available to
+     * reconcile it with the echoed message from the incoming message stream.
+     */
+    fun toVisitorAttachmentItem(): VisitorAttachmentItem? = when {
+        engagementFile == null -> null
+        isImage -> VisitorAttachmentItem.LocalImage(engagementFile.id, engagementFile.id, this)
+        else -> VisitorAttachmentItem.LocalFile(engagementFile.id, engagementFile.id, this)
     }
 
     enum class Status(val isError: Boolean) {

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/SecureConversationsRepository.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/SecureConversationsRepository.kt
@@ -3,13 +3,13 @@ package com.glia.widgets.internal.secureconversations
 import android.annotation.SuppressLint
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
-import com.glia.androidsdk.chat.SendMessagePayload
-import com.glia.androidsdk.chat.VisitorMessage
+import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.androidsdk.secureconversations.SecureConversations
 import com.glia.widgets.chat.data.GliaChatRepository
-import com.glia.widgets.chat.domain.GliaSendMessageUseCase
+import com.glia.widgets.di.Dependencies
 import com.glia.widgets.di.GliaCore
 import com.glia.widgets.helper.asStateFlowable
+import com.glia.widgets.helper.rx.Schedulers
 import com.glia.widgets.internal.queue.QueueRepository
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Observable
@@ -17,7 +17,11 @@ import io.reactivex.rxjava3.processors.BehaviorProcessor
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 import io.reactivex.rxjava3.subjects.Subject
 
-internal class SecureConversationsRepository(private val core: GliaCore, private val queueRepository: QueueRepository) {
+internal class SecureConversationsRepository @JvmOverloads constructor(
+    private val core: GliaCore,
+    private val queueRepository: QueueRepository,
+    private val schedulers: Schedulers = Dependencies.schedulers
+) {
     private val secureConversations: SecureConversations by lazy { core.secureConversations }
 
     private val _messageSendingObservable: Subject<Boolean> = BehaviorSubject.createDefault(false)
@@ -68,20 +72,97 @@ internal class SecureConversationsRepository(private val core: GliaCore, private
     }
 
     @SuppressLint("CheckResult")
-    fun send(payload: SendMessagePayload, callback: RequestCallback<VisitorMessage?>) {
-        _messageSendingObservable.onNext(true)
+    private fun withQueues(onSuccess: (Array<String>) -> Unit, onFailure: (GliaException) -> Unit) {
         queueRepository.relevantQueueIds.subscribe { queueIds ->
             if (queueIds.isNotEmpty()) {
-                secureConversations.send(payload, queueIds.toTypedArray(), handleResult(callback))
+                onSuccess(queueIds.toTypedArray())
             } else {
-                handleResult(callback).onResult(null, GliaException("relevant queues are empty", GliaException.Cause.INVALID_INPUT))
+                onFailure(GliaException("relevant queues are empty", GliaException.Cause.INVALID_INPUT))
             }
-
         }
     }
 
-    fun send(payload: SendMessagePayload, listener: GliaSendMessageUseCase.Listener) {
-        send(payload) { visitorMessage, ex -> onMessageReceived(visitorMessage, ex, listener, payload) }
+    private fun wrapFailure(onFailure: (GliaException) -> Unit): (GliaException) -> Unit = {
+        _messageSendingObservable.onNext(false)
+        runOnMain { onFailure(it) }
+    }
+
+    private fun wrapSuccess(onSuccess: () -> Unit): () -> Unit = {
+        _messageSendingObservable.onNext(false)
+        runOnMain { onSuccess() }
+    }
+
+    // Core no longer hops to the main thread before invoking send callbacks, so marshal them
+    // back onto it for the UI-driving consumers and the message-sending state.
+    private fun runOnMain(block: () -> Unit) {
+        schedulers.mainScheduler.scheduleDirect { block() }
+    }
+
+    fun sendMessageWithAttachments(
+        content: String,
+        fileAttachments: List<String>,
+        messageId: String,
+        onSuccess: () -> Unit,
+        onFailure: (GliaException) -> Unit
+    ) {
+        _messageSendingObservable.onNext(true)
+
+        withQueues({
+            secureConversations.sendMessageWithAttachments(
+                content = content,
+                fileAttachments = fileAttachments,
+                queueIds = it,
+                messageId = messageId,
+                onSuccess = wrapSuccess(onSuccess),
+                onFailure = wrapFailure(onFailure)
+            )
+        }, wrapFailure(onFailure))
+    }
+
+    fun sendMessage(content: String, messageId: String, onSuccess: () -> Unit, onFailure: (GliaException) -> Unit) {
+        _messageSendingObservable.onNext(true)
+
+        withQueues({
+            secureConversations.sendMessage(
+                content = content,
+                queueIds = it,
+                messageId = messageId,
+                onSuccess = wrapSuccess(onSuccess),
+                onFailure = wrapFailure(onFailure)
+            )
+        }, wrapFailure(onFailure))
+    }
+
+    fun sendSingleChoiceAttachment(
+        singleChoiceAttachment: SingleChoiceAttachment,
+        messageId: String,
+        onSuccess: () -> Unit,
+        onFailure: (GliaException) -> Unit
+    ) {
+        _messageSendingObservable.onNext(true)
+
+        withQueues({
+            secureConversations.sendSingleChoiceAttachment(
+                singleChoiceAttachment = singleChoiceAttachment,
+                queueIds = it,
+                messageId = messageId,
+                onSuccess = wrapSuccess(onSuccess),
+                onFailure = wrapFailure(onFailure)
+            )
+        }, wrapFailure(onFailure))
+    }
+
+    fun sendFileAttachment(fileId: String, onSuccess: () -> Unit, onFailure: (GliaException) -> Unit) {
+        _messageSendingObservable.onNext(true)
+
+        withQueues({
+            secureConversations.sendFileAttachment(
+                queueIds = it,
+                fileId = fileId,
+                onSuccess = wrapSuccess(onSuccess),
+                onFailure = wrapFailure(onFailure)
+            )
+        }, wrapFailure(onFailure))
     }
 
     fun markMessagesRead(callback: RequestCallback<Void>) {
@@ -90,25 +171,5 @@ internal class SecureConversationsRepository(private val core: GliaCore, private
 
     fun setLeaveSecureConversationDialogVisible(visible: Boolean) {
         _isLeaveSecureConversationDialogVisibleObservable.onNext(visible)
-    }
-
-    private fun handleResult(callback: RequestCallback<VisitorMessage?>): RequestCallback<VisitorMessage?> {
-        return RequestCallback { message: VisitorMessage?, exception: GliaException? ->
-            _messageSendingObservable.onNext(false)
-            callback.onResult(message, exception)
-        }
-    }
-
-    private fun onMessageReceived(
-        visitorMessage: VisitorMessage?,
-        ex: GliaException?,
-        listener: GliaSendMessageUseCase.Listener,
-        payload: SendMessagePayload
-    ) {
-        if (ex != null) {
-            listener.error(ex, payload.messageId)
-        } else {
-            listener.messageSent(visitorMessage)
-        }
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/domain/SendSecureMessageUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/secureconversations/domain/SendSecureMessageUseCase.kt
@@ -1,82 +1,63 @@
 package com.glia.widgets.internal.secureconversations.domain
 
-import com.glia.androidsdk.RequestCallback
-import com.glia.androidsdk.chat.FilesAttachment
-import com.glia.androidsdk.chat.SendMessagePayload
-import com.glia.androidsdk.chat.VisitorMessage
-import com.glia.widgets.chat.data.GliaChatRepository
-import com.glia.widgets.engagement.domain.IsQueueingOrLiveEngagementUseCase
+import com.glia.androidsdk.GliaException
 import com.glia.widgets.internal.fileupload.FileAttachmentRepository
 import com.glia.widgets.internal.fileupload.model.LocalAttachment
 import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
 import com.glia.widgets.internal.secureconversations.SendMessageRepository
+import java.util.UUID
 
+/**
+ * Use case for sending the Message Center message as a secure conversation.
+ *
+ * Sends the current [SendMessageRepository] value together with any ready-to-send file
+ * attachments through [SecureConversationsRepository]. On a successful send with attachments,
+ * the composed message and the attachments are cleared before [onSuccess] is invoked.
+ */
 internal class SendSecureMessageUseCase(
     private val sendMessageRepository: SendMessageRepository,
     private val secureConversationsRepository: SecureConversationsRepository,
-    private val fileAttachmentRepository: FileAttachmentRepository,
-    private val chatRepository: GliaChatRepository,
-    private val isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase
+    private val fileAttachmentRepository: FileAttachmentRepository
 ) {
 
-    private val hasOngoingEngagement: Boolean
-        get() = isQueueingOrLiveEngagementUseCase.hasOngoingLiveEngagement
-
-    operator fun invoke(
-        callback: RequestCallback<VisitorMessage?>
-    ) {
+    operator fun invoke(onSuccess: () -> Unit, onFailure: (GliaException) -> Unit) {
         val message = sendMessageRepository.value
         val fileAttachments = fileAttachmentRepository.getReadyToSendFileAttachments()
-        sendMessage(message, fileAttachments, callback)
+        sendMessage(message, fileAttachments, onSuccess, onFailure)
     }
 
-    private fun sendMessage(
-        message: String,
-        localAttachments: List<LocalAttachment>,
-        callback: RequestCallback<VisitorMessage?>
-    ) {
+    private fun sendMessage(message: String, localAttachments: List<LocalAttachment>, onSuccess: () -> Unit, onFailure: (GliaException) -> Unit) {
         if (localAttachments.isNotEmpty()) {
-            sendMessageWithAttachments(message, localAttachments) { result, ex ->
-                if (ex == null) {
-                    sendMessageRepository.reset()
-                    fileAttachmentRepository.detachFiles(localAttachments)
-                }
-                callback.onResult(result, ex)
-            }
+            sendMessageWithAttachments(message, localAttachments, {
+                sendMessageRepository.reset()
+                fileAttachmentRepository.detachFiles(localAttachments)
+                onSuccess()
+            }, onFailure)
         } else {
-            sendMessage(message, callback)
-        }
-    }
-
-    private fun sendMessage(
-        message: String,
-        callback: RequestCallback<VisitorMessage?>
-    ) {
-        val payload = SendMessagePayload(content = message)
-
-        if (hasOngoingEngagement) {
-            chatRepository.sendMessage(payload, callback)
-        } else {
-            secureConversationsRepository.send(payload, callback)
+            secureConversationsRepository.sendMessage(
+                content = message,
+                messageId = UUID.randomUUID().toString(),
+                onSuccess = onSuccess,
+                onFailure = onFailure
+            )
         }
     }
 
     private fun sendMessageWithAttachments(
         message: String,
         localAttachments: List<LocalAttachment>,
-        callback: RequestCallback<VisitorMessage?>
+        onSuccess: () -> Unit,
+        onFailure: (GliaException) -> Unit
     ) {
-        val attachment = localAttachments
-            .mapNotNull { it.engagementFile }
-            .takeIf { it.isNotEmpty() }
-            ?.run { FilesAttachment.from(toTypedArray()) }
+        val attachments = localAttachments
+            .mapNotNull { it.engagementFile?.id }
 
-        val payload = SendMessagePayload(content = message, attachment)
-
-        if (hasOngoingEngagement) {
-            chatRepository.sendMessage(payload, callback)
-        } else {
-            secureConversationsRepository.send(payload, callback)
-        }
+        secureConversationsRepository.sendMessageWithAttachments(
+            content = message,
+            fileAttachments = attachments,
+            messageId = UUID.randomUUID().toString(),
+            onSuccess = onSuccess,
+            onFailure = onFailure
+        )
     }
 }

--- a/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/messagecenter/MessageCenterController.kt
@@ -1,9 +1,7 @@
 package com.glia.widgets.messagecenter
 
 import android.net.Uri
-import androidx.annotation.VisibleForTesting
 import com.glia.androidsdk.GliaException
-import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.androidsdk.engagement.EngagementFile
 import com.glia.telemetry_lib.ButtonNames
 import com.glia.telemetry_lib.GliaLogger
@@ -137,36 +135,29 @@ internal class MessageCenterController(
         view?.hideSoftKeyboard()
 
         requestNotificationPermissionIfPushNotificationsSetUpUseCase {
-            sendSecureMessageUseCase { _: VisitorMessage?, gliaException: GliaException? ->
-                handleSendMessageResult(gliaException)
-            }
-        }
-    }
+            sendSecureMessageUseCase({
+                view?.showConfirmationScreen()
+            }) {
+                when (it.cause) {
+                    GliaException.Cause.AUTHENTICATION_ERROR -> {
+                        dialogController.showMessageCenterUnavailableDialog()
+                        setState(state.copy(showSendMessageGroup = false))
+                    }
 
-    @VisibleForTesting
-    fun handleSendMessageResult(gliaException: GliaException?) {
-        if (gliaException == null) {
-            view?.showConfirmationScreen()
-        } else {
-            when (gliaException.cause) {
-                GliaException.Cause.AUTHENTICATION_ERROR -> {
-                    dialogController.showMessageCenterUnavailableDialog()
-                    setState(state.copy(showSendMessageGroup = false))
-                }
+                    GliaException.Cause.INTERNAL_ERROR -> {
+                        dialogController.showUnexpectedErrorDialog()
+                        setState(state.copy(showSendMessageGroup = false))
+                    }
 
-                GliaException.Cause.INTERNAL_ERROR -> {
-                    dialogController.showUnexpectedErrorDialog()
-                    setState(state.copy(showSendMessageGroup = false))
-                }
-
-                else -> {
-                    dialogController.showUnexpectedErrorDialog()
-                    setState(
-                        state.copy(
-                            messageEditTextEnabled = true,
-                            addAttachmentButtonEnabled = true
+                    else -> {
+                        dialogController.showUnexpectedErrorDialog()
+                        setState(
+                            state.copy(
+                                messageEditTextEnabled = true,
+                                addAttachmentButtonEnabled = true
+                            )
                         )
-                    )
+                    }
                 }
             }
         }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerDialogStateTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerDialogStateTest.kt
@@ -40,13 +40,7 @@ class ChatManagerDialogStateTest {
         state.chatItemIds.add("2")
         state.chatItemIds.add("3")
 
-        val chatMessage: ChatMessage = mock()
-        whenever(chatMessage.id) doReturn "4"
-
-        val chatMessageInternal: ChatMessageInternal = mock()
-        whenever(chatMessageInternal.chatMessage) doReturn chatMessage
-
-        assertTrue(state.isNew(chatMessageInternal))
+        assertTrue(state.isNew("4"))
         assertTrue(state.chatItemIds.count() == 4)
         assertTrue(state.chatItemIds.contains("4"))
     }
@@ -57,13 +51,7 @@ class ChatManagerDialogStateTest {
         state.chatItemIds.add("2")
         state.chatItemIds.add("3")
 
-        val chatMessage: ChatMessage = mock()
-        whenever(chatMessage.id) doReturn "3"
-
-        val chatMessageInternal: ChatMessageInternal = mock()
-        whenever(chatMessageInternal.chatMessage) doReturn chatMessage
-
-        assertFalse(state.isNew(chatMessageInternal))
+        assertFalse(state.isNew("3"))
         assertTrue(state.chatItemIds.count() == 3)
     }
 

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -2,11 +2,8 @@ package com.glia.widgets.chat
 
 import android.os.Looper
 import com.glia.androidsdk.GliaException
-import com.glia.androidsdk.chat.AttachmentFile
 import com.glia.androidsdk.chat.ChatMessage
-import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.OperatorMessage
-import com.glia.androidsdk.chat.SendMessagePayload
 import com.glia.androidsdk.chat.SystemMessage
 import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.domain.AddNewMessagesDividerUseCase
@@ -25,6 +22,7 @@ import com.glia.widgets.chat.model.NewMessagesDividerItem
 import com.glia.widgets.chat.model.OperatorAttachmentItem
 import com.glia.widgets.chat.model.OperatorMessageItem
 import com.glia.widgets.chat.model.OperatorStatusItem
+import com.glia.widgets.chat.model.OutgoingMessage
 import com.glia.widgets.chat.model.RemoteAttachmentItem
 import com.glia.widgets.chat.model.TapToRetryItem
 import com.glia.widgets.chat.model.VisitorAttachmentItem
@@ -210,7 +208,7 @@ class ChatManagerTest {
 
     @Test
     fun `mapMessagePreviewAdded adds message preview to the chat items`() {
-        val payload = SendMessagePayload(content = "content")
+        val payload = OutgoingMessage.Text(content = "content")
         val item = VisitorMessageItem(payload.content, payload.messageId)
 
         assertTrue(state.messagePreviews.isEmpty())
@@ -225,7 +223,7 @@ class ChatManagerTest {
 
     @Test
     fun `mapMessagePreviewAdded adds message preview before OperatorStatusItem when chatItems contain OperatorStatusItem_InQueue`() {
-        val payload = SendMessagePayload(content = "content")
+        val payload = OutgoingMessage.Text(content = "content")
         val item = VisitorMessageItem(payload.content, payload.messageId)
 
         val inQueue = OperatorStatusItem.InQueue
@@ -243,19 +241,17 @@ class ChatManagerTest {
     }
 
     @Test
-    fun `mapAttachmentPreviewAdded adds attachment previews to the chat items`() {
-        val payload = SendMessagePayload(content = "content")
-        val item = VisitorAttachmentItem.LocalImage(id = "tota", messageId = payload.messageId, attachment = mock())
-        val item1 = VisitorAttachmentItem.LocalFile(id = "animal", messageId = payload.messageId, attachment = mock())
+    fun `mapAttachmentPreviewAdded adds attachment preview to the chat items`() {
+        val payload = OutgoingMessage.File(fileId = "tota")
+        val item = VisitorAttachmentItem.LocalImage(id = payload.fileId, messageId = payload.messageId, attachment = mock())
 
         assertTrue(state.messagePreviews.isEmpty())
         assertTrue(state.chatItems.isEmpty())
 
-        val newState = subjectUnderTest.mapAttachmentPreviewAdded(listOf(item, item1), payload, state)
-        assertEquals(payload, newState.messagePreviews.entries.first().value)
+        val newState = subjectUnderTest.mapAttachmentPreviewAdded(item, payload, state)
+        assertEquals(payload, newState.messagePreviews[item.id])
         assertEquals(item, newState.chatItems.first())
-        assertEquals(item1, newState.chatItems[1])
-        assertEquals(2, newState.chatItems.count())
+        assertEquals(1, newState.chatItems.count())
         assertEquals(1, newState.messagePreviews.count())
     }
 
@@ -516,7 +512,9 @@ class ChatManagerTest {
 
     @Test
     fun `mapAction calls mapAttachmentPreviewAdded when Action_AttachmentPreviewAdded passed`() {
-        val action: ChatManager.Action.AttachmentPreviewAdded = ChatManager.Action.AttachmentPreviewAdded(emptyList(), mock())
+        val attachment = VisitorAttachmentItem.LocalFile(id = "file_id", messageId = "file_id", attachment = mock())
+        val action: ChatManager.Action.AttachmentPreviewAdded =
+            ChatManager.Action.AttachmentPreviewAdded(attachment, OutgoingMessage.File(fileId = "file_id"))
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.mapAction(action, state)
         verify(subjectUnderTestSpy).mapAttachmentPreviewAdded(any(), any(), any())
@@ -524,7 +522,9 @@ class ChatManagerTest {
 
     @Test
     fun `mapAction calls mapMessagePreviewAdded when Action_MessagePreviewAdded passed`() {
-        val action: ChatManager.Action.MessagePreviewAdded = ChatManager.Action.MessagePreviewAdded(mock(), mock())
+        val payload = OutgoingMessage.Text(content = "content")
+        val action: ChatManager.Action.MessagePreviewAdded =
+            ChatManager.Action.MessagePreviewAdded(VisitorMessageItem(payload.content, payload.messageId), payload)
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.mapAction(action, state)
         verify(subjectUnderTestSpy).mapMessagePreviewAdded(any(), any(), any())
@@ -547,12 +547,11 @@ class ChatManagerTest {
     }
 
     @Test
-    fun `mapAction calls mapNewMessage when Action_OnMessageSent passed`() {
-        val message = mockChatMessage<VisitorMessage>()
-        val action: ChatManager.Action.OnMessageSent = ChatManager.Action.OnMessageSent(message.chatMessage as VisitorMessage)
+    fun `mapAction calls mapMessageSent when Action_OnMessageSent passed`() {
+        val action: ChatManager.Action.OnMessageSent = ChatManager.Action.OnMessageSent("message_id")
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.mapAction(action, state)
-        verify(subjectUnderTestSpy).mapNewMessage(any(), any())
+        verify(subjectUnderTestSpy).mapMessageSent(eq("message_id"), any())
     }
 
     @Test
@@ -600,8 +599,9 @@ class ChatManagerTest {
     @Test
     fun `mapNewMessage does nothing when message is not new`() {
         val chatMessageInternal = mockChatMessage<OperatorMessage>()
+        val messageId = chatMessageInternal.chatMessage.id
         val stateSpy = spy(state)
-        doReturn(false).whenever(stateSpy).isNew(chatMessageInternal)
+        doReturn(false).whenever(stateSpy).isNew(messageId)
 
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.mapNewMessage(chatMessageInternal, stateSpy)
@@ -613,9 +613,10 @@ class ChatManagerTest {
     @Test
     fun `mapNewMessage calls appendNewChatMessageUseCase when message is new`() {
         val chatMessageInternal = mockChatMessage<OperatorMessage>()
+        val messageId = chatMessageInternal.chatMessage.id
         val stateSpy = spy(state)
 
-        doReturn(true).whenever(stateSpy).isNew(chatMessageInternal)
+        doReturn(true).whenever(stateSpy).isNew(messageId)
 
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.mapNewMessage(chatMessageInternal, stateSpy)
@@ -627,8 +628,9 @@ class ChatManagerTest {
     @Test
     fun `mapNewMessage calls checkUnsentMessage when message is new VisitorMessage`() {
         val chatMessageInternal = mockChatMessage<VisitorMessage>()
+        val messageId = chatMessageInternal.chatMessage.id
         val stateSpy = spy(state)
-        doReturn(true).whenever(stateSpy).isNew(chatMessageInternal)
+        doReturn(true).whenever(stateSpy).isNew(messageId)
 
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.mapNewMessage(chatMessageInternal, stateSpy)
@@ -661,33 +663,34 @@ class ChatManagerTest {
 
     @Test
     fun `checkUnsentMessages calls sendUnsentMessagesUseCase when message previews is not empty`() {
-        val unsentMessage = SendMessagePayload(content = "message")
+        val unsentMessage = OutgoingMessage.Text(content = "message")
 
         state.messagePreviews[unsentMessage.messageId] = unsentMessage
         state.preEngagementChatItemIds.add(unsentMessage.messageId)
 
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.checkUnsentMessages(state)
-        val successCaptor = argumentCaptor<(VisitorMessage) -> Unit>()
+        val successCaptor = argumentCaptor<() -> Unit>()
         val failureCaptor = argumentCaptor<(GliaException) -> Unit>()
         verify(sendUnsentMessagesUseCase).invoke(eq(unsentMessage), successCaptor.capture(), failureCaptor.capture())
-        successCaptor.lastValue.invoke(mock())
+        successCaptor.lastValue.invoke()
 
         val actionCaptor = argumentCaptor<ChatManager.Action>()
         verify(subjectUnderTestSpy).onChatAction(actionCaptor.capture())
-        assertTrue(actionCaptor.lastValue is ChatManager.Action.OnMessageSent)
+        val action = actionCaptor.lastValue as ChatManager.Action.OnMessageSent
+        assertEquals(unsentMessage.messageId, action.messageId)
     }
 
     @Test
     fun `checkUnsentMessages calls OnSendMessageError action when message response is failure`() {
-        val unsentMessage = SendMessagePayload(content = "message")
+        val unsentMessage = OutgoingMessage.Text(content = "message")
 
         state.messagePreviews[unsentMessage.messageId] = unsentMessage
         state.preEngagementChatItemIds.add(unsentMessage.messageId)
 
         val subjectUnderTestSpy = spy(subjectUnderTest)
         subjectUnderTestSpy.checkUnsentMessages(state)
-        val successCaptor = argumentCaptor<(VisitorMessage) -> Unit>()
+        val successCaptor = argumentCaptor<() -> Unit>()
         val failureCaptor = argumentCaptor<(GliaException) -> Unit>()
         verify(sendUnsentMessagesUseCase).invoke(eq(unsentMessage), successCaptor.capture(), failureCaptor.capture())
         failureCaptor.lastValue.invoke(mock())
@@ -813,8 +816,9 @@ class ChatManagerTest {
     @Test
     fun `subscribeToState subscribes to history and messages`() {
         val chatMessageInternal = mockChatMessage<SystemMessage>()
+        val messageId = chatMessageInternal.chatMessage.id
         val stateSpy = spy(state)
-        doReturn(true).whenever(stateSpy).isNew(chatMessageInternal)
+        doReturn(true).whenever(stateSpy).isNew(messageId)
         doReturn(10).whenever(stateSpy).addedMessagesCount
         stateProcessor.onNext(stateSpy)
 
@@ -832,6 +836,23 @@ class ChatManagerTest {
         val test = action.test()
         subjectUnderTest.onChatAction(ChatManager.Action.Transferring)
         test.assertValue(ChatManager.Action.Transferring)
+    }
+
+    @Test
+    fun `onChatAction delivers all actions when called concurrently from multiple threads`() {
+        val threadCount = 4
+        val actionsPerThread = 50
+        val test = action.test()
+
+        val threads = (1..threadCount).map {
+            Thread {
+                repeat(actionsPerThread) { subjectUnderTest.onChatAction(ChatManager.Action.Transferring) }
+            }
+        }
+        threads.forEach(Thread::start)
+        threads.forEach(Thread::join)
+
+        test.assertValueCount(threadCount * actionsPerThread)
     }
 
     @Test
@@ -865,8 +886,9 @@ class ChatManagerTest {
     @Test
     fun `initialize subscribes to state and quick replies`() {
         val chatMessageInternal = mockChatMessage<SystemMessage>()
+        val messageId = chatMessageInternal.chatMessage.id
         val stateSpy = spy(state)
-        doReturn(true).whenever(stateSpy).isNew(chatMessageInternal)
+        doReturn(true).whenever(stateSpy).isNew(messageId)
 
         whenever(loadHistoryUseCase()) doReturn Single.just(ChatHistoryResponse(emptyList()))
         whenever(onMessageUseCase()) doReturn Observable.just(chatMessageInternal)
@@ -905,8 +927,8 @@ class ChatManagerTest {
     }
 
     @Test
-    fun `mapRetryClicked updates chat items with no Error status for message without attachments when tap to retry item does not exist`() {
-        val payload = SendMessagePayload(content = "message")
+    fun `mapRetryClicked updates chat items with no Error status for message when tap to retry item does not exist`() {
+        val payload = OutgoingMessage.Text(content = "message")
         val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId, isError = true)
         state.messagePreviews[payload.messageId] = payload
         state.chatItems.add(visitorChatItem)
@@ -918,8 +940,8 @@ class ChatManagerTest {
     }
 
     @Test
-    fun `mapRetryClicked updates chat items with no Error status for message without attachments`() {
-        val payload = SendMessagePayload(content = "message")
+    fun `mapRetryClicked updates chat items with no Error status for message`() {
+        val payload = OutgoingMessage.Text(content = "message")
         val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId, isError = true)
         state.messagePreviews[payload.messageId] = payload
         state.chatItems.add(visitorChatItem)
@@ -934,27 +956,20 @@ class ChatManagerTest {
     }
 
     @Test
-    fun `mapRetryClicked updates chat items with preview status for attachment without message`() {
-        val messageId = "message_id"
-        val file: AttachmentFile = mock {
-            on { id } doReturn "attachment_id"
-        }
-        val filesAttachment: FilesAttachment = mock {
-            on { files } doReturn arrayOf(file)
-        }
-        val payload = SendMessagePayload(content = "", messageId = messageId, attachment = filesAttachment)
+    fun `mapRetryClicked updates chat items with preview status for attachment`() {
+        val payload = OutgoingMessage.File(fileId = "attachment_id")
         val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "attachment_id",
-            messageId = messageId,
+            id = payload.fileId,
+            messageId = payload.messageId,
             attachment = mock(),
             isError = true
         )
-        state.messagePreviews[messageId] = payload
+        state.messagePreviews[payload.messageId] = payload
         state.chatItems.add(attachmentItem)
         val tapToRetryItem = TapToRetryItem(payload.messageId)
         state.chatItems.add(tapToRetryItem)
 
-        val newState = subjectUnderTest.mapRetryClicked(messageId, state)
+        val newState = subjectUnderTest.mapRetryClicked(payload.messageId, state)
 
         val updatedAttachmentItem = newState.chatItems[0] as VisitorAttachmentItem
         assertFalse(updatedAttachmentItem.isError)
@@ -962,40 +977,37 @@ class ChatManagerTest {
     }
 
     @Test
-    fun `mapRetryClicked updates chat items with preview status for message with attachments`() {
-        val messageId = "message_id"
-        val file: AttachmentFile = mock {
-            on { id } doReturn "attachment_id"
-        }
-        val filesAttachment: FilesAttachment = mock {
-            on { files } doReturn arrayOf(file)
-        }
-        val payload = SendMessagePayload(content = "message", messageId = messageId, attachment = filesAttachment)
-        val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId, isError = true)
+    fun `mapRetryClicked resends only the message with the given id`() {
+        val textPayload = OutgoingMessage.Text(content = "message")
+        val filePayload = OutgoingMessage.File(fileId = "attachment_id")
+        val visitorChatItem = VisitorMessageItem(textPayload.content, textPayload.messageId, isError = true)
         val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "attachment_id",
-            messageId = messageId,
+            id = filePayload.fileId,
+            messageId = filePayload.messageId,
             attachment = mock(),
             isError = true
         )
-        state.messagePreviews[messageId] = payload
+        state.messagePreviews[textPayload.messageId] = textPayload
+        state.messagePreviews[filePayload.messageId] = filePayload
         state.chatItems.add(visitorChatItem)
         state.chatItems.add(attachmentItem)
-        val tapToRetryItem = TapToRetryItem(payload.messageId)
+        val tapToRetryItem = TapToRetryItem(textPayload.messageId)
         state.chatItems.add(tapToRetryItem)
 
-        val newState = subjectUnderTest.mapRetryClicked(messageId, state)
+        val newState = subjectUnderTest.mapRetryClicked(textPayload.messageId, state)
 
         val updatedMessageItem = newState.chatItems.first() as VisitorMessageItem
-        val updatedAttachmentItem = newState.chatItems[1] as VisitorAttachmentItem
+        val untouchedAttachmentItem = newState.chatItems[1] as VisitorAttachmentItem
         assertFalse(updatedMessageItem.isError)
-        assertFalse(updatedAttachmentItem.isError)
+        assertTrue(untouchedAttachmentItem.isError)
         assertFalse(newState.chatItems.contains(tapToRetryItem))
+        verify(sendUnsentMessagesUseCase).invoke(eq(textPayload), any(), any())
+        verify(sendUnsentMessagesUseCase, never()).invoke(eq(filePayload), any(), any())
     }
 
     @Test
-    fun `mapSendMessageFailed updates chat items with error indicator status for message without attachments`() {
-        val payload = SendMessagePayload(content = "message")
+    fun `mapSendMessageFailed updates chat items with error indicator status for message`() {
+        val payload = OutgoingMessage.Text(content = "message")
         val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId)
         state.messagePreviews[payload.messageId] = payload
         state.chatItems.add(visitorChatItem)
@@ -1008,51 +1020,39 @@ class ChatManagerTest {
     }
 
     @Test
-    fun `mapSendMessageFailed updates chat items with error indicator status for attachments without message`() {
-        val messageId = "message_id"
-        val file: AttachmentFile = mock {
-            on { id } doReturn "attachment_id"
-        }
-        val filesAttachment: FilesAttachment = mock {
-            on { files } doReturn arrayOf(file)
-        }
-        val payload = SendMessagePayload(content = "", messageId = messageId, attachment = filesAttachment)
-        val attachmentItem = VisitorAttachmentItem.LocalFile(id = "attachment_id", messageId = messageId, attachment = mock())
-        state.messagePreviews[messageId] = payload
+    fun `mapSendMessageFailed updates chat items with error indicator status for attachment`() {
+        val payload = OutgoingMessage.File(fileId = "attachment_id")
+        val attachmentItem = VisitorAttachmentItem.LocalFile(id = payload.fileId, messageId = payload.messageId, attachment = mock())
+        state.messagePreviews[payload.messageId] = payload
         state.chatItems.add(attachmentItem)
 
-        val newState = subjectUnderTest.mapSendMessageFailed(messageId, state)
+        val newState = subjectUnderTest.mapSendMessageFailed(payload.messageId, state)
 
         val updatedAttachmentItem = newState.chatItems[0] as VisitorAttachmentItem
         assertTrue(updatedAttachmentItem.isError)
         val tapToRetryItem = newState.chatItems.last() as TapToRetryItem
-        assertEquals(messageId, tapToRetryItem.messageId)
+        assertEquals(payload.messageId, tapToRetryItem.messageId)
     }
 
     @Test
-    fun `mapSendMessageFailed updates chat items with error status for message with attachments`() {
-        val messageId = "message_id"
-        val file: AttachmentFile = mock {
-            on { id } doReturn "attachment_id"
-        }
-        val filesAttachment: FilesAttachment = mock {
-            on { files } doReturn arrayOf(file)
-        }
-        val payload = SendMessagePayload(content = "message", messageId = messageId, attachment = filesAttachment)
-        val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId)
-        val attachmentItem = VisitorAttachmentItem.LocalFile(id = "attachment_id", messageId = messageId, attachment = mock())
-        state.messagePreviews[messageId] = payload
+    fun `mapSendMessageFailed marks only the failed message as error`() {
+        val textPayload = OutgoingMessage.Text(content = "message")
+        val filePayload = OutgoingMessage.File(fileId = "attachment_id")
+        val visitorChatItem = VisitorMessageItem(textPayload.content, textPayload.messageId)
+        val attachmentItem = VisitorAttachmentItem.LocalFile(id = filePayload.fileId, messageId = filePayload.messageId, attachment = mock())
+        state.messagePreviews[textPayload.messageId] = textPayload
+        state.messagePreviews[filePayload.messageId] = filePayload
         state.chatItems.add(visitorChatItem)
         state.chatItems.add(attachmentItem)
 
-        val newState = subjectUnderTest.mapSendMessageFailed(messageId, state)
+        val newState = subjectUnderTest.mapSendMessageFailed(textPayload.messageId, state)
 
         val updatedMessageItem = newState.chatItems.first() as VisitorChatItem
-        val updatedAttachmentItem = newState.chatItems[1] as VisitorAttachmentItem
-        val tapToRetryItem = newState.chatItems[2] as TapToRetryItem
+        val tapToRetryItem = newState.chatItems[1] as TapToRetryItem
+        val untouchedAttachmentItem = newState.chatItems[2] as VisitorAttachmentItem
         assertTrue(updatedMessageItem.isError)
-        assertTrue(updatedAttachmentItem.isError)
-        assertEquals(messageId, tapToRetryItem.messageId)
+        assertEquals(textPayload.messageId, tapToRetryItem.messageId)
+        assertFalse(untouchedAttachmentItem.isError)
     }
 
     @Test

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/data/GliaChatRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/data/GliaChatRepositoryTest.kt
@@ -6,9 +6,7 @@ import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.chat.Chat
 import com.glia.androidsdk.chat.ChatMessage
-import com.glia.androidsdk.chat.SendMessagePayload
-import com.glia.androidsdk.chat.VisitorMessage
-import com.glia.widgets.chat.domain.GliaSendMessageUseCase.Listener
+import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.widgets.di.GliaCore
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -98,58 +96,50 @@ class GliaChatRepositoryTest {
     }
 
     @Test
-    fun `sendMessage with callback forwards Core result to the callback`() {
-        val payload: SendMessagePayload = mockk()
-        val visitorMessage: VisitorMessage = mockk()
-        val callback: RequestCallback<VisitorMessage?> = mockk(relaxed = true)
+    fun `sendMessage delegates to the current engagement chat`() {
+        val onSuccess: () -> Unit = mockk(relaxed = true)
+        val onFailure: (GliaException) -> Unit = mockk(relaxed = true)
         every { gliaCore.currentEngagement } returns Optional.of(engagement)
-        val sdkCallbackSlot = slot<RequestCallback<VisitorMessage>>()
-        every { chat.sendMessage(payload, capture(sdkCallbackSlot)) } answers {
-            sdkCallbackSlot.captured.onResult(visitorMessage, null)
-        }
 
-        repository.sendMessage(payload, callback)
+        repository.sendMessage("content", MESSAGE_ID, onSuccess, onFailure)
 
-        verify { callback.onResult(visitorMessage, null) }
+        verify { chat.sendMessage("content", MESSAGE_ID, onSuccess, onFailure) }
     }
 
     @Test
-    fun `sendMessage with listener notifies messageSent on success`() {
-        val payload: SendMessagePayload = mockk()
-        val visitorMessage: VisitorMessage = mockk()
-        val listener: Listener = mockk(relaxed = true)
-        every { payload.messageId } returns MESSAGE_ID
-        every { gliaCore.currentEngagement } returns Optional.of(engagement)
-        val sdkCallbackSlot = slot<RequestCallback<VisitorMessage>>()
-        every { chat.sendMessage(payload, capture(sdkCallbackSlot)) } answers {
-            sdkCallbackSlot.captured.onResult(visitorMessage, null)
-        }
+    fun `sendMessage does nothing when there is no current engagement`() {
+        every { gliaCore.currentEngagement } returns Optional.empty()
 
-        repository.sendMessage(payload, listener)
+        repository.sendMessage("content", MESSAGE_ID, {}, {})
 
-        verify { listener.messageSent(visitorMessage) }
-        verify(inverse = true) { listener.error(any(), any()) }
+        verify(inverse = true) { chat.sendMessage(any(), any(), any(), any()) }
     }
 
     @Test
-    fun `sendMessage with listener notifies error with messageId on failure`() {
-        val payload: SendMessagePayload = mockk()
-        val exception = GliaException("error", GliaException.Cause.INTERNAL_ERROR)
-        val listener: Listener = mockk(relaxed = true)
-        every { payload.messageId } returns MESSAGE_ID
+    fun `sendSingleChoiceAttachment delegates to the current engagement chat`() {
+        val attachment: SingleChoiceAttachment = mockk()
+        val onSuccess: () -> Unit = mockk(relaxed = true)
+        val onFailure: (GliaException) -> Unit = mockk(relaxed = true)
         every { gliaCore.currentEngagement } returns Optional.of(engagement)
-        val sdkCallbackSlot = slot<RequestCallback<VisitorMessage>>()
-        every { chat.sendMessage(payload, capture(sdkCallbackSlot)) } answers {
-            sdkCallbackSlot.captured.onResult(null, exception)
-        }
 
-        repository.sendMessage(payload, listener)
+        repository.sendSingleChoiceAttachment(attachment, MESSAGE_ID, onSuccess, onFailure)
 
-        verify { listener.error(exception, MESSAGE_ID) }
-        verify(inverse = true) { listener.messageSent(any()) }
+        verify { chat.sendSingleChoiceAttachment(attachment, MESSAGE_ID, onSuccess, onFailure) }
+    }
+
+    @Test
+    fun `sendFileAttachment delegates to the current engagement chat`() {
+        val onSuccess: () -> Unit = mockk(relaxed = true)
+        val onFailure: (GliaException) -> Unit = mockk(relaxed = true)
+        every { gliaCore.currentEngagement } returns Optional.of(engagement)
+
+        repository.sendFileAttachment(FILE_ID, onSuccess, onFailure)
+
+        verify { chat.sendFileAttachment(FILE_ID, onSuccess, onFailure) }
     }
 
     private companion object {
         const val MESSAGE_ID = "message-id"
+        const val FILE_ID = "file-id"
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewChatMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewChatMessageUseCaseTest.kt
@@ -5,7 +5,9 @@ import com.glia.androidsdk.chat.OperatorMessage
 import com.glia.androidsdk.chat.SystemMessage
 import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.ChatManager
+import com.glia.widgets.chat.model.OutgoingMessage
 import com.glia.widgets.internal.engagement.domain.model.ChatMessageInternal
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +15,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -79,6 +82,31 @@ class AppendNewChatMessageUseCaseTest {
         verify(appendNewOperatorMessageUseCase, never()).invoke(any(), any())
         verify(appendSystemMessageItemUseCase, never()).invoke(any(), any())
         verify(state, never()).resetOperator()
+    }
+
+    @Test
+    fun `markMessageDelivered marks message delivered and resets operator when preview exists`() {
+        val realState = spy(ChatManager.State())
+        val payload = OutgoingMessage.Text("message")
+        realState.messagePreviews[payload.messageId] = payload
+        realState.preEngagementChatItemIds.add(payload.messageId)
+
+        useCase.markMessageDelivered(payload.messageId, realState)
+
+        verify(appendNewVisitorMessageUseCase).markMessageDelivered(realState, payload.messageId)
+        verify(realState).resetOperator()
+        assertTrue(realState.messagePreviews.isEmpty())
+        assertTrue(realState.preEngagementChatItemIds.isEmpty())
+    }
+
+    @Test
+    fun `markMessageDelivered skips delivery marking when preview is absent`() {
+        val realState = spy(ChatManager.State())
+
+        useCase.markMessageDelivered("missing_id", realState)
+
+        verify(appendNewVisitorMessageUseCase, never()).markMessageDelivered(any(), any())
+        verify(realState).resetOperator()
     }
 
     private inline fun <reified T : ChatMessage> mockCHatMessage() {

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.VisitorMessage
 import com.glia.widgets.chat.ChatManager
 import com.glia.widgets.chat.model.DeliveredItem
+import com.glia.widgets.chat.model.OutgoingMessage
 import com.glia.widgets.chat.model.VisitorAttachmentItem
 import com.glia.widgets.chat.model.VisitorMessageItem
 import com.glia.widgets.internal.engagement.domain.model.ChatMessageInternal
@@ -143,8 +144,8 @@ class AppendNewVisitorMessageUseCaseTest {
         whenever(mapVisitorAttachmentUseCase(eq(file), any())) doReturn attachment
         whenever(mapVisitorAttachmentUseCase(eq(file1), any())) doReturn attachment1
 
-        state.messagePreviews[messageId] = mock()
-        state.messagePreviews[messageId1] = mock()
+        state.messagePreviews[messageId] = OutgoingMessage.Text(messageContent, messageId)
+        state.messagePreviews[messageId1] = OutgoingMessage.Text(messageContent1, messageId1)
         state.chatItems += VisitorMessageItem(messageContent, messageId, isError = false, messageTimeStamp)
         state.chatItems += VisitorMessageItem(messageContent1, messageId1, isError = false, messageTimeStamp1)
         state.chatItems += attachment
@@ -176,7 +177,39 @@ class AppendNewVisitorMessageUseCaseTest {
         assertTrue(state.chatItems.count() == 5)
         assertTrue(state.chatItems.first() is VisitorMessageItem)
         assertTrue(state.chatItems[1] is VisitorMessageItem)
-        assertTrue(state.chatItems.last() is DeliveredItem)
+        // The DeliveredItem is placed right after the delivered message item - attachments are
+        // separate messages in the new send model and no longer affect its position.
+        val deliveredItem = state.chatItems[2] as DeliveredItem
+        assertEquals(messageId1, deliveredItem.messageId)
         assertEquals(0, state.messagePreviews.count())
+    }
+
+    @Test
+    fun `markMessageDelivered clears error and adds DeliveredItem after the message item`() {
+        val messageId = "1"
+        state.chatItems += VisitorMessageItem("content", messageId, isError = true, timestamp = 1)
+
+        useCase.markMessageDelivered(state, messageId)
+
+        assertTrue(state.chatItems.count() == 2)
+        val messageItem = state.chatItems.first() as VisitorMessageItem
+        assertFalse(messageItem.isError)
+        val deliveredItem = state.chatItems.last() as DeliveredItem
+        assertEquals(messageId, deliveredItem.messageId)
+    }
+
+    @Test
+    fun `markMessageDelivered moves DeliveredItem to the newly delivered message`() {
+        val firstId = "1"
+        val secondId = "2"
+        state.chatItems += VisitorMessageItem("first", firstId, isError = false, timestamp = 1)
+        state.chatItems += VisitorMessageItem("second", secondId, isError = false, timestamp = 2)
+
+        useCase.markMessageDelivered(state, firstId)
+        useCase.markMessageDelivered(state, secondId)
+
+        assertEquals(1, state.chatItems.count { it is DeliveredItem })
+        val deliveredItem = state.chatItems.last() as DeliveredItem
+        assertEquals(secondId, deliveredItem.messageId)
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/GliaSendMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/GliaSendMessageUseCaseTest.kt
@@ -1,0 +1,258 @@
+package com.glia.widgets.chat.domain
+
+import android.net.Uri
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.chat.SingleChoiceAttachment
+import com.glia.androidsdk.engagement.EngagementFile
+import com.glia.widgets.chat.data.GliaChatRepository
+import com.glia.widgets.chat.model.OutgoingMessage
+import com.glia.widgets.chat.model.VisitorAttachmentItem
+import com.glia.widgets.chat.model.VisitorMessageItem
+import com.glia.widgets.engagement.domain.IsOperatorPresentUseCase
+import com.glia.widgets.internal.fileupload.FileAttachmentRepository
+import com.glia.widgets.internal.fileupload.model.LocalAttachment
+import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
+import com.glia.widgets.internal.secureconversations.domain.ManageSecureMessagingStatusUseCase
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GliaSendMessageUseCaseTest {
+
+    private val chatRepository: GliaChatRepository = mockk(relaxUnitFun = true)
+    private val fileAttachmentRepository: FileAttachmentRepository = mockk(relaxUnitFun = true)
+    private val isOperatorPresentUseCase: IsOperatorPresentUseCase = mockk()
+    private val secureConversationsRepository: SecureConversationsRepository = mockk(relaxUnitFun = true)
+    private val manageSecureMessagingStatusUseCase: ManageSecureMessagingStatusUseCase = mockk()
+    private val listener: GliaSendMessageUseCase.Listener = mockk(relaxUnitFun = true)
+
+    private lateinit var useCase: GliaSendMessageUseCase
+
+    @Before
+    fun setUp() {
+        useCase = GliaSendMessageUseCase(
+            chatRepository,
+            fileAttachmentRepository,
+            isOperatorPresentUseCase,
+            secureConversationsRepository,
+            manageSecureMessagingStatusUseCase
+        )
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns emptyList()
+        givenOperatorOnline(false)
+        givenSecureMessaging(false)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `execute validates message and sends text through chat repository when operator is online`() {
+        givenOperatorOnline(true)
+        val itemSlot = slot<VisitorMessageItem>()
+        val payloadSlot = slot<OutgoingMessage>()
+        every { listener.onMessagePrepared(capture(itemSlot), capture(payloadSlot)) } returns Unit
+
+        useCase.execute(MESSAGE, listener)
+
+        verify { listener.onMessageValidated() }
+        val payload = payloadSlot.captured as OutgoingMessage.Text
+        assertEquals(MESSAGE, payload.content)
+        assertEquals(payload.messageId, itemSlot.captured.id)
+        verify { chatRepository.sendMessage(MESSAGE, payload.messageId, any(), any()) }
+        verify(inverse = true) { secureConversationsRepository.sendMessage(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute sends text through secure conversations when secure messaging is active`() {
+        givenSecureMessaging(true)
+
+        useCase.execute(MESSAGE, listener)
+
+        verify { secureConversationsRepository.sendMessage(eq(MESSAGE), any(), any(), any()) }
+        verify(inverse = true) { chatRepository.sendMessage(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute prefers live chat over secure messaging when operator is online`() {
+        givenOperatorOnline(true)
+        givenSecureMessaging(true)
+
+        useCase.execute(MESSAGE, listener)
+
+        verify { chatRepository.sendMessage(eq(MESSAGE), any(), any(), any()) }
+        verify(inverse = true) { secureConversationsRepository.sendMessage(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute notifies errorOperatorOffline when neither operator nor secure messaging is available`() {
+        useCase.execute(MESSAGE, listener)
+
+        verify { listener.errorOperatorOffline(any()) }
+        verify(inverse = true) { chatRepository.sendMessage(any(), any(), any(), any()) }
+        verify(inverse = true) { secureConversationsRepository.sendMessage(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute does nothing when message is blank and there are no attachments`() {
+        useCase.execute("", listener)
+
+        verify(inverse = true) { listener.onMessageValidated() }
+        verify(inverse = true) { listener.onMessagePrepared(any(), any()) }
+        verify(inverse = true) { listener.errorOperatorOffline(any()) }
+    }
+
+    @Test
+    fun `execute notifies messageSent when Core reports text send success`() {
+        givenOperatorOnline(true)
+        val payloadSlot = slot<OutgoingMessage>()
+        every { listener.onMessagePrepared(any(), capture(payloadSlot)) } returns Unit
+        val onSuccessSlot = slot<() -> Unit>()
+        every { chatRepository.sendMessage(any(), any(), capture(onSuccessSlot), any()) } returns Unit
+
+        useCase.execute(MESSAGE, listener)
+        onSuccessSlot.captured.invoke()
+
+        verify { listener.messageSent(payloadSlot.captured.messageId) }
+    }
+
+    @Test
+    fun `execute notifies error when Core reports text send failure`() {
+        givenOperatorOnline(true)
+        val exception = GliaException("error", GliaException.Cause.INTERNAL_ERROR)
+        val payloadSlot = slot<OutgoingMessage>()
+        every { listener.onMessagePrepared(any(), capture(payloadSlot)) } returns Unit
+        val onFailureSlot = slot<(GliaException) -> Unit>()
+        every { chatRepository.sendMessage(any(), any(), any(), capture(onFailureSlot)) } returns Unit
+
+        useCase.execute(MESSAGE, listener)
+        onFailureSlot.captured.invoke(exception)
+
+        verify { listener.error(exception, payloadSlot.captured.messageId) }
+    }
+
+    @Test
+    fun `execute prepares and sends each attachment as a separate file message`() {
+        givenOperatorOnline(true)
+        val attachments = listOf(localAttachment(FILE_ID), localAttachment(FILE_ID_1))
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns attachments
+        val itemSlots = mutableListOf<VisitorAttachmentItem>()
+        val payloadSlots = mutableListOf<OutgoingMessage>()
+        every { listener.onAttachmentPrepared(capture(itemSlots), capture(payloadSlots)) } returns Unit
+
+        useCase.execute("", listener)
+
+        assertEquals(listOf(FILE_ID, FILE_ID_1), itemSlots.map { it.id })
+        assertEquals(listOf(FILE_ID, FILE_ID_1), payloadSlots.map { it.messageId })
+        verify { chatRepository.sendFileAttachment(FILE_ID, any(), any()) }
+        verify { chatRepository.sendFileAttachment(FILE_ID_1, any(), any()) }
+        verify { fileAttachmentRepository.detachFiles(attachments) }
+    }
+
+    @Test
+    fun `execute sends attachments through secure conversations when secure messaging is active`() {
+        givenSecureMessaging(true)
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns listOf(localAttachment(FILE_ID))
+
+        useCase.execute("", listener)
+
+        verify { secureConversationsRepository.sendFileAttachment(FILE_ID, any(), any()) }
+        verify(inverse = true) { chatRepository.sendFileAttachment(any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute notifies errorOperatorOffline for attachments when sending is not possible`() {
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns listOf(localAttachment(FILE_ID))
+
+        useCase.execute("", listener)
+
+        verify { listener.errorOperatorOffline(FILE_ID) }
+        verify(inverse = true) { chatRepository.sendFileAttachment(any(), any(), any()) }
+        verify(inverse = true) { secureConversationsRepository.sendFileAttachment(any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute skips attachments that have no engagement file`() {
+        givenOperatorOnline(true)
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns listOf(localAttachment(fileId = null))
+
+        useCase.execute("", listener)
+
+        verify(inverse = true) { listener.onAttachmentPrepared(any(), any()) }
+        verify(inverse = true) { chatRepository.sendFileAttachment(any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute sends single choice attachment through chat repository when operator is online`() {
+        givenOperatorOnline(true)
+        val singleChoiceAttachment: SingleChoiceAttachment = mockk {
+            every { selectedOptionText } returns "selected"
+        }
+        val itemSlot = slot<VisitorMessageItem>()
+        val payloadSlot = slot<OutgoingMessage>()
+        every { listener.onMessagePrepared(capture(itemSlot), capture(payloadSlot)) } returns Unit
+
+        useCase.execute(singleChoiceAttachment, listener)
+
+        assertEquals("selected", itemSlot.captured.message)
+        verify { chatRepository.sendSingleChoiceAttachment(singleChoiceAttachment, payloadSlot.captured.messageId, any(), any()) }
+    }
+
+    @Test
+    fun `execute prefers secure conversations for single choice attachment when secure messaging is active`() {
+        givenOperatorOnline(true)
+        givenSecureMessaging(true)
+        val singleChoiceAttachment: SingleChoiceAttachment = mockk {
+            every { selectedOptionText } returns "selected"
+        }
+
+        useCase.execute(singleChoiceAttachment, listener)
+
+        verify { secureConversationsRepository.sendSingleChoiceAttachment(eq(singleChoiceAttachment), any(), any(), any()) }
+        verify(inverse = true) { chatRepository.sendSingleChoiceAttachment(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `execute notifies errorOperatorOffline for single choice attachment when sending is not possible`() {
+        val singleChoiceAttachment: SingleChoiceAttachment = mockk {
+            every { selectedOptionText } returns "selected"
+        }
+
+        useCase.execute(singleChoiceAttachment, listener)
+
+        verify { listener.errorOperatorOffline(any()) }
+    }
+
+    private fun givenOperatorOnline(isOnline: Boolean) {
+        every { isOperatorPresentUseCase() } returns isOnline
+    }
+
+    private fun givenSecureMessaging(isActive: Boolean) {
+        every { manageSecureMessagingStatusUseCase.shouldUseSecureMessagingEndpoints } returns isActive
+    }
+
+    private fun localAttachment(fileId: String?): LocalAttachment {
+        val engagementFile: EngagementFile? = fileId?.let { mockk { every { id } returns it } }
+        return LocalAttachment(
+            uri = mockk<Uri>(),
+            mimeType = "image/png",
+            displayName = "display-name",
+            size = 10L,
+            attachmentStatus = LocalAttachment.Status.READY_TO_SEND,
+            engagementFile = engagementFile
+        )
+    }
+
+    private companion object {
+        const val MESSAGE = "message"
+        const val FILE_ID = "file-id"
+        const val FILE_ID_1 = "file-id-1"
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/SendUnsentMessagesUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/SendUnsentMessagesUseCaseTest.kt
@@ -1,0 +1,109 @@
+package com.glia.widgets.chat.domain
+
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.chat.SingleChoiceAttachment
+import com.glia.widgets.chat.data.GliaChatRepository
+import com.glia.widgets.chat.model.OutgoingMessage
+import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
+import com.glia.widgets.internal.secureconversations.domain.ManageSecureMessagingStatusUseCase
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class SendUnsentMessagesUseCaseTest {
+
+    private val chatRepository: GliaChatRepository = mockk(relaxUnitFun = true)
+    private val secureConversationsRepository: SecureConversationsRepository = mockk(relaxUnitFun = true)
+    private val manageSecureMessagingStatusUseCase: ManageSecureMessagingStatusUseCase = mockk()
+
+    private val onSuccess: () -> Unit = mockk(relaxed = true)
+    private val onFailure: (GliaException) -> Unit = mockk(relaxed = true)
+
+    private lateinit var useCase: SendUnsentMessagesUseCase
+
+    @Before
+    fun setUp() {
+        useCase = SendUnsentMessagesUseCase(chatRepository, secureConversationsRepository, manageSecureMessagingStatusUseCase)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `invoke sends text through chat repository when secure messaging is not active`() {
+        givenSecureMessaging(false)
+        val payload = OutgoingMessage.Text("content")
+
+        useCase(payload, onSuccess, onFailure)
+
+        verify { chatRepository.sendMessage("content", payload.messageId, onSuccess, onFailure) }
+        verify(inverse = true) { secureConversationsRepository.sendMessage(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `invoke sends text through secure conversations when secure messaging is active`() {
+        givenSecureMessaging(true)
+        val payload = OutgoingMessage.Text("content")
+
+        useCase(payload, onSuccess, onFailure)
+
+        verify { secureConversationsRepository.sendMessage("content", payload.messageId, onSuccess, onFailure) }
+        verify(inverse = true) { chatRepository.sendMessage(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `invoke sends file through chat repository when secure messaging is not active`() {
+        givenSecureMessaging(false)
+        val payload = OutgoingMessage.File("file-id")
+
+        useCase(payload, onSuccess, onFailure)
+
+        verify { chatRepository.sendFileAttachment("file-id", onSuccess, onFailure) }
+        verify(inverse = true) { secureConversationsRepository.sendFileAttachment(any(), any(), any()) }
+    }
+
+    @Test
+    fun `invoke sends file through secure conversations when secure messaging is active`() {
+        givenSecureMessaging(true)
+        val payload = OutgoingMessage.File("file-id")
+
+        useCase(payload, onSuccess, onFailure)
+
+        verify { secureConversationsRepository.sendFileAttachment("file-id", onSuccess, onFailure) }
+        verify(inverse = true) { chatRepository.sendFileAttachment(any(), any(), any()) }
+    }
+
+    @Test
+    fun `invoke sends single choice through chat repository when secure messaging is not active`() {
+        givenSecureMessaging(false)
+        val attachment: SingleChoiceAttachment = mockk()
+        val payload = OutgoingMessage.SingleChoice(attachment)
+
+        useCase(payload, onSuccess, onFailure)
+
+        verify { chatRepository.sendSingleChoiceAttachment(attachment, payload.messageId, onSuccess, onFailure) }
+        verify(inverse = true) { secureConversationsRepository.sendSingleChoiceAttachment(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `invoke sends single choice through secure conversations when secure messaging is active`() {
+        givenSecureMessaging(true)
+        val attachment: SingleChoiceAttachment = mockk()
+        val payload = OutgoingMessage.SingleChoice(attachment)
+
+        useCase(payload, onSuccess, onFailure)
+
+        verify { secureConversationsRepository.sendSingleChoiceAttachment(attachment, payload.messageId, onSuccess, onFailure) }
+        verify(inverse = true) { chatRepository.sendSingleChoiceAttachment(any(), any(), any(), any()) }
+    }
+
+    private fun givenSecureMessaging(isActive: Boolean) {
+        every { manageSecureMessagingStatusUseCase.shouldUseSecureMessagingEndpoints } returns isActive
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/secureconversations/SecureConversationsRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/secureconversations/SecureConversationsRepositoryTest.kt
@@ -3,8 +3,7 @@ package com.glia.widgets.internal.secureconversations
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.RequestCallback
 import com.glia.androidsdk.chat.ChatMessage
-import com.glia.androidsdk.chat.SendMessagePayload
-import com.glia.androidsdk.chat.VisitorMessage
+import com.glia.androidsdk.chat.SingleChoiceAttachment
 import com.glia.androidsdk.secureconversations.SecureConversations
 import com.glia.widgets.chat.data.GliaChatRepository
 import com.glia.widgets.di.GliaCore
@@ -15,12 +14,15 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
+import io.reactivex.rxjava3.core.Scheduler
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.junit.After
+import org.junit.Assert.assertArrayEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
+import com.glia.widgets.helper.rx.Schedulers as GliaSchedulers
 
 class SecureConversationsRepositoryTest {
 
@@ -33,11 +35,16 @@ class SecureConversationsRepositoryTest {
     private val pendingSCSlot = slot<RequestCallback<Boolean>>()
 
 
+    private val testSchedulers: GliaSchedulers = object : GliaSchedulers {
+        override val computationScheduler: Scheduler = Schedulers.trampoline()
+        override val mainScheduler: Scheduler = Schedulers.trampoline()
+    }
+
     @Before
     fun setUp() {
         RxAndroidPlugins.setInitMainThreadSchedulerHandler { Schedulers.trampoline() }
         every { core.secureConversations } returns secureConversations
-        repository = SecureConversationsRepository(core, queueRepository)
+        repository = SecureConversationsRepository(core, queueRepository, testSchedulers)
         verify(inverse = true) { secureConversations.subscribeToUnreadMessageCount(any()) }
         verify(inverse = true) { secureConversations.subscribeToPendingSecureConversationStatus(any()) }
         repository.unreadMessagesCountObservable.test()
@@ -146,29 +153,93 @@ class SecureConversationsRepositoryTest {
     }
 
     @Test
-    fun `send should call secureConversations send with queueIds`() {
-        val payload: SendMessagePayload = mockk()
-        val callback: RequestCallback<VisitorMessage?> = mockk(relaxed = true)
-        val queueIds = listOf("queue1", "queue2")
+    fun `sendMessage sends through secureConversations with relevant queue ids`() {
+        val queueIdsSlot = slot<Array<String>>()
+        every { queueRepository.relevantQueueIds } returns Single.just(listOf("queue1", "queue2"))
+        every { secureConversations.sendMessage(any(), capture(queueIdsSlot), any(), any(), any()) } returns Unit
 
-        every { queueRepository.relevantQueueIds } returns Single.just(queueIds)
+        repository.sendMessage("content", MESSAGE_ID, {}, {})
 
-        repository.send(payload, callback)
-
-        verify { secureConversations.send(payload, queueIds.toTypedArray(), any()) }
+        verify { secureConversations.sendMessage(eq("content"), any(), eq(MESSAGE_ID), any(), any()) }
+        assertArrayEquals(arrayOf("queue1", "queue2"), queueIdsSlot.captured)
     }
 
     @Test
-    fun `send should call callback with exception when queueIds are empty`() {
-        val payload: SendMessagePayload = mockk()
-        val callback: RequestCallback<VisitorMessage?> = mockk(relaxed = true)
-        val queueIds = emptyList<String>()
+    fun `sendMessage emits sending state and invokes onSuccess when Core reports success`() {
+        val onSuccess: () -> Unit = mockk(relaxed = true)
+        val sdkOnSuccessSlot = slot<() -> Unit>()
+        every { queueRepository.relevantQueueIds } returns Single.just(listOf("queue1"))
+        every { secureConversations.sendMessage(any(), any(), any(), capture(sdkOnSuccessSlot), any()) } returns Unit
 
-        every { queueRepository.relevantQueueIds } returns Single.just(queueIds)
+        val sendingObserver = repository.messageSendingObservable.test()
 
-        repository.send(payload, callback)
+        repository.sendMessage("content", MESSAGE_ID, onSuccess, {})
+        sdkOnSuccessSlot.captured.invoke()
 
-        verify { callback.onResult(null, any<GliaException>()) }
+        verify { onSuccess.invoke() }
+        sendingObserver.assertValues(false, true, false)
+    }
+
+    @Test
+    fun `sendMessage invokes onFailure and stops sending state when Core reports failure`() {
+        val onFailure: (GliaException) -> Unit = mockk(relaxed = true)
+        val exception = GliaException("error", GliaException.Cause.INTERNAL_ERROR)
+        val sdkOnFailureSlot = slot<(GliaException) -> Unit>()
+        every { queueRepository.relevantQueueIds } returns Single.just(listOf("queue1"))
+        every { secureConversations.sendMessage(any(), any(), any(), any(), capture(sdkOnFailureSlot)) } returns Unit
+
+        val sendingObserver = repository.messageSendingObservable.test()
+
+        repository.sendMessage("content", MESSAGE_ID, {}, onFailure)
+        sdkOnFailureSlot.captured.invoke(exception)
+
+        verify { onFailure.invoke(exception) }
+        sendingObserver.assertValues(false, true, false)
+    }
+
+    @Test
+    fun `sendMessage invokes onFailure when relevant queue ids are empty`() {
+        val onFailure: (GliaException) -> Unit = mockk(relaxed = true)
+        every { queueRepository.relevantQueueIds } returns Single.just(emptyList())
+
+        repository.sendMessage("content", MESSAGE_ID, {}, onFailure)
+
+        verify { onFailure.invoke(any()) }
+        verify(inverse = true) { secureConversations.sendMessage(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `sendMessageWithAttachments sends content and file ids through secureConversations`() {
+        val fileAttachments = listOf("file1", "file2")
+        every { queueRepository.relevantQueueIds } returns Single.just(listOf("queue1"))
+        every { secureConversations.sendMessageWithAttachments(any(), any(), any(), any(), any(), any()) } returns Unit
+
+        repository.sendMessageWithAttachments("content", fileAttachments, MESSAGE_ID, {}, {})
+
+        verify {
+            secureConversations.sendMessageWithAttachments(eq("content"), eq(fileAttachments), any(), eq(MESSAGE_ID), any(), any())
+        }
+    }
+
+    @Test
+    fun `sendSingleChoiceAttachment sends attachment through secureConversations`() {
+        val attachment: SingleChoiceAttachment = mockk()
+        every { queueRepository.relevantQueueIds } returns Single.just(listOf("queue1"))
+        every { secureConversations.sendSingleChoiceAttachment(any(), any(), any(), any(), any()) } returns Unit
+
+        repository.sendSingleChoiceAttachment(attachment, MESSAGE_ID, {}, {})
+
+        verify { secureConversations.sendSingleChoiceAttachment(eq(attachment), any(), eq(MESSAGE_ID), any(), any()) }
+    }
+
+    @Test
+    fun `sendFileAttachment sends file id through secureConversations`() {
+        every { queueRepository.relevantQueueIds } returns Single.just(listOf("queue1"))
+        every { secureConversations.sendFileAttachment(any(), any(), any(), any()) } returns Unit
+
+        repository.sendFileAttachment(FILE_ID, {}, {})
+
+        verify { secureConversations.sendFileAttachment(eq(FILE_ID), any(), any(), any()) }
     }
 
     @Test
@@ -178,5 +249,10 @@ class SecureConversationsRepositoryTest {
         repository.markMessagesRead(callback)
 
         verify { secureConversations.markMessagesRead(callback) }
+    }
+
+    private companion object {
+        const val MESSAGE_ID = "message-id"
+        const val FILE_ID = "file-id"
     }
 }

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/secureconversations/domain/SendSecureMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/secureconversations/domain/SendSecureMessageUseCaseTest.kt
@@ -1,0 +1,116 @@
+package com.glia.widgets.internal.secureconversations.domain
+
+import android.net.Uri
+import com.glia.androidsdk.GliaException
+import com.glia.androidsdk.engagement.EngagementFile
+import com.glia.widgets.internal.fileupload.FileAttachmentRepository
+import com.glia.widgets.internal.fileupload.model.LocalAttachment
+import com.glia.widgets.internal.secureconversations.SecureConversationsRepository
+import com.glia.widgets.internal.secureconversations.SendMessageRepository
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class SendSecureMessageUseCaseTest {
+
+    private val sendMessageRepository: SendMessageRepository = mockk(relaxUnitFun = true)
+    private val secureConversationsRepository: SecureConversationsRepository = mockk(relaxUnitFun = true)
+    private val fileAttachmentRepository: FileAttachmentRepository = mockk(relaxUnitFun = true)
+
+    private val onSuccess: () -> Unit = mockk(relaxed = true)
+    private val onFailure: (GliaException) -> Unit = mockk(relaxed = true)
+
+    private lateinit var useCase: SendSecureMessageUseCase
+
+    @Before
+    fun setUp() {
+        useCase = SendSecureMessageUseCase(sendMessageRepository, secureConversationsRepository, fileAttachmentRepository)
+        every { sendMessageRepository.value } returns MESSAGE
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns emptyList()
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `invoke sends plain message when there are no attachments`() {
+        useCase(onSuccess, onFailure)
+
+        verify { secureConversationsRepository.sendMessage(eq(MESSAGE), any(), eq(onSuccess), eq(onFailure)) }
+        verify(inverse = true) { secureConversationsRepository.sendMessageWithAttachments(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `invoke sends message with attachment file ids when attachments are ready to send`() {
+        val attachments = listOf(localAttachment(FILE_ID), localAttachment(FILE_ID_1))
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns attachments
+
+        useCase(onSuccess, onFailure)
+
+        verify {
+            secureConversationsRepository.sendMessageWithAttachments(eq(MESSAGE), eq(listOf(FILE_ID, FILE_ID_1)), any(), any(), any())
+        }
+        verify(inverse = true) { secureConversationsRepository.sendMessage(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `invoke resets composed message and detaches files before reporting success for attachment sends`() {
+        val attachments = listOf(localAttachment(FILE_ID))
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns attachments
+        val sdkOnSuccessSlot = slot<() -> Unit>()
+        every {
+            secureConversationsRepository.sendMessageWithAttachments(any(), any(), any(), capture(sdkOnSuccessSlot), any())
+        } returns Unit
+
+        useCase(onSuccess, onFailure)
+        sdkOnSuccessSlot.captured.invoke()
+
+        verify { sendMessageRepository.reset() }
+        verify { fileAttachmentRepository.detachFiles(attachments) }
+        verify { onSuccess.invoke() }
+    }
+
+    @Test
+    fun `invoke propagates failure without resetting state for attachment sends`() {
+        val attachments = listOf(localAttachment(FILE_ID))
+        val exception = GliaException("error", GliaException.Cause.INTERNAL_ERROR)
+        every { fileAttachmentRepository.getReadyToSendFileAttachments() } returns attachments
+        val sdkOnFailureSlot = slot<(GliaException) -> Unit>()
+        every {
+            secureConversationsRepository.sendMessageWithAttachments(any(), any(), any(), any(), capture(sdkOnFailureSlot))
+        } returns Unit
+
+        useCase(onSuccess, onFailure)
+        sdkOnFailureSlot.captured.invoke(exception)
+
+        verify { onFailure.invoke(exception) }
+        verify(inverse = true) { sendMessageRepository.reset() }
+        verify(inverse = true) { fileAttachmentRepository.detachFiles(any()) }
+        verify(inverse = true) { onSuccess.invoke() }
+    }
+
+    private fun localAttachment(fileId: String): LocalAttachment {
+        val engagementFile: EngagementFile = mockk { every { id } returns fileId }
+        return LocalAttachment(
+            uri = mockk<Uri>(),
+            mimeType = "image/png",
+            displayName = "display-name",
+            size = 10L,
+            attachmentStatus = LocalAttachment.Status.READY_TO_SEND,
+            engagementFile = engagementFile
+        )
+    }
+
+    private companion object {
+        const val MESSAGE = "message"
+        const val FILE_ID = "file-id"
+        const val FILE_ID_1 = "file-id-1"
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/messagecenter/MessageCenterControllerTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -172,34 +173,56 @@ internal class MessageCenterControllerTest {
         verify(viewContract).setupViewAppearance()
     }
 
+    private fun stubSendMessageFlow(sendResult: GliaException?) {
+        whenever(requestNotificationPermissionIfPushNotificationsSetUpUseCase.invoke(any())) doAnswer {
+            it.getArgument<() -> Unit>(0).invoke()
+        }
+        whenever(sendSecureMessageUseCase.invoke(any(), any())) doAnswer {
+            if (sendResult == null) {
+                it.getArgument<() -> Unit>(0).invoke()
+            } else {
+                it.getArgument<(GliaException) -> Unit>(1).invoke(sendResult)
+            }
+        }
+    }
+
     @Test
-    fun handleMessageSendResult_CallsShowNavigationScreen_WhenErrorNull() {
+    fun onSendMessageClicked_ShowsConfirmationScreen_WhenSendSucceeds() {
         messageCenterController.setView(viewContract)
-        messageCenterController.handleSendMessageResult(null)
+        stubSendMessageFlow(sendResult = null)
+
+        messageCenterController.onSendMessageClicked()
+
         verify(viewContract, times(1)).showConfirmationScreen()
     }
 
     @Test
-    fun handleMessageSendResult_CallsNavigateToMessaging_WhenAuthError() {
+    fun onSendMessageClicked_ShowsMessageCenterUnavailableDialog_WhenAuthError() {
         messageCenterController.setView(viewContract)
-        val gliaException = GliaException("Message", GliaException.Cause.AUTHENTICATION_ERROR)
-        messageCenterController.handleSendMessageResult(gliaException)
+        stubSendMessageFlow(GliaException("Message", GliaException.Cause.AUTHENTICATION_ERROR))
+
+        messageCenterController.onSendMessageClicked()
+
         verify(dialogController).showMessageCenterUnavailableDialog()
     }
 
     @Test
-    fun handleMessageSendResult_CallsNavigateToMessaging_WhenInternalError() {
+    fun onSendMessageClicked_ShowsUnexpectedErrorDialog_WhenInternalError() {
         messageCenterController.setView(viewContract)
-        val gliaException = GliaException("Message", GliaException.Cause.INTERNAL_ERROR)
-        messageCenterController.handleSendMessageResult(gliaException)
+        stubSendMessageFlow(GliaException("Message", GliaException.Cause.INTERNAL_ERROR))
+
+        messageCenterController.onSendMessageClicked()
+
         verify(dialogController).showUnexpectedErrorDialog()
     }
 
     @Test
-    fun handleMessageSendResult_CallsNavigateToMessaging_WhenOtherError() {
+    fun onSendMessageClicked_ShowsUnexpectedErrorDialog_WhenOtherError() {
         messageCenterController.setView(viewContract)
-        val gliaException = GliaException("Message", GliaException.Cause.INVALID_INPUT)
-        messageCenterController.handleSendMessageResult(gliaException)
+        stubSendMessageFlow(GliaException("Message", GliaException.Cause.INVALID_INPUT))
+
+        messageCenterController.onSendMessageClicked()
+
         verify(dialogController).showUnexpectedErrorDialog()
     }
 

--- a/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotAttachment.kt
+++ b/widgetssdk/src/testSnapshot/java/com/glia/widgets/snapshotutils/SnapshotAttachment.kt
@@ -12,17 +12,17 @@ import org.mockito.kotlin.whenever
 internal interface SnapshotAttachment {
 
     fun remoteAttachment(
-        id: String = "imageId",
-        size: Long = 12345,
-        contentType: String = "image",
-        isDeleted: Boolean = false,
-        name: String = "tricky_plan.jpg"
-    ) = object : AttachmentFile {
-        override fun getId(): String = id
-        override fun getSize(): Long = size
-        override fun getContentType(): String = contentType
-        override fun isDeleted(): Boolean = isDeleted
-        override fun getName(): String = name
+        fileId: String = "imageId",
+        fileSize: Long = 12345,
+        fileContentType: String = "image",
+        fileIsDeleted: Boolean = false,
+        fileName: String = "tricky_plan.jpg"
+    ): AttachmentFile = object : AttachmentFile {
+        override val id: String = fileId
+        override val size: Long = fileSize
+        override val contentType: String = fileContentType
+        override val isDeleted: Boolean = fileIsDeleted
+        override val name: String = fileName
     }
 
     fun visitorAttachmentItemImage(attachment: AttachmentFile = remoteAttachment()): VisitorAttachmentItem.RemoteImage {
@@ -31,10 +31,10 @@ internal interface SnapshotAttachment {
 
     fun visitorAttachmentItemFile(
         attachment: AttachmentFile = remoteAttachment(
-            id = "fileId",
-            size = 1234567890,
-            contentType = "pdf",
-            name = "File Name.pdf"
+            fileId = "fileId",
+            fileSize = 1234567890,
+            fileContentType = "pdf",
+            fileName = "File Name.pdf"
         )
     ): VisitorAttachmentItem.RemoteFile {
         return VisitorAttachmentItem.RemoteFile(
@@ -59,7 +59,7 @@ internal interface SnapshotAttachment {
     fun operatorAttachmentItemFile(
         isFileExists: Boolean = false,
         isDownloading: Boolean = false,
-        attachment: AttachmentFile = remoteAttachment(id = "pdfId", contentType = "pdf", name = "Document.pdf"),
+        attachment: AttachmentFile = remoteAttachment(fileId = "pdfId", fileContentType = "pdf", fileName = "Document.pdf"),
         id: String = "operatorImageId",
         timestamp: Long = 1706534848,
         showChatHead: Boolean = false,


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5376

**What was solved?**

Migrated the Widgets chat/secure-conversations send path to the new unified Core SDK send API.

- Replaced the removed Core `SendMessagePayload` with a Widgets-internal sealed `OutgoingMessage` type (`Text` / `SingleChoice` / `File`, where a file's id doubles as its message id).
- Routed chat and secure conversations sends through the new unified Core API, using separated `onSuccess` / `onFailure` lambdas instead of `RequestCallback<VisitorMessage>`.
- The sent message is no longer returned on send; it is reconciled from the `CHAT_MESSAGE` event stream by message id.
- The message center now sends content and all files in a single `SecureConversations.sendMessageWithAttachments` request (no per-message aggregation).
- Removed the dead live-engagement branch from `SendSecureMessageUseCase` (and its now-unused `chatRepository` / `IsQueueingOrLiveEngagementUseCase` dependencies).
- Core no longer marshals send callbacks to the main thread, so `SecureConversationsRepository` now hops its send callbacks (and the message-sending state) back onto the main thread via the injected `Schedulers`.

**Additional info:**

> ⚠️ This branch compiles only against the local Core SDK with the unified send API. It cannot build on CI / merge until that Core version is published.

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

N/A — no UI changes.
