### PR TITLE
Release CallController's view reference when CallView is destroyed

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallContract.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallContract.kt
@@ -25,6 +25,7 @@ internal interface CallContract {
         fun onResume()
         fun onPause()
         fun setView(view: View)
+        fun getView(): View?
         fun onLiveObservationDialogRequested()
         fun endEngagementDialogYesClicked()
         fun endEngagementDialogDismissed()

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallController.kt
@@ -303,6 +303,8 @@ internal class CallController(
         view.emitState(callState)
     }
 
+    override fun getView(): CallContract.View? = view
+
     override fun endEngagementDialogYesClicked() {
         Logger.d(TAG, "endEngagementDialogYesClicked")
         stop()

--- a/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/call/CallView.kt
@@ -35,6 +35,7 @@ import com.glia.widgets.helper.Logger
 import com.glia.widgets.helper.SimpleWindowInsetsAndAnimationHandler
 import com.glia.widgets.helper.TAG
 import com.glia.widgets.helper.Utils
+import com.glia.widgets.helper.asActivity
 import com.glia.widgets.helper.getColorCompat
 import com.glia.widgets.helper.getColorStateListCompat
 import com.glia.widgets.helper.getFontCompat
@@ -206,6 +207,14 @@ internal class CallView(context: Context, attrs: AttributeSet?, defStyleAttr: In
     }
 
     private fun destroyControllers() {
+        // The retained controller keeps a strong reference to its current view; release it here,
+        // otherwise the destroyed CallActivity stays reachable through this view until the next
+        // CallView attaches. A newer view may have already taken over the controller - leave it be.
+        callController?.let {
+            if (it.getView() == this) {
+                it.onDestroy(context.asActivity() is CallActivity)
+            }
+        }
         callController = null
         dialogController = null
     }

--- a/widgetssdk/src/test/java/com/glia/widgets/call/CallControllerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/call/CallControllerTest.kt
@@ -1,0 +1,226 @@
+package com.glia.widgets.call
+
+import com.glia.widgets.call.domain.HandleCallPermissionsUseCase
+import com.glia.widgets.chat.domain.DecideOnQueueingUseCase
+import com.glia.widgets.chat.domain.UpdateFromCallScreenUseCase
+import com.glia.widgets.engagement.domain.AcceptMediaUpgradeOfferUseCase
+import com.glia.widgets.engagement.domain.EndEngagementUseCase
+import com.glia.widgets.engagement.domain.EngagementStateUseCase
+import com.glia.widgets.engagement.domain.EnqueueForEngagementUseCase
+import com.glia.widgets.engagement.domain.FlipCameraButtonStateUseCase
+import com.glia.widgets.engagement.domain.FlipVisitorCameraUseCase
+import com.glia.widgets.engagement.domain.IsCurrentEngagementCallVisualizerUseCase
+import com.glia.widgets.engagement.domain.IsMediaQualityPoorUseCase
+import com.glia.widgets.engagement.domain.IsQueueingOrLiveEngagementUseCase
+import com.glia.widgets.engagement.domain.OperatorMediaUseCase
+import com.glia.widgets.engagement.domain.ToggleVisitorAudioMediaStateUseCase
+import com.glia.widgets.engagement.domain.ToggleVisitorVideoMediaStateUseCase
+import com.glia.widgets.engagement.domain.VisitorMediaUseCase
+import com.glia.widgets.helper.DeviceMonitor
+import com.glia.widgets.helper.Logger
+import com.glia.widgets.helper.TimeCounter
+import com.glia.widgets.internal.audio.domain.TurnSpeakerphoneUseCase
+import com.glia.widgets.internal.dialog.DialogContract
+import com.glia.widgets.internal.dialog.domain.ConfirmationDialogLinksUseCase
+import com.glia.widgets.internal.dialog.domain.IsShowOverlayPermissionRequestDialogUseCase
+import com.glia.widgets.internal.engagement.domain.ConfirmationDialogUseCase
+import com.glia.widgets.internal.engagement.domain.ShouldShowMediaEngagementViewUseCase
+import com.glia.widgets.internal.notification.domain.CallNotificationUseCase
+import com.glia.widgets.view.MessagesNotSeenHandler
+import com.glia.widgets.view.MinimizeHandler
+import com.glia.widgets.webbrowser.domain.GetUrlFromLinkUseCase
+import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class CallControllerTest {
+    private lateinit var callTimer: TimeCounter
+    private lateinit var inactivityTimeCounter: TimeCounter
+    private lateinit var connectingTimerCounter: TimeCounter
+    private lateinit var minimizeHandler: MinimizeHandler
+    private lateinit var dialogController: DialogContract.Controller
+    private lateinit var messagesNotSeenHandler: MessagesNotSeenHandler
+    private lateinit var callNotificationUseCase: CallNotificationUseCase
+    private lateinit var endEngagementUseCase: EndEngagementUseCase
+    private lateinit var shouldShowMediaEngagementViewUseCase: ShouldShowMediaEngagementViewUseCase
+    private lateinit var isShowOverlayPermissionRequestDialogUseCase: IsShowOverlayPermissionRequestDialogUseCase
+    private lateinit var updateFromCallScreenUseCase: UpdateFromCallScreenUseCase
+    private lateinit var isCurrentEngagementCallVisualizerUseCase: IsCurrentEngagementCallVisualizerUseCase
+    private lateinit var turnSpeakerphoneUseCase: TurnSpeakerphoneUseCase
+    private lateinit var confirmationDialogUseCase: ConfirmationDialogUseCase
+    private lateinit var confirmationDialogLinksUseCase: ConfirmationDialogLinksUseCase
+    private lateinit var handleCallPermissionsUseCase: HandleCallPermissionsUseCase
+    private lateinit var engagementStateUseCase: EngagementStateUseCase
+    private lateinit var operatorMediaUseCase: OperatorMediaUseCase
+    private lateinit var acceptMediaUpgradeOfferUseCase: AcceptMediaUpgradeOfferUseCase
+    private lateinit var visitorMediaUseCase: VisitorMediaUseCase
+    private lateinit var toggleVisitorAudioMediaStateUseCase: ToggleVisitorAudioMediaStateUseCase
+    private lateinit var toggleVisitorVideoMediaStateUseCase: ToggleVisitorVideoMediaStateUseCase
+    private lateinit var flipVisitorCameraUseCase: FlipVisitorCameraUseCase
+    private lateinit var flipCameraButtonStateUseCase: FlipCameraButtonStateUseCase
+    private lateinit var isQueueingOrLiveEngagementUseCase: IsQueueingOrLiveEngagementUseCase
+    private lateinit var enqueueForEngagementUseCase: EnqueueForEngagementUseCase
+    private lateinit var decideOnQueueingUseCase: DecideOnQueueingUseCase
+    private lateinit var getUrlFromLinkUseCase: GetUrlFromLinkUseCase
+    private lateinit var deviceMonitor: DeviceMonitor
+    private lateinit var isMediaQualityPoorUseCase: IsMediaQualityPoorUseCase
+
+    private lateinit var callView: CallContract.View
+
+    private lateinit var callController: CallController
+
+    @Before
+    fun setUp() {
+        Logger.setIsDebug(false)
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler { Schedulers.trampoline() }
+        callTimer = mock()
+        inactivityTimeCounter = mock()
+        connectingTimerCounter = mock()
+        minimizeHandler = mock()
+        dialogController = mock()
+        messagesNotSeenHandler = mock()
+        callNotificationUseCase = mock()
+        endEngagementUseCase = mock()
+        shouldShowMediaEngagementViewUseCase = mock()
+        isShowOverlayPermissionRequestDialogUseCase = mock()
+        updateFromCallScreenUseCase = mock()
+        isCurrentEngagementCallVisualizerUseCase = mock()
+        turnSpeakerphoneUseCase = mock()
+        confirmationDialogUseCase = mock()
+        confirmationDialogLinksUseCase = mock()
+        handleCallPermissionsUseCase = mock()
+        engagementStateUseCase = mock {
+            on { invoke() } doReturn Flowable.empty()
+        }
+        operatorMediaUseCase = mock {
+            on { invoke() } doReturn Flowable.empty()
+        }
+        acceptMediaUpgradeOfferUseCase = mock {
+            on { result } doReturn Flowable.empty()
+        }
+        visitorMediaUseCase = mock {
+            on { invoke() } doReturn Flowable.empty()
+            on { onHoldState } doReturn Flowable.empty()
+        }
+        toggleVisitorAudioMediaStateUseCase = mock()
+        toggleVisitorVideoMediaStateUseCase = mock()
+        flipVisitorCameraUseCase = mock()
+        flipCameraButtonStateUseCase = mock {
+            on { invoke() } doReturn Flowable.empty()
+        }
+        isQueueingOrLiveEngagementUseCase = mock()
+        enqueueForEngagementUseCase = mock()
+        decideOnQueueingUseCase = mock {
+            on { invoke() } doReturn Flowable.empty()
+        }
+        getUrlFromLinkUseCase = mock()
+        deviceMonitor = mock()
+        isMediaQualityPoorUseCase = mock {
+            on { invoke() } doReturn Flowable.empty()
+        }
+
+        callView = mock()
+
+        callController = CallController(
+            callTimer = callTimer,
+            inactivityTimeCounter = inactivityTimeCounter,
+            connectingTimerCounter = connectingTimerCounter,
+            minimizeHandler = minimizeHandler,
+            dialogController = dialogController,
+            messagesNotSeenHandler = messagesNotSeenHandler,
+            callNotificationUseCase = callNotificationUseCase,
+            endEngagementUseCase = endEngagementUseCase,
+            shouldShowMediaEngagementViewUseCase = shouldShowMediaEngagementViewUseCase,
+            isShowOverlayPermissionRequestDialogUseCase = isShowOverlayPermissionRequestDialogUseCase,
+            updateFromCallScreenUseCase = updateFromCallScreenUseCase,
+            isCurrentEngagementCallVisualizerUseCase = isCurrentEngagementCallVisualizerUseCase,
+            turnSpeakerphoneUseCase = turnSpeakerphoneUseCase,
+            confirmationDialogUseCase = confirmationDialogUseCase,
+            confirmationDialogLinksUseCase = confirmationDialogLinksUseCase,
+            handleCallPermissionsUseCase = handleCallPermissionsUseCase,
+            engagementStateUseCase = engagementStateUseCase,
+            operatorMediaUseCase = operatorMediaUseCase,
+            acceptMediaUpgradeOfferUseCase = acceptMediaUpgradeOfferUseCase,
+            visitorMediaUseCase = visitorMediaUseCase,
+            toggleVisitorAudioMediaStateUseCase = toggleVisitorAudioMediaStateUseCase,
+            toggleVisitorVideoMediaStateUseCase = toggleVisitorVideoMediaStateUseCase,
+            flipVisitorCameraUseCase = flipVisitorCameraUseCase,
+            flipCameraButtonStateUseCase = flipCameraButtonStateUseCase,
+            isQueueingOrLiveEngagementUseCase = isQueueingOrLiveEngagementUseCase,
+            enqueueForEngagementUseCase = enqueueForEngagementUseCase,
+            decideOnQueueingUseCase = decideOnQueueingUseCase,
+            getUrlFromLinkUseCase = getUrlFromLinkUseCase,
+            deviceMonitor = deviceMonitor,
+            isMediaQualityPoorUseCase = isMediaQualityPoorUseCase
+        )
+    }
+
+    @After
+    fun tearDown() {
+        RxAndroidPlugins.reset()
+    }
+
+    @Test
+    fun `setView registers the view and emits the current state`() {
+        callController.setView(callView)
+
+        assertEquals(callView, callController.getView())
+        verify(callView).emitState(any())
+    }
+
+    @Test
+    fun `onDestroy releases the view when retained so the host activity is not leaked`() {
+        callController.setView(callView)
+
+        callController.onDestroy(true)
+
+        verify(callView).destroyView()
+        assertNull(callController.getView())
+    }
+
+    @Test
+    fun `onDestroy keeps timers and subscriptions when retained`() {
+        callController.setView(callView)
+
+        callController.onDestroy(true)
+
+        verify(callTimer, never()).clear()
+        verify(inactivityTimeCounter, never()).clear()
+        verify(connectingTimerCounter, never()).clear()
+        verify(minimizeHandler, never()).clear()
+    }
+
+    @Test
+    fun `onDestroy releases the view and clears timers when not retained`() {
+        callController.setView(callView)
+
+        callController.onDestroy(false)
+
+        verify(callView).destroyView()
+        assertNull(callController.getView())
+        verify(callTimer).clear()
+        verify(inactivityTimeCounter).clear()
+        verify(connectingTimerCounter).clear()
+        verify(minimizeHandler).clear()
+    }
+
+    @Test
+    fun `getView returns the latest view when a new view replaces the previous one`() {
+        val newView = mock<CallContract.View>()
+        callController.setView(callView)
+
+        callController.setView(newView)
+
+        assertEquals(newView, callController.getView())
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5460

**What was solved?**

Fixed a `CallActivity` leak that trips StrictMode's `detectActivityLeaks()` (`InstanceCountViolation: class com.glia.widgets.call.CallActivity; instances=3; limit=2`).

`CallController` is retained across activity recreation and holds a strong reference to its `CallContract.View`, whose context is the `CallActivity`. `CallView.onDestroy()` only nulled its own pointer to the controller and never told the controller to drop the view, so on any finish path that bypasses the controller's click handlers (system back gesture, listener-driven `finish()`, early `finish()` in `onCreate` when `shouldShowMediaEngagementView()` is false) the destroyed activity stayed strongly reachable until the next `CallView` attached.

The fix mirrors the existing `ChatView` pattern:
- `CallView.destroyControllers()` now calls `callController.onDestroy(context.asActivity() is CallActivity)`, releasing the view while keeping the retained controller's timers/subscriptions for activity recreation.
- The call is guarded by `getView() == this` (new `CallContract.Controller.getView()`, same as `ChatContract`) so a stale view never clears a newer view's registration.

**Additional info:**

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from Android SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3568861468/Logging+from+Android+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

Added `CallControllerTest` covering `setView`/`getView` registration, view release on `onDestroy(retained = true/false)`, retained-mode keeping timers/subscriptions, and view replacement. Full `widgetssdk:testDebugUnitTest` suite passes. No visual changes, so no snapshot updates. No new logging added.

**Screenshots:**
