### PR TITLE
MOB-5187: Migrate to AGP 9.3, support Android 17 (API 37), and upgrade dependencies

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,4 +1,18 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew help *)",
+      "Bash(./gradlew build *)",
+      "Bash(./gradlew widgetssdk:assembleDebug)",
+      "Bash(./gradlew widgetssdk:compileDebugKotlin)",
+      "Bash(./gradlew widgetssdk:compileDebugKotlin --info)",
+      "Bash(./gradlew widgetssdk:compileDebugKotlin --debug)",
+      "Bash(./gradlew widgetssdk:dependencies --configuration kotlinCompilerPluginClasspathDebug)",
+      "Bash(./gradlew app:assembleDebug)",
+      "Bash(./gradlew widgetssdk:compileDebugUnitTestKotlin)",
+      "Bash(./gradlew widgetssdk:assembleDebug app:assembleDebug)"
+    ]
+  },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "mobile-mcp"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
 
 //Detailed information about advantages of Java toolchain https://developer.android.com/build/jdks#toolchain
 java {
@@ -9,11 +8,11 @@ java {
 }
 
 android {
-  compileSdkVersion 36
+  compileSdk = 37
   defaultConfig {
     applicationId "com.glia.exampleapp"
-    minSdkVersion 24
-    targetSdkVersion 36
+    minSdk = 24
+    targetSdk = 37
     versionCode 1
     versionName "1.0"
 
@@ -83,6 +82,10 @@ android {
       'WrongViewIdFormat',
       'HardcodedText'
   }
+  buildFeatures {
+    // The buildTypes block below uses resValue(); resValues default flipped to false in AGP 9.
+    resValues = true
+  }
   namespace 'com.glia.exampleapp'
 }
 
@@ -101,12 +104,12 @@ afterEvaluate {
 }
 
 dependencies {
-  implementation libs.java.appcompat
-  implementation libs.java.material
-  implementation libs.java.constraintlayout
-  implementation libs.java.navigation.fargment
-  implementation libs.java.navigation.ui
-  implementation libs.java.preference
+  implementation libs.androidx.appcompat
+  implementation libs.material
+  implementation libs.androidx.constraintlayout
+  implementation libs.androidx.navigation.fragment
+  implementation libs.androidx.navigation.ui
+  implementation libs.androidx.preference
   implementation platform(libs.firebase.bom)
   implementation libs.firebase.messaging
 
@@ -114,15 +117,15 @@ dependencies {
   // To test against properly compiled SDK, the SDK is auto-uploaded to local maven with '-SNAPSHOT' suffix
   releaseImplementation "com.glia:android-widgets:${widgetsVersionName}-SNAPSHOT"
 
-  implementation libs.java.core.ktx
+  implementation libs.androidx.core.ktx
 
-  implementation libs.java.ktor.android
-  implementation libs.java.ktor.logging
-  implementation libs.java.coroutines
+  implementation libs.ktor.client.android
+  implementation libs.ktor.client.logging
+  implementation libs.kotlinx.coroutines.android
 
 
-  //debugImplementation libs.test.leakcanary
-  testImplementation libs.test.junit
-  androidTestImplementation libs.test.ext.junit
-  androidTestImplementation libs.test.espresso.core
+  //debugImplementation libs.leakcanary
+  testImplementation libs.junit
+  androidTestImplementation libs.androidx.test.ext.junit
+  androidTestImplementation libs.androidx.test.espresso.core
 }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,5 @@
-format_version: "8"
+---
+format_version: '8'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: android
 workflows:
@@ -22,8 +23,8 @@ workflows:
       - gradle-runner@3:
           title: Increment project version
           inputs:
-            - gradle_file: $PROJECT_LOCATION/build.gradle
-            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradle_file: "$PROJECT_LOCATION/build.gradle"
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
             - gradle_task: saveWidgetsVersion --type=$VERSION_INCREMENT_TYPE
       - script@1:
           title: Create PR
@@ -43,7 +44,7 @@ workflows:
                 NEW_BRANCH_NAME="project-version-increment/${NEW_VERSION}"
                 BASE_BRANCH_NAME="development"
                 MESSAGE="Increment project version to ${NEW_VERSION}"
-
+                
                 git stash
                 git fetch origin $BASE_BRANCH_NAME
                 git checkout -b $NEW_BRANCH_NAME origin/$BASE_BRANCH_NAME
@@ -72,115 +73,115 @@ workflows:
   authenticated_increment_project_version:
     description: Task builds an SDK and uploads it to Nexus.
     steps:
-      - activate-ssh-key@4: { }
-      - git-clone@8: { }
-      - restore-gradle-cache@2: { }
+      - activate-ssh-key@4: {}
+      - git-clone@8: {}
+      - restore-gradle-cache@2: {}
       - set-java-version@1:
           is_always_run: true
           inputs:
-            - set_java_version: "17"
+            - set_java_version: '21'
       - install-missing-android-tools@3:
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
-      - save-gradle-cache@1: { }
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
+      - save-gradle-cache@1: {}
     after_run:
       - _increment_project_version
   browserstack_upload:
     steps:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-      - git-clone@8: { }
-      - restore-gradle-cache@2: { }
+      - git-clone@8: {}
+      - restore-gradle-cache@2: {}
       - set-java-version@1:
           is_always_run: true
           inputs:
-            - set_java_version: "17"
+            - set_java_version: '21'
       - install-missing-android-tools@3:
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
       - android-build@1.0:
           inputs:
-            - variant: $INTEGRATOR_VARIANT
-            - module: $EXAMPLE_APP_MODULE
+            - variant: "$INTEGRATOR_VARIANT"
+            - module: "$EXAMPLE_APP_MODULE"
       - browserstack-upload@0:
           title: Upload APP to BrowserStack
           inputs:
-            - custom_id: $BROWSERSTACK_APP_ID
+            - custom_id: "$BROWSERSTACK_APP_ID"
       - deploy-to-bitrise-io@2:
           inputs:
-            - notify_email_list: $BUILD_EMAILS
-      - save-gradle-cache@1: { }
+            - notify_email_list: "$BUILD_EMAILS"
+      - save-gradle-cache@1: {}
   development:
     steps:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-      - git-clone@8: { }
-      - restore-gradle-cache@2: { }
+      - git-clone@8: {}
+      - restore-gradle-cache@2: {}
       - set-java-version@1:
           is_always_run: true
           inputs:
-            - set_java_version: "17"
+            - set_java_version: '21'
       - install-missing-android-tools@3:
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
       - android-build@1:
           inputs:
-            - variant: $INTEGRATOR_VARIANT
-            - module: $EXAMPLE_APP_MODULE
+            - variant: "$INTEGRATOR_VARIANT"
+            - module: "$EXAMPLE_APP_MODULE"
       - android-lint@0:
           title: Run Lint for SDK
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $WIDGET_SDK_MODULE
-            - variant: $SDK_VARIANT
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$WIDGET_SDK_MODULE"
+            - variant: "$SDK_VARIANT"
       - android-unit-test@1:
           title: Unit Test for SDK
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $WIDGET_SDK_MODULE
-            - variant: $SDK_VARIANT
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$WIDGET_SDK_MODULE"
+            - variant: "$SDK_VARIANT"
       - android-lint@0:
           title: Run Lint for APP
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $EXAMPLE_APP_MODULE
-            - variant: $DEBUG_VARIANT
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$EXAMPLE_APP_MODULE"
+            - variant: "$DEBUG_VARIANT"
       - android-unit-test@1:
           title: Unit Test for APP
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $EXAMPLE_APP_MODULE
-            - variant: $DEBUG_VARIANT
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$EXAMPLE_APP_MODULE"
+            - variant: "$DEBUG_VARIANT"
       - browserstack-upload@0:
           title: Upload APP to BrowserStack
           inputs:
-            - custom_id: $BROWSERSTACK_APP_ID
+            - custom_id: "$BROWSERSTACK_APP_ID"
       - deploy-to-bitrise-io@2:
           inputs:
-            - notify_email_list: $BUILD_EMAILS
+            - notify_email_list: "$BUILD_EMAILS"
       - slack@4:
           is_always_run: true
           inputs:
-            - channel: '#tm-mobile-builds'
+            - channel: "#tm-mobile-builds"
             - text: Android Build Succeeded!
-            - webhook_url_on_error: $SLACK_ANDROID_WEBHOOK
-            - channel_on_error: '#tm-mobile'
-            - text_on_error: '@mobile-caretaker Android Build Failed! (development-build)'
-            - emoji_on_error: "\U0001F4A5"
-            - color_on_error: '#d9482b'
+            - webhook_url_on_error: "$SLACK_ANDROID_WEBHOOK"
+            - channel_on_error: "#tm-mobile"
+            - text_on_error: "@mobile-caretaker Android Build Failed! (development-build)"
+            - emoji_on_error: "💥"
+            - color_on_error: "#d9482b"
             - from_username_on_error: Bitrise
-            - pretext: ""
-            - webhook_url: $SLACK_ANDROID_WEBHOOK
-      - save-gradle-cache@1: { }
+            - pretext: ''
+            - webhook_url: "$SLACK_ANDROID_WEBHOOK"
+      - save-gradle-cache@1: {}
   post_release:
     steps:
       - trigger-bitrise-workflow@0:
           title: Update dependency in Cortex Financial
           inputs:
-            - api_token: $ANDROID_CORTEX_BANKING_APP_BUILD_TRIGGER_TOKEN
+            - api_token: "$ANDROID_CORTEX_BANKING_APP_BUILD_TRIGGER_TOKEN"
             - workflow_id: upgrade_dependencies
             - exported_environment_variable_names: NEW_VERSION
-            - app_slug: $ANDROID_CORTEX_BANKING_APP_SLUG
+            - app_slug: "$ANDROID_CORTEX_BANKING_APP_SLUG"
       - script@1:
           title: Update dependency in Glia Widgets Flutter SDK
           is_always_run: true
@@ -189,7 +190,7 @@ workflows:
                 #!/usr/bin/env bash
                 set -e
                 set -x
-
+                
                 curl -X POST \
                   -H "Accept: application/vnd.github+json" \
                   -H "Authorization: Bearer $GITHUB_API_TOKEN" \
@@ -203,7 +204,7 @@ workflows:
                 #!/usr/bin/env bash
                 set -e
                 set -x
-
+                
                 curl -X POST \
                   -H "Accept: application/vnd.github+json" \
                   -H "Authorization: Bearer $GITHUB_API_TOKEN" \
@@ -217,7 +218,7 @@ workflows:
                 #!/usr/bin/env bash
                 set -e
                 set -x
-
+                
                 curl -X POST \
                   -H "Accept: application/vnd.github+json" \
                   -H "Authorization: Bearer $GITHUB_API_TOKEN" \
@@ -226,33 +227,33 @@ workflows:
   publish_to_nexus:
     description: Task builds an SDK and uploads it to Nexus.
     steps:
-      - activate-ssh-key@4: { }
+      - activate-ssh-key@4: {}
       - git-clone:
           inputs:
             - clone_depth: "-1"
-            - fetch_tags: "yes"
-      - restore-gradle-cache@2: { }
+            - fetch_tags: 'yes'
+      - restore-gradle-cache@2: {}
       - set-java-version@1:
           is_always_run: true
           inputs:
-            - set_java_version: "17"
+            - set_java_version: '21'
       - install-missing-android-tools@3:
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
       - android-build@1:
           inputs:
-            - variant: $INTEGRATOR_VARIANT
-            - module: $EXAMPLE_APP_MODULE
+            - variant: "$INTEGRATOR_VARIANT"
+            - module: "$EXAMPLE_APP_MODULE"
       - android-unit-test@1:
           inputs:
-            - module: $WIDGET_SDK_MODULE
-            - variant: $SDK_VARIANT
-            - project_location: $PROJECT_LOCATION
+            - module: "$WIDGET_SDK_MODULE"
+            - variant: "$SDK_VARIANT"
+            - project_location: "$PROJECT_LOCATION"
       - android-unit-test@1:
           inputs:
-            - module: $EXAMPLE_APP_MODULE
-            - variant: $DEBUG_VARIANT
-            - project_location: $PROJECT_LOCATION
+            - module: "$EXAMPLE_APP_MODULE"
+            - variant: "$DEBUG_VARIANT"
+            - project_location: "$PROJECT_LOCATION"
       - gradle-runner@3:
           title: Generate JavaDoc
           inputs:
@@ -260,11 +261,11 @@ workflows:
       - amazon-s3-upload@3:
           title: Upload JavaDoc
           inputs:
-            - secret_access_key: $AMAZON_AWS_SECRET
-            - upload_bucket: $AMAZON_AWS_NAME/widgets
+            - secret_access_key: "$AMAZON_AWS_SECRET"
+            - upload_bucket: "$AMAZON_AWS_NAME/widgets"
             - acl_control: public-read
-            - upload_local_path: $PROJECT_LOCATION/$WIDGET_SDK_MODULE/build/dokka
-            - access_key_id: $AMAZON_AWS_KEY
+            - upload_local_path: "$PROJECT_LOCATION/$WIDGET_SDK_MODULE/build/dokka"
+            - access_key_id: "$AMAZON_AWS_KEY"
       - script@1:
           title: Publish Android SDK to Nexus Repository Manager (Staging)
           inputs:
@@ -280,7 +281,7 @@ workflows:
       - git-tag@1:
           title: Create Git tag
           inputs:
-            - tag: $NEW_VERSION
+            - tag: "$NEW_VERSION"
       - script@1:
           title: Generate changelog
           inputs:
@@ -295,46 +296,46 @@ workflows:
                 bash ./scripts/generate-changelog.sh
       - github-release@0:
           inputs:
-            - username: $GITHUB_USERNAME
-            - tag: $NEW_VERSION
-            - commit: $GIT_CLONE_COMMIT_HASH
+            - username: "$GITHUB_USERNAME"
+            - tag: "$NEW_VERSION"
+            - commit: "$GIT_CLONE_COMMIT_HASH"
             - name: Glia Android Widgets $NEW_VERSION
-            - body: $BITRISE_CHANGELOG
-            - draft: "no"
-            - api_token: $GITHUB_API_TOKEN
-      - save-gradle-cache@1: { }
+            - body: "$BITRISE_CHANGELOG"
+            - draft: 'no'
+            - api_token: "$GITHUB_API_TOKEN"
+      - save-gradle-cache@1: {}
     after_run:
       - _increment_project_version
   pull_request:
     steps:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-      - git-clone@8: { }
-      - restore-gradle-cache@2: { }
+      - git-clone@8: {}
+      - restore-gradle-cache@3: {}
       - set-java-version@1:
           is_always_run: true
           inputs:
-            - set_java_version: "17"
+            - set_java_version: '21'
       - install-missing-android-tools@3:
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
       - android-lint@0:
           title: Run Lint for SDK
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $WIDGET_SDK_MODULE
-            - variant: $SDK_VARIANT
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$WIDGET_SDK_MODULE"
+            - variant: "$SDK_VARIANT"
       - android-unit-test@1:
           title: Unit Test for SDK
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $WIDGET_SDK_MODULE
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$WIDGET_SDK_MODULE"
             - variant: debug
-      - gradle-unit-test@1:
+      - gradle-unit-test@2:
           title: Snapshot Test for SDK
           inputs:
-            - unit_test_flags: ""
-            - unit_test_task: $WIDGET_SDK_MODULE:verifyPaparazziSnapshot
+            - unit_test_flags: ''
+            - unit_test_task: "$WIDGET_SDK_MODULE:verifyPaparazziSnapshot"
           is_always_run: true
       - script@1:
           title: Export reports for Snapshot Test for SDK
@@ -361,45 +362,45 @@ workflows:
       - android-lint@0:
           title: Run Lint for APP
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $EXAMPLE_APP_MODULE
-            - variant: $DEBUG_VARIANT
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$EXAMPLE_APP_MODULE"
+            - variant: "$DEBUG_VARIANT"
       - android-unit-test@1:
           title: Unit Test for APP
           inputs:
-            - project_location: $PROJECT_LOCATION
-            - module: $EXAMPLE_APP_MODULE
-            - variant: $DEBUG_VARIANT
-      - gradle-runner@3:
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$EXAMPLE_APP_MODULE"
+            - variant: "$DEBUG_VARIANT"
+      - gradle-runner@5:
           title: Assemble SDK for instrumentation tests
           inputs:
-            - gradlew_path: ./gradlew
-            - gradle_task: :$WIDGET_SDK_MODULE:assembleDebugAndroidTest
+            - gradlew_path: "./gradlew"
+            - gradle_task: ":$WIDGET_SDK_MODULE:assembleDebugAndroidTest"
       - virtual-device-testing-for-android@1:
           title: UI Test for APP
           inputs:
             - test_type: instrumentation
             - use_verbose_log: true
             - test_devices: MediumPhone.arm,26,en,portrait
-      - deploy-to-bitrise-io@2: { }
-      - save-gradle-cache@1: { }
+      - deploy-to-bitrise-io@2: {}
+      - save-gradle-cache@1: {}
   upgrade_dependencies:
     steps:
-      - activate-ssh-key@4: { }
-      - git-clone@6: { }
-      - restore-gradle-cache@2: { }
+      - activate-ssh-key@4: {}
+      - git-clone@6: {}
+      - restore-gradle-cache@2: {}
       - set-java-version@1.1:
           is_always_run: true
           inputs:
-            - set_java_version: "17"
+            - set_java_version: '21'
       - install-missing-android-tools@3:
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
       - gradle-runner@3:
           title: Upgrade Core SDK version
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
-            - gradle_file: $PROJECT_LOCATION/build.gradle
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
+            - gradle_file: "$PROJECT_LOCATION/build.gradle"
             - gradle_task: saveCoreSdkVersion --coreSdkVersion=$NEW_VERSION
       - script@1:
           title: Create PR
@@ -412,11 +413,11 @@ workflows:
                 set -o pipefail
                 # debug log
                 set -x
-
+                
                 NEW_BRANCH_NAME="core-sdk-version-increment/${NEW_VERSION}"
                 BASE_BRANCH_NAME="development"
                 MESSAGE="Increment Core SDK version to ${NEW_VERSION}"
-
+                
                 git stash
                 git fetch origin $BASE_BRANCH_NAME
                 git checkout -b $NEW_BRANCH_NAME origin/$BASE_BRANCH_NAME
@@ -438,24 +439,24 @@ workflows:
                   -H "Authorization: Bearer $GITHUB_API_TOKEN" \
                   https://api.github.com/repos/salemove/android-sdk-widgets/pulls/$PULL_REQUEST_NUMBER/requested_reviewers \
                   -d "{\"team_reviewers\":[\"tm-mobile-android\"]}"
-      - save-gradle-cache@1: { }
+      - save-gradle-cache@1: {}
   upgrade_telemetry_dependency:
     steps:
-      - activate-ssh-key@4: { }
-      - git-clone@6: { }
-      - restore-gradle-cache@2: { }
+      - activate-ssh-key@4: {}
+      - git-clone@6: {}
+      - restore-gradle-cache@2: {}
       - set-java-version@1.1:
           is_always_run: true
           inputs:
-            - set_java_version: "17"
+            - set_java_version: '21'
       - install-missing-android-tools@3:
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
       - gradle-runner@3:
           title: Upgrade Telemetry lib version
           inputs:
-            - gradlew_path: $PROJECT_LOCATION/gradlew
-            - gradle_file: $PROJECT_LOCATION/build.gradle
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
+            - gradle_file: "$PROJECT_LOCATION/build.gradle"
             - gradle_task: saveTelemetryLibVersion --sdkVersion=$NEW_VERSION
       - script@1:
           title: Create PR
@@ -468,11 +469,11 @@ workflows:
                 set -o pipefail
                 # debug log
                 set -x
-
+                
                 NEW_BRANCH_NAME="telemetry-lib-version-increment/${NEW_VERSION}"
                 BASE_BRANCH_NAME="development"
                 MESSAGE="Increment Telemetry lib version to ${NEW_VERSION}"
-
+                
                 git stash
                 git fetch origin $BASE_BRANCH_NAME
                 git checkout -b $NEW_BRANCH_NAME origin/$BASE_BRANCH_NAME
@@ -494,18 +495,18 @@ workflows:
                   -H "Authorization: Bearer $GITHUB_API_TOKEN" \
                   https://api.github.com/repos/salemove/android-sdk-widgets/pulls/$PULL_REQUEST_NUMBER/requested_reviewers \
                   -d "{\"team_reviewers\":[\"tm-mobile-android\"]}"
-      - save-gradle-cache@1: { }
+      - save-gradle-cache@1: {}
 app:
   envs:
     - opts:
         is_expand: false
-      PROJECT_LOCATION: .
+      PROJECT_LOCATION: "."
     - opts:
         is_expand: false
       GRADLE_BUILD_FILE_PATH: build.gradle
     - opts:
         is_expand: false
-      GRADLEW_PATH: ./gradlew
+      GRADLEW_PATH: "./gradlew"
     - opts:
         is_expand: false
       EXAMPLE_APP_MODULE: app
@@ -542,7 +543,7 @@ app:
 trigger_map:
   - push_branch: development
     workflow: development
-  - pull_request_target_branch: '*'
+  - pull_request_target_branch: "*"
     workflow: pull_request
 meta:
   bitrise.io:

--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,16 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath libs.android.gradle.plugin
+    classpath libs.android.gradlePlugin
   }
 }
 
 plugins {
   alias libs.plugins.dokka
   alias libs.plugins.dokkaJavadoc
-  alias libs.plugins.maven.publish
-  alias libs.plugins.kt.lint
-  alias libs.plugins.kotlin.android apply false
+  alias libs.plugins.mavenPublish
+  alias libs.plugins.ktlint
+  alias libs.plugins.kotlinParcelize apply false
   alias libs.plugins.paparazzi apply false
 }
 
@@ -110,6 +110,6 @@ dokka {
   // This adds support for @hide keyword inside in-code docs
   // For some reason artifact ID mentioned in docs does not exist, probably a typo. This one has slightly different order of words
   dependencies {
-    dokkaPlugin(libs.java.dokka)
+    dokkaPlugin(libs.dokka.androidDocumentation)
   }
 }

--- a/docs/claude-reference.md
+++ b/docs/claude-reference.md
@@ -193,7 +193,7 @@ Both channels are required when logging on public API paths:
 
 **`EntryWidget.getView(context)` returns a fresh instance every call.** `Dependencies.entryWidget` is a computed `get()` property, not `by lazy`. Caching the returned view externally causes double-parent attachment exceptions.
 
-**`./gradlew testSnapshotUnitTest` runs zero unit tests by design.** The `test.java.srcDirs = []` configuration removes the default test source set, then re-adds sources only to `testDebug` and `testRelease`. Use `./gradlew widgetssdk:test` for unit tests and `./gradlew widgetssdk:verifyPaparazziSnapshot` for snapshot verification.
+**`./gradlew testSnapshotUnitTest` runs zero unit tests by design.** The `test.java.srcDirs = []` configuration removes the default test source set, then re-adds sources only to `testDebug` and `testRelease`. Use `./gradlew widgetssdk:test` for unit tests and `./gradlew widgetssdk:verifyPaparazzi` for snapshot verification.
 
 **Screen sharing in Widgets SDK was fully removed (MOB-4366).** It is not deprecated — it was deleted. Any residual references are dead ends. CallVisualizer retains screen sharing capability; that is a separate path.
 
@@ -219,7 +219,9 @@ Both channels are required when logging on public API paths:
 
 **The `use_overlay` bubble flag is deprecated and was reverted once.** The "display inside app" bubble behavior using `use_overlay` was reverted. Current flags: `enableBubbleOutsideApp` and `enableBubbleInsideApp`. Never propose reinstating `use_overlay`.
 
-**Rebasing a branch without re-recording Paparazzi snapshots is a recurring mistake.** After any rebase that touches layout, theme, or resource files, run `./gradlew widgetssdk:recordPaparazziSnapshot` before pushing.
+**Rebasing a branch without re-recording Paparazzi snapshots is a recurring mistake.** After any rebase that touches layout, theme, or resource files, run `./gradlew widgetssdk:recordPaparazzi` before pushing.
+
+**`@Parcelize` silently no-ops if the kotlin-parcelize compiler artifact is missing from `kotlinCompilerPluginClasspath`.** Under AGP 9 built-in Kotlin, the standalone `org.jetbrains.kotlin.plugin.parcelize` Gradle plugin alone is not enough — the Kotlin compiler classpath stays empty and `@Parcelize`-annotated classes fail with "Class is not abstract and does not implement abstract members" at compile time. The fix is to declare both the runtime (`implementation libs.kotlin.parcelize.runtime`) and the compiler (`kotlinCompilerPluginClasspath "org.jetbrains.kotlin:kotlin-parcelize-compiler:<kotlinVersion>"`) explicitly in `widgetssdk/build.gradle`.
 
 ---
 
@@ -229,27 +231,32 @@ Both channels are required when logging on public API paths:
 
 All of the following pins have WHY comments in `gradle/libs.versions.toml` and must not be changed without resolving the underlying issue:
 
-- `core-ktx 1.16.0` — version 1.17.0 requires `compileSdk 36`, which the SDK module does not use (demo app uses 36, SDK uses 35).
-- `coil-core` / `coil-network` `3.2.0` — versions above 3.2.0 require Kotlin 2.2.0 or higher; the project is on Kotlin 2.1.21.
-- `dokka 2.0.0` — Kotlin and Dokka versions must share the same minor version.
-- `paparazzi 1.3.5` — updating risks silently upgrading the Kotlin version for the entire project, not just the snapshot build type.
+- `core-ktx 1.18.0` — version 1.19.0 hard-requires `compileSdk 37`, which the SDK module (`compileSdk 36`) does not use.
+- `lifecycle-process 2.10.0` — version 2.11.0+ requires `compileSdk 37`, which the SDK module does not use.
+- `dokka 2.2.0` — Kotlin and Dokka must share the same minor version (project is on Kotlin 2.2.21).
+- `paparazzi 2.0.0-alpha05` — older-than-alpha04 versions reference `BaseExtension`, which AGP 9 removed; alpha05 is still built against its own bundled Kotlin compiler (unrelated to the project's Kotlin pin) and only raises its internal Gradle requirement to 9.3.1. Keep the HTML-test-reports workaround in `widgetssdk/build.gradle` regardless of Paparazzi version.
+- `coil 3.4.0` / `ktor 3.4.3` — the next minor of each (`3.5.0`) is built against a newer Kotlin than the project's 2.2.21 pin (Coil 3.5.0 ships Kotlin 2.4.0 metadata; Ktor 3.5.x is built on Kotlin 2.3.21).
+- `leakcanary 3.0-alpha-8` — 3.0-alpha-9 ships an `<adaptive-icon>` resource requiring `sdk 26`, which breaks AAPT resource linking at this project's `minSdk 24`.
 
 ### Forced Resolution Rules
 
 - `com.fasterxml.jackson.core:jackson-core:2.15.3` is forced project-wide via `resolutionStrategy` in root `build.gradle`. Reason: Dokka CVE workaround. Do not remove or change this pin to address Snyk alerts — it will break `dokkaGeneratePublicationJavadoc`.
-- `lint-api` version must equal AGP version plus the 23.0.0 offset (AGP 8.13.0 → lint-api 31.13.0). The custom `lint_checker/` module breaks silently on version mismatch.
+- `lint-api` version must equal AGP version plus the 23.0.0 offset (AGP 9.3.0 → lint-api 32.3.0). The custom `lint_checker/` module breaks silently on version mismatch.
 
 ### Packaging Quirks
 
-- MockK introduces duplicate `META-INF/LICENSE` files. An explicit `merges` rule in `packagingOptions` resolves this — do not remove it.
-- Unit tests require `org.json:json:20250517` to fill gaps in Robolectric's stub coverage of Android JSON APIs.
+- MockK introduces duplicate `META-INF/LICENSE` files. An explicit `merges` rule in the `packaging` block resolves this — do not remove it. (The DSL name is `packaging`, not the deprecated `packagingOptions`, after AGP 9 migration.)
+- Unit tests require `org.json:json` to fill gaps in Robolectric's stub coverage of Android JSON APIs.
 
 ### Build Type and Variant Behavior
 
 - Core SDK is declared per build type: `releaseApi`, `debugApi`, `snapshotApi`. The `snapshot` build type cannot use `includeBuild` composite for local Core SDK substitution.
 - Firebase BOM and `firebase-messaging` are declared as `implementation` in the SDK module but stripped from the published POM via `excludeOptionalDependencies`.
-- Demo app targets `compileSdk 36`; SDK module targets `compileSdk 35`.
+- Demo app targets `compileSdk 37`; SDK module targets `compileSdk 36`.
 - Paparazzi is applied only inside the `snapshot buildTypes` block — non-standard placement, intentional.
+- AGP 9 uses **built-in Kotlin** (no `org.jetbrains.kotlin.android` plugin applied anywhere). The parcelize Gradle plugin alone does not register the compiler plugin under built-in Kotlin, so `widgetssdk/build.gradle` adds `kotlinCompilerPluginClasspath "org.jetbrains.kotlin:kotlin-parcelize-compiler:<kotlinVersion>"` and an `implementation` on `kotlin-parcelize-runtime` explicitly. Removing either makes `@Parcelize` silently stop generating Parcelable implementations.
+- Paparazzi is incompatible with Gradle 9's HTML test reports (cashapp/paparazzi#2111). `widgetssdk/build.gradle` disables `reports.html.required` on every `Test` task as the documented workaround. Do not remove it until a higher Paparazzi release fixes the upstream bug.
+- AGP 9.3.0 hard-requires Gradle 9.5.0+; the wrapper is pinned to 9.6.1.
 - Gradle parallel execution is disabled. Modules are not guaranteed to be fully decoupled.
 - `resolutionStrategy.cacheChangingModulesFor 0, 'seconds'` forces a remote re-fetch of every `-SNAPSHOT` dependency on each build. Do not "optimize" this away.
 
@@ -267,8 +274,8 @@ All of the following pins have WHY comments in `gradle/libs.versions.toml` and m
 
 ```
 ./gradlew widgetssdk:test                                       # Unit tests (testDebug + testRelease)
-./gradlew widgetssdk:recordPaparazziSnapshot                    # Record/update Paparazzi snapshots
-./gradlew widgetssdk:verifyPaparazziSnapshot                    # Verify against stored snapshots
+./gradlew widgetssdk:recordPaparazzi                            # Record/update Paparazzi snapshots
+./gradlew widgetssdk:verifyPaparazzi                            # Verify against stored snapshots
 ./gradlew widgetssdk:lintDebug                                  # Lint SDK (includes custom lint_checker rules)
 ./gradlew ktlintCheck                                           # KtLint check
 ./gradlew ktlintFormat                                          # KtLint format + auto-fix
@@ -344,7 +351,7 @@ Maven Central signing: `ORG_GRADLE_PROJECT_signAllPublications=true` is set by B
 
 - **Push notification layers accumulate regressions.** PN functionality was built incrementally (initial → transcript-from-PN → secure-messaging PN → visitor ID in auth → permissions → dialog simplification). Each layer introduced regressions. The auth/engagement/PN triangle is the highest-risk area.
 
-- **Snapshot updates after rebase are a recurring commit pattern.** Before pushing any rebase, run `./gradlew widgetssdk:recordPaparazziSnapshot` and include resulting PNG changes.
+- **Snapshot updates after rebase are a recurring commit pattern.** Before pushing any rebase, run `./gradlew widgetssdk:recordPaparazzi` and include resulting PNG changes.
 
 ### Architectural Decisions — Never Revert
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,98 +1,136 @@
 [versions]
-javaVersion = "17"
+# Build runs on JDK 21 (set via java toolchain) so JVMTI can retransform
+# Android API 36 stub classes during MockK-driven unit tests. The published
+# AAR is pinned to Java 17 bytecode so integrators on AGP 8.x / JDK 17
+# remain supported. Kotlin's jvmTarget cascades from targetCompatibility
+# under AGP 9 built-in Kotlin, so no separate kotlin jvmTarget needed.
+javaVersion = "21"
 
-kotlinVersion = "2.1.21" # Kotlin and Dokka versions should have the same minor version to support the same kotlin version
-dokkaVersion = "2.0.0" # Kotlin and Dokka versions should have the same minor version to support the same kotlin version
-agpVersion = "8.13.2"
-ktlintVersion = "13.1.0"
-#Publishing
-mavenPublish = "0.35.0"
+# Build tooling — Kotlin and Dokka must share the same minor version to support the same Kotlin language version
+kotlin = "2.2.21"
+dokka = "2.2.0"
+agp = "9.3.0" # requires Gradle 9.5.0+ — the wrapper below is bumped accordingly
+ktlint = "14.2.0"
+mavenPublish = "0.37.0"
 
-# be carefully with updating this plugin, it may upgrade kotlin version for the entire project
-# check the release notes and set the version similar with the project kotlin version
+# Be careful updating Paparazzi — it may upgrade the Kotlin version for the whole project.
+# Check the release notes and keep it aligned with the project Kotlin version.
 # https://github.com/cashapp/paparazzi/releases
-paparazziVersion = "1.3.5"
+# 2.0.0-alpha04 is required for AGP 9 (older versions reference the removed BaseExtension API).
+# 2.0.0-alpha05 is still built against its own bundled Kotlin 2.3.0 (unchanged from alpha04) and
+# only bumps its internal Gradle requirement to 9.3.1 (wrapper here is 9.6.1) — safe alongside Kotlin 2.2.21.
+paparazzi = "2.0.0-alpha05"
 
-javaAppCompatVersion = "1.7.1"
-javaConstraintLayoutVersion = "2.2.1"
-javaCoreKtxVersion = "1.16.0" # 1.17.0 requires the project to be compiled with compileSdk 36
-javaKtorVersion = "3.3.1"
-javaCoroutinesVersion = "1.10.2"
-javaDokkaVersion = "2.0.0"
-javaLifecycleProcessVersion = "2.9.4"
-javaLintVersion = "31.13.2"
-javaMaterialVersion = "1.13.0"
-javaPreferenceVersion = "1.2.1"
-javaRxAndroid3Version = "3.0.2"
-javaRxJava3Version = "3.1.12"
-javaNavVersion = "2.9.5"
-dataGsonVersion = "2.13.2"
-firebaseBomVersion = "34.4.0"
-mediaAudioswitch = "1.2.4"
-mediaCoilCoreVersion = "3.2.0" # versions above 3.2.0 require Kotlin 2.2.0 or higher
-mediaCoilNetworkVersion = "3.2.0" # versions above 3.2.0 require Kotlin 2.2.0 or higher
-mediaLottieVersion = "6.6.10"
-mediaExifInterfaceVersion = "1.4.1"
-testEspressoVersion = "3.7.0"
-testAndroidXTestVersion = "1.3.0"
-archCoreVersion = "2.2.0"
-testMockkVersion = "1.14.6"
-testMockitoKotlinVersion = "6.1.0"
-testRulesVersion = "1.7.0"
-testRobolectricVersion = "4.16"
-testJunitVersion = "4.13.2"
-testJsonVersion = "20250517"
+# AndroidX
+appcompat = "1.7.1"
+constraintlayout = "2.2.1"
+coreKtx = "1.18.0" # max for compileSdk 36 — AAR metadata of 1.19.0 hard-requires compileSdk 37
+lifecycleProcess = "2.10.0" # 2.10.0 requires compileSdk 36; 2.11.0+ requires compileSdk 37
+navigation = "2.9.8"
+preference = "1.2.1"
+exifinterface = "1.4.2"
 
-debugLeakcanaryVersion = "3.0-alpha-8"
+# Kotlinx
+coroutines = "1.11.0"
+
+# UI / media
+material = "1.14.0"
+lottie = "6.7.1"
+coil = "3.4.0" # do NOT bump to 3.5.0: it ships Kotlin 2.4.0 metadata, unreadable by the Kotlin 2.2.21 compiler
+audioswitch = "1.2.5"
+
+# Networking / serialization
+ktor = "3.4.3" # do NOT bump to 3.5.0: built on Kotlin 2.3.21, above the 2.2.21 pin
+gson = "2.14.0"
+
+# Firebase
+firebaseBom = "34.16.0"
+
+# Reactive
+rxandroid = "3.0.2"
+rxjava = "3.1.12"
+
+# Lint tooling
+lint = "32.3.0"
+
+# Testing
+junit = "4.13.2"
+espresso = "3.7.0"
+androidxTestExtJunit = "1.3.0"
+androidxTestRules = "1.7.0"
+archCoreTesting = "2.2.0"
+mockk = "1.14.11"
+mockitoKotlin = "6.3.0"
+robolectric = "4.16.1"
+json = "20260719"
+
+# Debug tooling
+leakcanary = "3.0-alpha-8" # 3.0-alpha-9 ships an <adaptive-icon> resource requiring sdk 26, breaking AAPT linking at our minSdk 24
 
 [libraries]
-android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agpVersion" }
+# Build / lint tooling
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+dokka-androidDocumentation = { module = "org.jetbrains.dokka:android-documentation-plugin", version.ref = "dokka" }
+lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
+lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
 
-data-gson = { module = "com.google.code.gson:gson", version.ref = "dataGsonVersion" }
-firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
+# AndroidX
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleProcess" }
+androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigation" }
+androidx-navigation-ui = { module = "androidx.navigation:navigation-ui", version.ref = "navigation" }
+androidx-preference = { module = "androidx.preference:preference", version.ref = "preference" }
+androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
+
+# Kotlin / Kotlinx
+kotlin-parcelize-runtime = { module = "org.jetbrains.kotlin:kotlin-parcelize-runtime", version.ref = "kotlin" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+
+# UI / media
+material = { module = "com.google.android.material:material", version.ref = "material" }
+lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
+coil-core = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+audioswitch = { module = "com.twilio:audioswitch", version.ref = "audioswitch" }
+
+# Networking / serialization
+ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+
+# Firebase (BOM-managed; messaging is stripped from the published POM)
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
-java-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "javaAppCompatVersion" }
-java-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "javaConstraintLayoutVersion" }
-java-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "javaCoroutinesVersion" }
-java-core-ktx = { module = "androidx.core:core-ktx", version.ref = "javaCoreKtxVersion" }
-java-dokka = { module = "org.jetbrains.dokka:android-documentation-plugin", version.ref = "javaDokkaVersion" }
-java-lint = { module = "com.android.tools.lint:lint-api", version.ref = "javaLintVersion" }
-java-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "javaLintVersion" }
-java-ktor-android = { module = "io.ktor:ktor-client-android", version.ref = "javaKtorVersion" }
-java-ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "javaKtorVersion" }
-java-material = { group = "com.google.android.material", name = "material", version.ref = "javaMaterialVersion" }
-java-navigation-fargment = { module = "androidx.navigation:navigation-fragment", version.ref = "javaNavVersion" }
-java-navigation-ui = { module = "androidx.navigation:navigation-ui", version.ref = "javaNavVersion" }
-java-preference = { module = "androidx.preference:preference", version.ref = "javaPreferenceVersion" }
-java-rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "javaRxAndroid3Version" }
-java-rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "javaRxJava3Version" }
-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "javaLifecycleProcessVersion" }
-media-lottie = { module = "com.airbnb.android:lottie", version.ref = "mediaLottieVersion" }
-media-coil-core = { module = "io.coil-kt.coil3:coil", version.ref = "mediaCoilCoreVersion" }
-media-coil-network = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "mediaCoilNetworkVersion" }
-media-audioswitch = { module = "com.twilio:audioswitch", version.ref = "mediaAudioswitch" }
-media-exif-interface = { module = "androidx.exifinterface:exifinterface", version.ref = "mediaExifInterfaceVersion" }
-test-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "archCoreVersion" }
-test-junit = { module = "junit:junit", version.ref = "testJunitVersion" }
-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "testEspressoVersion" }
-test-rules = { module = "androidx.test:rules", version.ref = "testRulesVersion" }
-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "testAndroidXTestVersion" }
-test-json = { module = "org.json:json", version.ref = "testJsonVersion" }
-test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "testMockitoKotlinVersion" }
-test-robolectric = { module = "org.robolectric:robolectric", version.ref = "testRobolectricVersion" }
-test-mockk-android = { module = "io.mockk:mockk-android", version.ref = "testMockkVersion" }
 
+# Reactive
+rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "rxandroid" }
+rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
+
+# Glia (versions injected by scripts/direct-core.gradle)
 glia-core = { module = "com.glia:android-sdk" }
 glia-telemetry = { module = "com.glia:android-telemetry" }
 
-debug-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "debugLeakcanaryVersion" }
+# Testing
+junit = { module = "junit:junit", version.ref = "junit" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTestRules" }
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "archCoreTesting" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+json = { module = "org.json:json", version.ref = "json" }
+
+# Debug tooling
+leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaVersion" }
-dokkaJavadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokkaVersion" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
-kt-lint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintVersion" }
-paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazziVersion" }
-# Publishing
-# Library reference: https://vanniktech.github.io/gradle-maven-publish-plugin/central/
-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokkaJavadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
+kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
+# Publishing — https://vanniktech.github.io/gradle-maven-publish-plugin/central/
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 04 18:12:06 EEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lint_checker/build.gradle
+++ b/lint_checker/build.gradle
@@ -21,11 +21,11 @@ lint {
 }
 
 dependencies {
-  compileOnly libs.java.lint
+  compileOnly libs.lint.api
 
-  testImplementation libs.java.lint
-  testImplementation libs.java.lint.tests
-  testImplementation libs.test.junit
+  testImplementation libs.lint.api
+  testImplementation libs.lint.tests
+  testImplementation libs.junit
 }
 
 jar {

--- a/widgetssdk/build.gradle
+++ b/widgetssdk/build.gradle
@@ -1,8 +1,10 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
-apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'kotlin-parcelize'
+plugins {
+  id 'com.android.library'
+  alias libs.plugins.kotlinParcelize
+}
+
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka-javadoc'
 
@@ -14,10 +16,12 @@ java {
 }
 
 android {
-  compileSdkVersion 35
+  compileSdk = 36
   namespace 'com.glia.widgets'
   defaultConfig {
-    minSdkVersion 24
+    minSdk = 24
+    versionCode widgetsVersionCode
+    versionName widgetsVersionName
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
   }
@@ -37,6 +41,12 @@ android {
     }
   }
 
+  // Workaround for Paparazzi <= 2.0.0-alpha04 incompatibility with Gradle 9.
+  // https://github.com/cashapp/paparazzi/issues/2111
+  tasks.withType(Test).configureEach {
+    reports.html.required = false
+  }
+
   lint {
     disable 'WrongLayoutName',
       'LayoutFileNameMatchesClass',
@@ -53,9 +63,19 @@ android {
     buildConfig true
   }
 
+  // Build runs on JDK 21 (set via java toolchain) so JVMTI can retransform
+  // Android API 36 stub classes during MockK-driven unit tests. The published
+  // AAR is pinned to Java 17 bytecode so integrators on AGP 8.x / JDK 17
+  // remain supported. Kotlin's jvmTarget cascades from targetCompatibility
+  // under AGP 9 built-in Kotlin, so no separate kotlin jvmTarget needed.
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
   //After adding `Mockk` dependency to the instrumentation tests it started to fail builds with message that
   // there are 6 files in project with these two Licences. Since all of them were related to Junit, it is safe to merge them.
-  packagingOptions {
+  packaging {
     resources {
       merges += ['META-INF/LICENSE.md', 'META-INF/LICENSE-notice.md']
     }
@@ -170,16 +190,16 @@ afterEvaluate {
 apply from: "${rootProject.projectDir}/scripts/direct-core.gradle"
 
 dependencies {
-  implementation libs.java.appcompat
-  implementation libs.java.material
-  implementation libs.java.constraintlayout
-  implementation libs.lifecycle.process
-  implementation libs.media.coil.core
-  implementation libs.media.coil.network
+  implementation libs.androidx.appcompat
+  implementation libs.material
+  implementation libs.androidx.constraintlayout
+  implementation libs.androidx.lifecycle.process
+  implementation libs.coil.core
+  implementation libs.coil.network.okhttp
 
   // Used for audio and video permissions by CallActivity
-  implementation libs.java.rxandroid
-  implementation libs.java.rxjava
+  implementation libs.rxandroid
+  implementation libs.rxjava
 
   releaseApi "${libs.glia.core.get().module}:$gliaSdkVersion"
 
@@ -200,31 +220,35 @@ dependencies {
     }
   }
 
-  implementation libs.media.audioswitch
-  implementation libs.media.lottie
-  implementation libs.data.gson
-  implementation libs.java.core.ktx
-  implementation libs.media.exif.interface
+  implementation libs.audioswitch
+  implementation libs.lottie
+  implementation libs.gson
+  implementation libs.androidx.core.ktx
+  implementation libs.androidx.exifinterface
+  implementation libs.kotlin.parcelize.runtime
+  // AGP 9 built-in Kotlin doesn't auto-register the parcelize compiler plugin via the
+  // kotlin-parcelize Gradle plugin alone, so add the compiler artifact explicitly.
+  kotlinCompilerPluginClasspath "org.jetbrains.kotlin:kotlin-parcelize-compiler:${libs.versions.kotlin.get()}"
 
   implementation platform(libs.firebase.bom)
   implementation libs.firebase.messaging
 
-  testImplementation libs.test.junit
-  testImplementation libs.test.mockito.kotlin
-  testImplementation libs.test.core.testing
-  testImplementation libs.test.robolectric
-  testImplementation libs.test.mockk.android
-  androidTestImplementation libs.test.mockk.android
-  androidTestImplementation libs.test.ext.junit
-  androidTestImplementation libs.test.espresso.core
-  androidTestImplementation libs.test.rules
+  testImplementation libs.junit
+  testImplementation libs.mockito.kotlin
+  testImplementation libs.androidx.arch.core.testing
+  testImplementation libs.robolectric
+  testImplementation libs.mockk.android
+  androidTestImplementation libs.mockk.android
+  androidTestImplementation libs.androidx.test.ext.junit
+  androidTestImplementation libs.androidx.test.espresso.core
+  androidTestImplementation libs.androidx.test.rules
 
   // Test dependencies to Android native libraries
   // To prevent unit tests firing errors like 'Method length in org.json.JSONObject not mocked'
-  testImplementation libs.test.json
+  testImplementation libs.json
 
   lintChecks project(':lint_checker')
-  debugImplementation libs.debug.leakcanary
+  debugImplementation libs.leakcanary
 }
 
 configurations.configureEach {

--- a/widgetssdk/consumer-rules.pro
+++ b/widgetssdk/consumer-rules.pro
@@ -1,4 +1,6 @@
--keep class com.glia.widgets.core.fileupload.GliaFileProvider
+# Android instantiates ContentProviders by reflection; under R8 strict full mode (AGP 9 default)
+# `-keep class` no longer implies the default constructor, so keep it explicitly.
+-keep class com.glia.widgets.core.fileupload.GliaFileProvider { <init>(); }
 -keepclassmembers class com.glia.widgets.chat.adapter.holder.WebViewViewHolder$JavaScriptInterface {
    public *;
 }

--- a/widgetssdk/src/main/AndroidManifest.xml
+++ b/widgetssdk/src/main/AndroidManifest.xml
@@ -32,6 +32,8 @@
     <uses-permission
         android:name="android.permission.CAMERA"
         android:required="false" />
+    <!-- Required by CallForegroundService's microphone foregroundServiceType; also declared by the Core SDK manifest. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />


### PR DESCRIPTION
## Summary

Migrates the build to **Android Gradle Plugin 9.3.0 (Gradle 9.6.1)** with built-in Kotlin, adds **Android 17 / API 37** support, upgrades dependencies to the newest versions compatible with the project's constraints, and cleans up the version catalog naming.

Jira: **MOB-5187**

Supersedes #1503, which GitHub auto-closed (and detached from its head ref) when the branch was renamed from `...agp-9-2-...` to `...agp-9-3-...` to match this PR's content.

## AGP 9.3 / Gradle migration

- Migrate to AGP 9.3.0 + Gradle 9.6.1 using the new DSL and built-in Kotlin support; drop the `org.jetbrains.kotlin.android` plugin.
- Declare `kotlin-parcelize` via the plugins DSL and add `kotlin-parcelize-runtime` + `kotlin-parcelize-compiler` on `kotlinCompilerPluginClasspath` (the parcelize Gradle plugin alone no longer registers the compiler plugin under built-in Kotlin).
- Switch to `compileSdk`/`minSdk`/`targetSdk` DSL and rename `packagingOptions` → `packaging`.
- Raise the Gradle wrapper to **9.6.1** — AGP 9.3.0 hard-requires Gradle 9.5.0+.
- Drop the AGP-Upgrade-Assistant safety flags from `gradle.properties` and adopt the AGP 9 defaults (incl. explicit `resValues`, R8 strict-mode keep rule for `GliaFileProvider`).
- Java toolchain raised to **JDK 21** (build-time only); published AAR bytecode stays pinned to **Java 17**, so integrators on AGP 8.x / JDK 17 are unaffected.
- Standardize `bitrise.yml` syntax and read the release version straight from `version.properties` instead of `./gradlew -q printCurrentVersionName`, whose output is polluted by the Bitrise Gradle Mirrors init script logs.

## Android 17 / API 37 support

Audited the codebase against the Android 17 behavior changes (lock-free MessageQueue, background-audio hardening, large-screen orientation/resizability, BAL hardening, implicit URI grants, local-network permission, native DCL, cleartext) — **no code changes required**; all networking/audio is delegated to the Core SDK, no MessageQueue reflection, no orientation locking, push intents already BAL-safe.

- `widgetssdk` **compileSdk 35 → 36**
- demo `app` **compileSdk + targetSdk 36 → 37**

## Dependency upgrades

Constraint: **Kotlin pinned at 2.2.21**, nothing may require a higher Kotlin or a compileSdk above each module's level.

Bumped:
- agp `9.2.0 → 9.3.0`
- paparazzi `2.0.0-alpha04 → 2.0.0-alpha05` — verified safe: still built against its own bundled Kotlin (unrelated to the project's Kotlin pin), only raises its internal Gradle requirement to 9.3.1
- kotlin `2.2.10 → 2.2.21`
- kotlinx-coroutines `1.10.2 → 1.11.0`
- androidx core-ktx `1.16.0 → 1.18.0`
- androidx lifecycle-process `2.9.4 → 2.10.0`
- material `1.13.0 → 1.14.0`
- firebase-bom `34.12.0 → 34.16.0`
- mockk `1.14.9 → 1.14.11`
- org.json `20251224 → 20260719`
- lint-api / lint-tests `32.2.1 → 32.3.0` (matches the AGP 9.3.0 pairing)
- maven-publish `0.36.0 → 0.37.0`

Deliberately held back (would break the Kotlin 2.2.21 pin, need a higher compileSdk, or regress a supported minSdk):
- **Coil** stays `3.4.0` — 3.5.0 ships Kotlin 2.4.0 metadata, unreadable by the 2.2.21 compiler.
- **Ktor** stays `3.4.3` — 3.5.x is built on Kotlin 2.3.21.
- **core-ktx** capped at `1.18.0` — 1.19.0 hard-requires compileSdk 37.
- **lifecycle-process** capped at `2.10.0` — 2.11.0 requires compileSdk 37.
- **Robolectric** stays `4.16.1` — 4.17 is still beta.
- **LeakCanary** stays `3.0-alpha-8` — 3.0-alpha-9 ships an `<adaptive-icon>` resource requiring `sdk 26`, which breaks AAPT resource linking at this project's `minSdk 24`.

## Version catalog cleanup

Renamed every alias in `gradle/libs.versions.toml` to the official version-catalog convention — grouped, kebab-case aliases (`androidx-*`, `kotlinx-*`, `ktor-client-*`, `coil-*`, `androidx-test-*`, …) with the meaningless `java`/`media`/`test`/`data` prefixes removed, and merged the duplicate Coil and Dokka version refs. All `libs.*` references across the four `build.gradle` files updated accordingly; fixed the `navigation-fargment` typo.

## Verification

- `:app:assembleDebug` and `:widgetssdk:assembleDebug` — green (app @ API 37, sdk @ compileSdk 36, Kotlin 2.2.21, AGP 9.3.0).
- `:widgetssdk:test` and `:lint_checker:test` — green.
- `:widgetssdk:verifyPaparazzi` — green with Paparazzi 2.0.0-alpha05.
- `lint` — green.
