### PR TITLE
Fix visitor attachment send crashes

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -298,9 +298,11 @@ internal class ChatManager(
         }
 
         files?.forEach { attachment ->
-            val index = chatItems.indexOfLast { it.id == attachment.id }
+            val index = chatItems.indexOfLast { (it as? LocalAttachmentItem)?.attachment?.engagementFile?.id == attachment.id }
 
-            chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(false)
+            if (index != -1) {
+                chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(false)
+            }
         }
     }
 
@@ -317,9 +319,11 @@ internal class ChatManager(
         }
 
         files.forEach { attachment ->
-            val index = chatItems.indexOfLast { it.id == attachment.id }
+            val index = chatItems.indexOfLast { (it as? LocalAttachmentItem)?.attachment?.engagementFile?.id == attachment.id }
 
-            chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(true)
+            if (index != -1) {
+                chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(true)
+            }
         }
 
         val lastItemIndex = if (files.isNotEmpty()) {

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/fileupload/model/LocalAttachment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/fileupload/model/LocalAttachment.kt
@@ -12,14 +12,13 @@ internal data class LocalAttachment(
     val size: Long,
     val attachmentStatus: Status = Status.UPLOADING,
     val engagementFile: EngagementFile? = null,
+    val id: String = UUID.randomUUID().toString(),
 ) {
 
     val isReadyToSend: Boolean
         get() = attachmentStatus == Status.READY_TO_SEND
     val isImage: Boolean
         get() = mimeType?.startsWith("image") ?: false
-    val id: String
-        get() = engagementFile?.id ?: UUID.randomUUID().toString()
 
     fun toVisitorAttachmentItem(messageId: String): VisitorAttachmentItem = if (isImage) {
         VisitorAttachmentItem.LocalImage(id, messageId, this)

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -3,6 +3,8 @@ package com.glia.widgets.chat
 import android.os.Looper
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.chat.AttachmentFile
+import com.glia.androidsdk.engagement.EngagementFile
+import com.glia.widgets.internal.fileupload.model.LocalAttachment
 import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.OperatorMessage
@@ -943,10 +945,12 @@ class ChatManagerTest {
             on { files } doReturn arrayOf(file)
         }
         val payload = SendMessagePayload(content = "", messageId = messageId, attachment = filesAttachment)
+        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
+        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
         val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "attachment_id",
+            id = "local_attachment_id",
             messageId = messageId,
-            attachment = mock(),
+            attachment = localAttachment,
             isError = true
         )
         state.messagePreviews[messageId] = payload
@@ -972,10 +976,12 @@ class ChatManagerTest {
         }
         val payload = SendMessagePayload(content = "message", messageId = messageId, attachment = filesAttachment)
         val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId, isError = true)
+        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
+        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
         val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "attachment_id",
+            id = "local_attachment_id",
             messageId = messageId,
-            attachment = mock(),
+            attachment = localAttachment,
             isError = true
         )
         state.messagePreviews[messageId] = payload
@@ -1017,7 +1023,13 @@ class ChatManagerTest {
             on { files } doReturn arrayOf(file)
         }
         val payload = SendMessagePayload(content = "", messageId = messageId, attachment = filesAttachment)
-        val attachmentItem = VisitorAttachmentItem.LocalFile(id = "attachment_id", messageId = messageId, attachment = mock())
+        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
+        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
+        val attachmentItem = VisitorAttachmentItem.LocalFile(
+            id = "local_attachment_id",
+            messageId = messageId,
+            attachment = localAttachment
+        )
         state.messagePreviews[messageId] = payload
         state.chatItems.add(attachmentItem)
 
@@ -1040,7 +1052,13 @@ class ChatManagerTest {
         }
         val payload = SendMessagePayload(content = "message", messageId = messageId, attachment = filesAttachment)
         val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId)
-        val attachmentItem = VisitorAttachmentItem.LocalFile(id = "attachment_id", messageId = messageId, attachment = mock())
+        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
+        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
+        val attachmentItem = VisitorAttachmentItem.LocalFile(
+            id = "local_attachment_id",
+            messageId = messageId,
+            attachment = localAttachment
+        )
         state.messagePreviews[messageId] = payload
         state.chatItems.add(visitorChatItem)
         state.chatItems.add(attachmentItem)

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/fileupload/FileAttachmentRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/fileupload/FileAttachmentRepositoryTest.kt
@@ -38,11 +38,10 @@ class LocalAttachmentRepositoryTest {
 
     private val gliaException = GliaException("", GliaException.Cause.INTERNAL_ERROR)
 
-    private val fileAttachment1: LocalAttachment
-        get() = LocalAttachment(uri1, "image/jpeg", "attachment_1", 123)
-
-    private val fileAttachment2: LocalAttachment
-        get() = LocalAttachment(uri2, "application/pdf", "attachment_2", 321)
+    // Stable per-test instances: LocalAttachment now carries a unique generated id, so each test must
+    // reuse the same instance for value-equality assertions (attach/detach/contains) to hold.
+    private lateinit var fileAttachment1: LocalAttachment
+    private lateinit var fileAttachment2: LocalAttachment
 
     @Before
     fun setUp() {
@@ -53,6 +52,8 @@ class LocalAttachmentRepositoryTest {
         engagementFile = mockk(relaxUnitFun = true)
         uri1 = mockk(relaxUnitFun = true)
         uri2 = mockk(relaxUnitFun = true)
+        fileAttachment1 = LocalAttachment(uri1, "image/jpeg", "attachment_1", 123)
+        fileAttachment2 = LocalAttachment(uri2, "application/pdf", "attachment_2", 321)
         observer1 = mockk(relaxUnitFun = true)
         observer2 = mockk(relaxUnitFun = true)
 


### PR DESCRIPTION
## Why
Sending visitor file attachments could crash the chat: multiple image attachments collided on the same RecyclerView stable id, and the send failure/retry path indexed the chat list without a not-found check.

## Summary
- Give `LocalAttachment` a stable unique id assigned once at creation, instead of recomputing it (engagement file id or a fresh random UUID) on every access.
- In `ChatManager`, match local attachment items by their engagement file id and skip when no matching item is present, instead of indexing with an unchecked `indexOfLast` result.