### PR TITLE
Revert "Fix visitor attachment send crashes" (#1511)

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -298,11 +298,9 @@ internal class ChatManager(
         }
 
         files?.forEach { attachment ->
-            val index = chatItems.indexOfLast { (it as? LocalAttachmentItem)?.attachment?.engagementFile?.id == attachment.id }
+            val index = chatItems.indexOfLast { it.id == attachment.id }
 
-            if (index != -1) {
-                chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(false)
-            }
+            chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(false)
         }
     }
 
@@ -319,11 +317,9 @@ internal class ChatManager(
         }
 
         files.forEach { attachment ->
-            val index = chatItems.indexOfLast { (it as? LocalAttachmentItem)?.attachment?.engagementFile?.id == attachment.id }
+            val index = chatItems.indexOfLast { it.id == attachment.id }
 
-            if (index != -1) {
-                chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(true)
-            }
+            chatItems[index] = (chatItems[index] as VisitorChatItem).copyWithError(true)
         }
 
         val lastItemIndex = if (files.isNotEmpty()) {

--- a/widgetssdk/src/main/java/com/glia/widgets/internal/fileupload/model/LocalAttachment.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/internal/fileupload/model/LocalAttachment.kt
@@ -12,13 +12,14 @@ internal data class LocalAttachment(
     val size: Long,
     val attachmentStatus: Status = Status.UPLOADING,
     val engagementFile: EngagementFile? = null,
-    val id: String = UUID.randomUUID().toString(),
 ) {
 
     val isReadyToSend: Boolean
         get() = attachmentStatus == Status.READY_TO_SEND
     val isImage: Boolean
         get() = mimeType?.startsWith("image") ?: false
+    val id: String
+        get() = engagementFile?.id ?: UUID.randomUUID().toString()
 
     fun toVisitorAttachmentItem(messageId: String): VisitorAttachmentItem = if (isImage) {
         VisitorAttachmentItem.LocalImage(id, messageId, this)

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -3,8 +3,6 @@ package com.glia.widgets.chat
 import android.os.Looper
 import com.glia.androidsdk.GliaException
 import com.glia.androidsdk.chat.AttachmentFile
-import com.glia.androidsdk.engagement.EngagementFile
-import com.glia.widgets.internal.fileupload.model.LocalAttachment
 import com.glia.androidsdk.chat.ChatMessage
 import com.glia.androidsdk.chat.FilesAttachment
 import com.glia.androidsdk.chat.OperatorMessage
@@ -945,12 +943,10 @@ class ChatManagerTest {
             on { files } doReturn arrayOf(file)
         }
         val payload = SendMessagePayload(content = "", messageId = messageId, attachment = filesAttachment)
-        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
-        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
         val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "local_attachment_id",
+            id = "attachment_id",
             messageId = messageId,
-            attachment = localAttachment,
+            attachment = mock(),
             isError = true
         )
         state.messagePreviews[messageId] = payload
@@ -976,12 +972,10 @@ class ChatManagerTest {
         }
         val payload = SendMessagePayload(content = "message", messageId = messageId, attachment = filesAttachment)
         val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId, isError = true)
-        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
-        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
         val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "local_attachment_id",
+            id = "attachment_id",
             messageId = messageId,
-            attachment = localAttachment,
+            attachment = mock(),
             isError = true
         )
         state.messagePreviews[messageId] = payload
@@ -1023,13 +1017,7 @@ class ChatManagerTest {
             on { files } doReturn arrayOf(file)
         }
         val payload = SendMessagePayload(content = "", messageId = messageId, attachment = filesAttachment)
-        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
-        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
-        val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "local_attachment_id",
-            messageId = messageId,
-            attachment = localAttachment
-        )
+        val attachmentItem = VisitorAttachmentItem.LocalFile(id = "attachment_id", messageId = messageId, attachment = mock())
         state.messagePreviews[messageId] = payload
         state.chatItems.add(attachmentItem)
 
@@ -1052,13 +1040,7 @@ class ChatManagerTest {
         }
         val payload = SendMessagePayload(content = "message", messageId = messageId, attachment = filesAttachment)
         val visitorChatItem = VisitorMessageItem(payload.content, payload.messageId)
-        val engagementFileMock: EngagementFile = mock { on { id } doReturn "attachment_id" }
-        val localAttachment: LocalAttachment = mock { on { engagementFile } doReturn engagementFileMock }
-        val attachmentItem = VisitorAttachmentItem.LocalFile(
-            id = "local_attachment_id",
-            messageId = messageId,
-            attachment = localAttachment
-        )
+        val attachmentItem = VisitorAttachmentItem.LocalFile(id = "attachment_id", messageId = messageId, attachment = mock())
         state.messagePreviews[messageId] = payload
         state.chatItems.add(visitorChatItem)
         state.chatItems.add(attachmentItem)

--- a/widgetssdk/src/test/java/com/glia/widgets/internal/fileupload/FileAttachmentRepositoryTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/internal/fileupload/FileAttachmentRepositoryTest.kt
@@ -38,10 +38,11 @@ class LocalAttachmentRepositoryTest {
 
     private val gliaException = GliaException("", GliaException.Cause.INTERNAL_ERROR)
 
-    // Stable per-test instances: LocalAttachment now carries a unique generated id, so each test must
-    // reuse the same instance for value-equality assertions (attach/detach/contains) to hold.
-    private lateinit var fileAttachment1: LocalAttachment
-    private lateinit var fileAttachment2: LocalAttachment
+    private val fileAttachment1: LocalAttachment
+        get() = LocalAttachment(uri1, "image/jpeg", "attachment_1", 123)
+
+    private val fileAttachment2: LocalAttachment
+        get() = LocalAttachment(uri2, "application/pdf", "attachment_2", 321)
 
     @Before
     fun setUp() {
@@ -52,8 +53,6 @@ class LocalAttachmentRepositoryTest {
         engagementFile = mockk(relaxUnitFun = true)
         uri1 = mockk(relaxUnitFun = true)
         uri2 = mockk(relaxUnitFun = true)
-        fileAttachment1 = LocalAttachment(uri1, "image/jpeg", "attachment_1", 123)
-        fileAttachment2 = LocalAttachment(uri2, "application/pdf", "attachment_2", 321)
         observer1 = mockk(relaxUnitFun = true)
         observer2 = mockk(relaxUnitFun = true)
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**

Reverts PR #1511 ("Fix visitor attachment send crashes") on `development`. The two commits introduced by that PR are reverted here:

- Revert "Guard chat item lookup when marking attachment send state" (`ee9ec47f`)
- Revert "Give LocalAttachment a stable unique id" (`b4c23afb`)

**Additional info:**

 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

