### PR TITLE
MOB-5469 Release the replaced visitor VideoView to stop leaking EglRenderer

### DIFF
--- a/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.kt
+++ b/widgetssdk/src/main/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoView.kt
@@ -66,6 +66,7 @@ internal class FloatingVisitorVideoView @JvmOverloads constructor(
     }
 
     fun showVisitorVideo(newVideoView: VideoView) {
+        videoView?.release()
         videoView = newVideoView
         newVideoView.setZOrderMediaOverlay(true)
         removeVideoView()

--- a/widgetssdk/src/test/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoContainerTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoContainerTest.kt
@@ -1,0 +1,164 @@
+package com.glia.widgets.view.floatingvisitorvideoview
+
+import android.content.Context
+import android.mockk
+import android.unMockk
+import android.view.View
+import com.glia.androidsdk.comms.MediaState
+import com.glia.androidsdk.comms.Video
+import com.glia.androidsdk.comms.VideoView
+import com.glia.telemetry_lib.GliaLogger
+import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.ResourceProvider
+import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
+import com.glia.widgets.helper.wrapWithTheme
+import com.glia.widgets.locale.LocaleProvider
+import com.glia.widgets.locale.StringKeyPair
+import io.reactivex.rxjava3.core.Observable
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+internal class FloatingVisitorVideoContainerTest {
+
+    private lateinit var context: Context
+    private lateinit var container: FloatingVisitorVideoContainer
+
+    @Before
+    fun setUp() {
+        GliaLogger.mockk()
+
+        val application = RuntimeEnvironment.getApplication()
+        Dependencies.resourceProvider = ResourceProvider(application)
+        Dependencies.localeProvider = mock<LocaleProvider>().also {
+            whenever(it.getLocaleObservable()) doReturn Observable.never()
+            whenever(it.getStringInternal(any<Int>(), any<List<StringKeyPair>>())) doReturn "stub"
+        }
+
+        context = application.wrapWithTheme().wrapWithMaterialThemeOverlay()
+        container = FloatingVisitorVideoContainer(context)
+    }
+
+    @After
+    fun tearDown() {
+        GliaLogger.unMockk()
+    }
+
+    /**
+     * Regression test for MOB-5469. A network reconnect during a video engagement emits a fresh
+     * [MediaState], so [FloatingVisitorVideoContainer.show] creates a new [VideoView] while the
+     * container is already visible. The replaced view has to be released, otherwise its
+     * `EglRenderer` leaks for the rest of the engagement.
+     */
+    @Test
+    fun `show with a new media state releases the video view created for the previous one`() {
+        val beforeReconnect = FakeVideoView(context)
+        val afterReconnect = FakeVideoView(context)
+
+        container.show(mediaState(beforeReconnect))
+        container.show(mediaState(afterReconnect))
+
+        assertEquals(View.VISIBLE, container.visibility)
+        assertEquals(1, beforeReconnect.releaseCount)
+        assertEquals(0, afterReconnect.releaseCount)
+    }
+
+    @Test
+    fun `show with the same media state instance keeps the current video view`() {
+        val videoView = FakeVideoView(context)
+        val mediaState = mediaState(videoView)
+
+        container.show(mediaState)
+        container.show(mediaState)
+
+        assertEquals(0, videoView.releaseCount)
+    }
+
+    @Test
+    fun `show with a null media state keeps the current video view`() {
+        val videoView = FakeVideoView(context)
+
+        container.show(mediaState(videoView))
+        container.show(null)
+
+        assertEquals(0, videoView.releaseCount)
+    }
+
+    @Test
+    fun `hide releases and detaches the current video view exactly once`() {
+        val videoView = FakeVideoView(context)
+
+        container.show(mediaState(videoView))
+        container.hide()
+
+        assertEquals(View.GONE, container.visibility)
+        assertEquals(1, videoView.releaseCount)
+        assertNull(videoView.parent)
+    }
+
+    @Test
+    fun `show after hide re-attaches the video view for the same media state`() {
+        val videoView = FakeVideoView(context)
+        val mediaState = mediaState(videoView)
+
+        container.show(mediaState)
+        container.hide()
+        container.show(mediaState)
+
+        // hide() resets the tracked media state id, so the same instance counts as new again
+        assertNotNull(videoView.parent)
+        assertEquals(View.VISIBLE, container.visibility)
+        // released only by hide(), not a second time by the re-attach
+        assertEquals(1, videoView.releaseCount)
+    }
+
+    private fun mediaState(videoView: VideoView): MediaState {
+        val video = mock<Video>()
+        whenever(video.createVideoView(anyOrNull())) doReturn videoView
+
+        val mediaState = mock<MediaState>()
+        whenever(mediaState.video) doReturn video
+
+        return mediaState
+    }
+
+    private class FakeVideoView(context: Context) : VideoView(context) {
+        var releaseCount: Int = 0
+
+        override fun pauseRendering() {
+            /* no-op */
+        }
+
+        override fun resumeRendering() {
+            /* no-op */
+        }
+
+        override fun setZOrderMediaOverlay(isMediaOverlay: Boolean) {
+            /* no-op */
+        }
+
+        override fun release() {
+            releaseCount++
+        }
+
+        override fun setGravity(gravity: Int) {
+            /* no-op */
+        }
+
+        override fun setScalingType(scalingType: ScalingType?) {
+            /* no-op */
+        }
+    }
+}

--- a/widgetssdk/src/test/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoViewTest.kt
+++ b/widgetssdk/src/test/java/com/glia/widgets/view/floatingvisitorvideoview/FloatingVisitorVideoViewTest.kt
@@ -1,0 +1,198 @@
+package com.glia.widgets.view.floatingvisitorvideoview
+
+import android.content.Context
+import android.mockk
+import android.unMockk
+import com.glia.androidsdk.comms.VideoView
+import com.glia.telemetry_lib.GliaLogger
+import com.glia.widgets.di.Dependencies
+import com.glia.widgets.helper.ResourceProvider
+import com.glia.widgets.helper.wrapWithMaterialThemeOverlay
+import com.glia.widgets.helper.wrapWithTheme
+import com.glia.widgets.locale.LocaleProvider
+import com.glia.widgets.locale.StringKeyPair
+import io.reactivex.rxjava3.core.Observable
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+internal class FloatingVisitorVideoViewTest {
+
+    private lateinit var context: Context
+    private lateinit var view: FloatingVisitorVideoView
+
+    @Before
+    fun setUp() {
+        GliaLogger.mockk()
+
+        val application = RuntimeEnvironment.getApplication()
+        Dependencies.resourceProvider = ResourceProvider(application)
+        Dependencies.localeProvider = mock<LocaleProvider>().also {
+            whenever(it.getLocaleObservable()) doReturn Observable.never()
+            whenever(it.getStringInternal(any<Int>(), any<List<StringKeyPair>>())) doReturn "stub"
+        }
+
+        context = application.wrapWithTheme().wrapWithMaterialThemeOverlay()
+        view = FloatingVisitorVideoView(context)
+    }
+
+    @After
+    fun tearDown() {
+        GliaLogger.unMockk()
+    }
+
+    /**
+     * Regression test for MOB-5469: a network reconnect during a video engagement produces a new
+     * [com.glia.androidsdk.comms.MediaState], which makes [FloatingVisitorVideoContainer.show] build
+     * a brand-new [VideoView] while the container is still visible. Before the fix the previously
+     * rendered view was overwritten without being released, leaking its `EglRenderer`.
+     */
+    @Test
+    fun `showVisitorVideo releases the previously shown video view`() {
+        val first = FakeVideoView(context)
+        val second = FakeVideoView(context)
+
+        view.showVisitorVideo(first)
+        view.showVisitorVideo(second)
+
+        assertEquals(1, first.releaseCount)
+        assertEquals(0, second.releaseCount)
+    }
+
+    @Test
+    fun `showVisitorVideo releases every replaced video view across repeated reconnects`() {
+        val videoViews = List(3) { FakeVideoView(context) }
+
+        videoViews.forEach(view::showVisitorVideo)
+
+        assertTrue(videoViews.dropLast(1).all { it.releaseCount == 1 })
+        assertEquals(0, videoViews.last().releaseCount)
+    }
+
+    @Test
+    fun `showVisitorVideo detaches the previously shown video view and adds the new one first`() {
+        val first = FakeVideoView(context)
+        val second = FakeVideoView(context)
+
+        view.showVisitorVideo(first)
+        view.showVisitorVideo(second)
+
+        assertNull(first.parent)
+        assertSame(second, view.getChildAt(0))
+    }
+
+    @Test
+    fun `showVisitorVideo does not release the replaced video view more than once when it is later hidden`() {
+        val first = FakeVideoView(context)
+        val second = FakeVideoView(context)
+
+        view.showVisitorVideo(first)
+        view.showVisitorVideo(second)
+        view.hideVisitorVideo()
+
+        assertEquals(1, first.releaseCount)
+        assertEquals(1, second.releaseCount)
+    }
+
+    @Test
+    fun `showVisitorVideo does not release an already hidden video view again`() {
+        val first = FakeVideoView(context)
+        val second = FakeVideoView(context)
+
+        view.showVisitorVideo(first)
+        view.hideVisitorVideo()
+        view.showVisitorVideo(second)
+
+        assertEquals(1, first.releaseCount)
+        assertEquals(0, second.releaseCount)
+    }
+
+    @Test
+    fun `showVisitorVideo places the new video view as a media overlay`() {
+        val videoView = FakeVideoView(context)
+
+        view.showVisitorVideo(videoView)
+
+        assertTrue(videoView.isMediaOverlay)
+    }
+
+    @Test
+    fun `hideVisitorVideo releases the current video view only once`() {
+        val videoView = FakeVideoView(context)
+
+        view.showVisitorVideo(videoView)
+        view.hideVisitorVideo()
+        view.hideVisitorVideo()
+
+        assertEquals(1, videoView.releaseCount)
+        assertNull(videoView.parent)
+    }
+
+    @Test
+    fun `showOnHold pauses and hideOnHold resumes the current video view`() {
+        val videoView = FakeVideoView(context)
+        view.showVisitorVideo(videoView)
+
+        view.showOnHold()
+        view.hideOnHold()
+
+        assertEquals(1, videoView.pauseCount)
+        assertEquals(1, videoView.resumeCount)
+    }
+
+    @Test
+    fun `onPause and onResume are not forwarded to a released video view`() {
+        val videoView = FakeVideoView(context)
+        view.showVisitorVideo(videoView)
+        view.hideVisitorVideo()
+
+        view.onPause()
+        view.onResume()
+
+        assertEquals(0, videoView.pauseCount)
+        assertEquals(0, videoView.resumeCount)
+    }
+
+    private class FakeVideoView(context: Context) : VideoView(context) {
+        var releaseCount: Int = 0
+        var pauseCount: Int = 0
+        var resumeCount: Int = 0
+        var isMediaOverlay: Boolean = false
+
+        override fun pauseRendering() {
+            pauseCount++
+        }
+
+        override fun resumeRendering() {
+            resumeCount++
+        }
+
+        override fun setZOrderMediaOverlay(isMediaOverlay: Boolean) {
+            this.isMediaOverlay = isMediaOverlay
+        }
+
+        override fun release() {
+            releaseCount++
+        }
+
+        override fun setGravity(gravity: Int) {
+            /* no-op */
+        }
+
+        override fun setScalingType(scalingType: ScalingType?) {
+            /* no-op */
+        }
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-5469

**What was solved?**

`FloatingVisitorVideoView.showVisitorVideo()` overwrote its `videoView` field without releasing the previous instance, leaking that view's `EglRenderer`.

This is reachable on every network reconnect during a video engagement:

1. A reconnect emits a fresh `MediaState`.
2. `FloatingVisitorVideoContainer.show()` treats it as new (`isNewMediaState()` compares `System.identityHashCode`) and calls `state.video.createVideoView(...)` — a **brand-new** `VideoView` — while the container is already `VISIBLE`.
3. `showVisitorVideo()` assigned it over the old reference. The old view was detached from the hierarchy by `removeVideoView()` but never `release()`d, so its `EglRenderer` (and the EGL context / surface it holds) stayed alive for the rest of the engagement. Repeated reconnects leaked one per reconnect.

The fix releases the outgoing `VideoView` before taking ownership of the new one. The existing release-and-null guard in `releaseVideoStream()` means `hideVisitorVideo()` and `onDetachedFromWindow()` cannot double-release.

**Additional info:**

I also audited the operator-side video path in `CallView` for the same bug — it is **not** affected. `showOperatorVideo()` opens with `releaseOperatorVideoStream()` (which releases *and* nulls the field), and it only runs when `operatorVideoContainer.isGone`, a state only reached via `hideOperatorVideo()` → `releaseOperatorVideoStream()`. No change needed there.

Tests added (2 new classes, 14 tests). 4 of them fail on `development` and pass with this fix — verified by stashing the one-line change and re-running:

`FloatingVisitorVideoViewTest`
- `showVisitorVideo releases the previously shown video view` ← core regression
- `showVisitorVideo releases every replaced video view across repeated reconnects` ← core regression
- `showVisitorVideo does not release the replaced video view more than once when it is later hidden` ← core regression
- `showVisitorVideo detaches the previously shown video view and adds the new one first`
- `showVisitorVideo does not release an already hidden video view again`
- `showVisitorVideo places the new video view as a media overlay`
- `hideVisitorVideo releases the current video view only once`
- `showOnHold pauses and hideOnHold resumes the current video view`
- `onPause and onResume are not forwarded to a released video view`

`FloatingVisitorVideoContainerTest` — reproduces the reconnect scenario end-to-end
- `show with a new media state releases the video view created for the previous one` ← core regression
- `show with the same media state instance keeps the current video view`
- `show with a null media state keeps the current video view`
- `hide releases and detaches the current video view exactly once`
- `show after hide re-attaches the video view for the same media state`

Both use a `FakeVideoView` (real `VideoView` subclass) that counts `release()` / `pauseRendering()` / `resumeRendering()` calls, so the release-exactly-once invariant is asserted rather than just "release was called".

`./gradlew :widgetssdk:testDebugUnitTest` — full module suite green.

No snapshot changes: this alters resource-release ordering only, with no layout, style, or visual behaviour difference, so no Paparazzi goldens are affected.

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [x] Did you add logging beneficial for troubleshooting of customer issues? — no new logging; the existing `LogEvents.CALL_SCREEN_VISITOR_VIDEO_SHOWN` on the show path is unchanged
 - [x] **Did you add new logging?** No new logging added, so no cross-platform log parity to reconcile.

**Screenshots:**

N/A — no visual change.
