### PR TITLE
Replace visitor message text with server-echoed content

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/ChatManager.kt
@@ -245,6 +245,10 @@ internal class ChatManager(
                 }
                 put(EventAttribute.MessageType, messageType)
             }
+        } else {
+            // The message was already reconciled through the send-success callback, which carries
+            // no content - the echo is still the source of truth for the displayed text.
+            appendNewChatMessageUseCase.updateVisitorMessageContent(chatMessage, messagesState)
         }
 
         return messagesState

--- a/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/chat/domain/AppendNewChatItemUseCase.kt
@@ -51,6 +51,16 @@ internal class AppendNewChatMessageUseCase(
     }
 
     /**
+     * Applies the server-echoed content of an already reconciled visitor message to its chat item.
+     * Used when the send-success callback (which carries no content) reconciled the message before
+     * the echo arrived through the incoming message stream.
+     */
+    fun updateVisitorMessageContent(chatMessageInternal: ChatMessageInternal, state: ChatManager.State) {
+        val message = chatMessageInternal.chatMessage as? VisitorMessage ?: return
+        appendNewVisitorMessageUseCase.updateMessageContent(state, message)
+    }
+
+    /**
      * Marks the optimistically rendered visitor message with [messageId] as delivered once the
      * send API reports success. Does nothing when the message was already reconciled through the
      * incoming message stream (its preview is gone by then).
@@ -172,11 +182,25 @@ internal class AppendNewVisitorMessageUseCase(private val mapVisitorAttachmentUs
 
         if (state.messagePreviews.remove(message.id) != null) {
             state.preEngagementChatItemIds.remove(message.id)
+            updateMessageContent(state, message)
             markMessageDelivered(state, message.id)
             return
         }
 
         addNewMessage(state, message)
+    }
+
+    /**
+     * Replaces the optimistically rendered text with the server-echoed [VisitorMessage.getContent],
+     * which is authoritative (the server may transform the submitted text).
+     */
+    fun updateMessageContent(state: ChatManager.State, message: VisitorMessage) {
+        val content = message.content.takeIf { it.isNotBlank() } ?: return
+        val index = state.chatItems.indexOfLast { it.id == message.id }.takeIf { it != -1 } ?: return
+        val item = state.chatItems[index] as? VisitorMessageItem ?: return
+        if (item.message == content) return
+
+        state.chatItems[index] = item.copy(message = content)
     }
 
     private fun markLastDeliveredItemAsDelivered(state: ChatManager.State) {

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/ChatManagerTest.kt
@@ -611,6 +611,19 @@ class ChatManagerTest {
     }
 
     @Test
+    fun `mapNewMessage updates visitor message content when message is not new`() {
+        val chatMessageInternal = mockChatMessage<VisitorMessage>()
+        val messageId = chatMessageInternal.chatMessage.id
+        val stateSpy = spy(state)
+        doReturn(false).whenever(stateSpy).isNew(messageId)
+
+        subjectUnderTest.mapNewMessage(chatMessageInternal, stateSpy)
+
+        verify(appendNewChatMessageUseCase, never()).invoke(any(), any())
+        verify(appendNewChatMessageUseCase).updateVisitorMessageContent(chatMessageInternal, stateSpy)
+    }
+
+    @Test
     fun `mapNewMessage calls appendNewChatMessageUseCase when message is new`() {
         val chatMessageInternal = mockChatMessage<OperatorMessage>()
         val messageId = chatMessageInternal.chatMessage.id

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewChatMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewChatMessageUseCaseTest.kt
@@ -85,6 +85,24 @@ class AppendNewChatMessageUseCaseTest {
     }
 
     @Test
+    fun `updateVisitorMessageContent delegates to appendNewVisitorMessageUseCase when message is Visitor message`() {
+        mockCHatMessage<VisitorMessage>()
+
+        useCase.updateVisitorMessageContent(chatMessageInternal, state)
+
+        verify(appendNewVisitorMessageUseCase).updateMessageContent(state, chatMessage as VisitorMessage)
+    }
+
+    @Test
+    fun `updateVisitorMessageContent does nothing when message is not Visitor message`() {
+        mockCHatMessage<OperatorMessage>()
+
+        useCase.updateVisitorMessageContent(chatMessageInternal, state)
+
+        verify(appendNewVisitorMessageUseCase, never()).updateMessageContent(any(), any())
+    }
+
+    @Test
     fun `markMessageDelivered marks message delivered and resets operator when preview exists`() {
         val realState = spy(ChatManager.State())
         val payload = OutgoingMessage.Text("message")

--- a/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/chat/domain/AppendNewVisitorMessageUseCaseTest.kt
@@ -185,6 +185,65 @@ class AppendNewVisitorMessageUseCaseTest {
     }
 
     @Test
+    fun `invoke replaces optimistic text with echoed content when message is in previews`() {
+        val messageId = "1"
+        state.messagePreviews[messageId] = OutgoingMessage.Text("local content", messageId)
+        state.chatItems += VisitorMessageItem("local content", messageId, isError = false, timestamp = 1)
+
+        whenever(visitorMessage.content) doReturn "server content"
+        whenever(visitorMessage.timestamp) doReturn 1L
+        whenever(visitorMessage.id) doReturn messageId
+
+        useCase(state, chatMessageInternal)
+
+        val messageItem = state.chatItems.first() as VisitorMessageItem
+        assertEquals("server content", messageItem.message)
+        assertTrue(state.chatItems[1] is DeliveredItem)
+        assertTrue(state.messagePreviews.isEmpty())
+    }
+
+    @Test
+    fun `updateMessageContent replaces the text of the matching message item`() {
+        val messageId = "1"
+        state.chatItems += VisitorMessageItem("local content", messageId, isError = false, timestamp = 1)
+
+        whenever(visitorMessage.content) doReturn "server content"
+        whenever(visitorMessage.id) doReturn messageId
+
+        useCase.updateMessageContent(state, visitorMessage)
+
+        val messageItem = state.chatItems.first() as VisitorMessageItem
+        assertEquals("server content", messageItem.message)
+    }
+
+    @Test
+    fun `updateMessageContent does nothing when echoed content is blank`() {
+        val messageId = "1"
+        val messageItem = VisitorMessageItem("local content", messageId, isError = false, timestamp = 1)
+        state.chatItems += messageItem
+
+        whenever(visitorMessage.content) doReturn " "
+        whenever(visitorMessage.id) doReturn messageId
+
+        useCase.updateMessageContent(state, visitorMessage)
+
+        assertEquals(messageItem, state.chatItems.first())
+    }
+
+    @Test
+    fun `updateMessageContent does nothing when no item matches the message id`() {
+        val messageItem = VisitorMessageItem("local content", "1", isError = false, timestamp = 1)
+        state.chatItems += messageItem
+
+        whenever(visitorMessage.content) doReturn "server content"
+        whenever(visitorMessage.id) doReturn "2"
+
+        useCase.updateMessageContent(state, visitorMessage)
+
+        assertEquals(messageItem, state.chatItems.first())
+    }
+
+    @Test
     fun `markMessageDelivered clears error and adds DeliveredItem after the message item`() {
         val messageId = "1"
         state.chatItems += VisitorMessageItem("content", messageId, isError = true, timestamp = 1)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5436

**What was solved?**

Visitor text messages are rendered optimistically with the locally typed content, and the server echo arriving through the `CHAT_MESSAGE` socket stream was only used to mark the item as delivered — the displayed text always stayed local. The server may transform the submitted text, so the echoed content is authoritative and now replaces the optimistic `VisitorMessageItem` text when the echo arrives.

Both reconciliation orderings are covered:
- **Echo first** — `AppendNewVisitorMessageUseCase` updates the item's text before marking it delivered.
- **Send-success first** — the echo was previously dropped entirely by the `isNew` de-duplication in `ChatManager.mapNewMessage`; it is now routed to a content update on the already-delivered item.

No-op for blank echo content (file attachment echoes), unknown message ids, non-text items, and unchanged content.

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**

N/A — no visual change; only the text data flowing into existing item types.