### PR TITLE
Read version from properties file in increment-version workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -37,7 +37,9 @@ workflows:
                 # debug log
                 set -x
 
-                NEW_VERSION=`./gradlew -q printCurrentVersionName`
+                # Read the version straight from the properties file - Gradle output
+                # is polluted by the Bitrise Gradle Mirrors init script log lines
+                NEW_VERSION=$(grep '^widgets.versionName=' version.properties | cut -d= -f2)
                 NEW_BRANCH_NAME="project-version-increment/${NEW_VERSION}"
                 BASE_BRANCH_NAME="development"
                 MESSAGE="Increment project version to ${NEW_VERSION}"


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5436

**What was solved?**

The "Increment project version" Bitrise workflow (`_increment_project_version`) was failing: the Bitrise Gradle Mirrors init script (bitrise-build-cache CLI) pollutes stdout of every Gradle invocation, so `./gradlew -q printCurrentVersionName` returned the mirror log lines along with the version. This produced an invalid branch name in the Create PR step and failed the build with `fatal: 'project-version-increment/[Bitrise' is not a valid branch name`.

Now the version is read directly from `version.properties` — the same file the workflow updates and commits — making the step immune to any Gradle stdout noise. Same fix as salemove/android-sdk#1073.

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests — CI-only change, no SDK code touched; extraction verified locally against `version.properties`
 - [x] Did you add logging beneficial for troubleshooting of customer issues? — N/A, CI workflow change
 - [x] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information. — N/A

**Screenshots:**

N/A